### PR TITLE
allow calling SystemImpl.setCanvas() before System.init() on html5

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -285,12 +285,14 @@ class SystemImpl {
 
 	private static function loadFinished() {
 		// Only consider custom canvas ID for release builds
-		var canvas: CanvasElement = null;
-		#if (sys_debug_html5 || !canvas_id)
-		canvas = cast Browser.document.getElementById("khanvas");
-		#else
-		canvas = cast Browser.document.getElementById(kha.CompilerDefines.canvas_id);
-		#end
+        var canvas: Dynamic = khanvas;
+        if(canvas == null) {
+            #if (sys_debug_html5 || !canvas_id)
+            canvas = Browser.document.getElementById("khanvas");
+            #else
+            canvas = Browser.document.getElementById(kha.CompilerDefines.canvas_id);
+            #end
+        }
 		canvas.style.cursor = "default";
 
 		canvas.onload = function () {


### PR DESCRIPTION
Sometimes it is convenient to manually supply canvas instead of searching it by id. In my case kha.js is in iframe and khanvas is in parent document, so it's impossible to find it by id in current document. So I decided to do like this:

		var khanvas = ...//find khanvas by myself
		SystemImpl.setCanvas(khanvas);
		System.init(...)

Changes in this pullrequest allow me to do so.