### PR TITLE
fix khanvas.setCapture/releaseCapture

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -557,7 +557,7 @@ class SystemImpl {
 				mouse.sendDownEvent(0, 0, mouseX, mouseY);
 			}
 
-			if (Reflect.hasField(khanvas, 'setCapture'))  khanvas.setCapture();
+			if (khanvas.setCapture != null)  khanvas.setCapture();
 			khanvas.ownerDocument.addEventListener('mouseup', mouseLeftUp);
 		}
 		else if(event.which == 2) { //middle button
@@ -578,7 +578,7 @@ class SystemImpl {
 		
 		insideInputEvent = true;
 		khanvas.ownerDocument.removeEventListener('mouseup', mouseLeftUp);
-		if(Reflect.hasField(khanvas.ownerDocument, 'releaseCapture')) khanvas.ownerDocument.releaseCapture();
+		if(khanvas.releaseCapture != null) khanvas.ownerDocument.releaseCapture();
 		if (leftMouseCtrlDown) {
 			mouse.sendUpEvent(0, 1, mouseX, mouseY);
 		}


### PR DESCRIPTION
Reflect.hasField calls hasOwnProperty internally. hasOwnProperty does not check prototype chain and always returns false in our case.