### PR TITLE
Disable html5 keyboard functionality if no_keyboard is defined

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -187,7 +187,7 @@ class SystemImpl {
 	private static var pressedKeys: Array<Bool>;
 	private static var buttonspressed: Array<Bool>;
 	private static var leftMouseCtrlDown: Bool = false;
-	private static var keyboard: Keyboard;
+	private static var keyboard: Keyboard = null;
 	private static var mouse: kha.input.Mouse;
 	private static var surface: Surface;
 	private static var gamepads: Array<Gamepad>;
@@ -203,7 +203,10 @@ class SystemImpl {
 
 	public static function init2(?backbufferFormat: TextureFormat) {
 		haxe.Log.trace = untyped js.Boot.__trace; // Hack for JS trace problems
+		
+		#if !no_keyboard
 		keyboard = new Keyboard();
+		#end
 		mouse = new kha.input.MouseImpl();
 		surface = new Surface();
 		gamepads = new Array<Gamepad>();
@@ -430,8 +433,10 @@ class SystemImpl {
 
 		canvas.onmousedown = mouseDown;
 		canvas.onmousemove = mouseMove;
-		canvas.onkeydown = keyDown;
-		canvas.onkeyup = keyUp;
+		if(keyboard != null) {
+			canvas.onkeydown = keyDown;
+			canvas.onkeyup = keyUp;
+		}
 		canvas.onblur = onBlur;
 		canvas.onfocus = onFocus;
 		untyped (canvas.onmousewheel = canvas.onwheel = mouseWheel);


### PR DESCRIPTION
Kha's keyboard event listeners in some way interfere with other keyboard listeners on same page. The most simple solution that I've found is to disable it at all, if it's not needed. 

In my case, I create global listeners like this `new JQuery(window.document).on('keydown', onKeyDown);` because I need all keypresses. And it works only after clicking somewhere on page outside canvas, even if the focus then goes back to canvas.