### PR TITLE
Image clear for Kore

### DIFF
--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -387,6 +387,10 @@ class Image implements Canvas implements Resource {
 		
 	}
 
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
+
 	public static var maxSize(get, null): Int;
 
 	public static function get_maxSize(): Int {

--- a/Backends/Empty/kha/Image.hx
+++ b/Backends/Empty/kha/Image.hx
@@ -42,6 +42,7 @@ class Image implements Canvas implements Resource {
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return 0; }
 	public var height(get, null): Int;

--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -249,4 +249,8 @@ class Image implements Canvas implements Resource {
 	public function setDepthStencilFrom(image: Image): Void {
 		
 	}
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 }

--- a/Backends/HTML5-Worker/kha/Image.hx
+++ b/Backends/HTML5-Worker/kha/Image.hx
@@ -57,6 +57,7 @@ class Image implements Canvas implements Resource {
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return w; }
 	public var height(get, null): Int;

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -95,6 +95,7 @@ class Image implements Canvas implements Resource {
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return 0; }
 	public var height(get, null): Int;

--- a/Backends/Java/kha/Image.hx
+++ b/Backends/Java/kha/Image.hx
@@ -143,4 +143,8 @@ class Image implements Canvas implements Resource {
 	public function setDepthStencilFrom(image: Image): Void {
 		
 	}
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 }

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -302,4 +302,9 @@ class Image implements Canvas implements Resource {
 	public function setDepthStencilFrom(image: Image): Void {
 		untyped __cpp__("renderTarget->setDepthStencilFrom(image->renderTarget)");
 	}
+
+	@:functionCode("if (texture != nullptr) texture->clear(x, y, z, width, height, depth, color);")
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 }

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -236,6 +236,10 @@ class Image implements Canvas implements Resource {
 	public function setDepthStencilFrom(image: Image): Void {
 		
 	}
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 	
 	@:hlNative("std", "kore_texture_create") static function kore_texture_create(width: Int, height: Int, format: Int, readable: Bool): Pointer { return null; }
 	@:hlNative("std", "kore_texture_create_from_file") static function kore_texture_create_from_file(filename: hl.types.Bytes, readable: Bool): Pointer { return null; }

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -44,7 +44,7 @@ extern class Krom {
 	static function generateMipmaps(texture: Dynamic, levels: Int): Void;
 	static function setMipmaps(texture: Dynamic, mipmaps: Array<kha.Image>): Void;
 	static function setDepthStencilFrom(target: Dynamic, source: Dynamic): Void;
-	static function clearTexture(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Int): Void;
+	static function clearTexture(target: Dynamic, x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Int): Void;
 	static function createIndexBuffer(count: Int): Dynamic;
 	static function deleteIndexBuffer(buffer: Dynamic): Dynamic;
 	static function setIndices(buffer: Dynamic, indices: Array<Int>): Void;

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -44,6 +44,7 @@ extern class Krom {
 	static function generateMipmaps(texture: Dynamic, levels: Int): Void;
 	static function setMipmaps(texture: Dynamic, mipmaps: Array<kha.Image>): Void;
 	static function setDepthStencilFrom(target: Dynamic, source: Dynamic): Void;
+	static function clearTexture(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Int): Void;
 	static function createIndexBuffer(count: Int): Dynamic;
 	static function deleteIndexBuffer(buffer: Dynamic): Dynamic;
 	static function setIndices(buffer: Dynamic, indices: Array<Int>): Void;

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -138,6 +138,10 @@ class Image implements Canvas implements Resource {
 		Krom.setDepthStencilFrom(renderTarget_, image.renderTarget_);
 	}
 
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		Krom.clearTexture(x, y, z, width, height, depth, color);
+	}
+
 	public var width(get, null): Int;
 	private function get_width(): Int { return texture_ == null ? renderTarget_.width : texture_.width; }
 	public var height(get, null): Int;

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -139,7 +139,7 @@ class Image implements Canvas implements Resource {
 	}
 
 	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
-		Krom.clearTexture(x, y, z, width, height, depth, color);
+		Krom.clearTexture(texture_, x, y, z, width, height, depth, color);
 	}
 
 	public var width(get, null): Int;

--- a/Backends/Node/kha/Image.hx
+++ b/Backends/Node/kha/Image.hx
@@ -62,6 +62,7 @@ class Image implements Canvas implements Resource {
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void { }
 	public var width(get, null): Int;
 	private function get_width(): Int { return w; }
 	public var height(get, null): Int;

--- a/Backends/PSM/kha/Image.hx
+++ b/Backends/PSM/kha/Image.hx
@@ -90,6 +90,10 @@ class Image {
 	public function setDepthStencilFrom(image: Image): Void {
 		
 	}
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 	
 	public var g2(get, null): kha.graphics2.Graphics;
 	

--- a/Backends/Unity/kha/Image.hx
+++ b/Backends/Unity/kha/Image.hx
@@ -148,6 +148,10 @@ class Image implements Canvas implements Resource {
 		
 	}
 
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
+
 	public static var maxSize(get, null): Int;
 
 	public static function get_maxSize(): Int {

--- a/Backends/WPF/kha/Image.hx
+++ b/Backends/WPF/kha/Image.hx
@@ -167,6 +167,10 @@ class Image implements Resource {
 	public function setDepthStencilFrom(image: Image): Void {
 		
 	}
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
+		
+	}
 	
 	public static var maxSize(get, null): Int;
 	

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -37,6 +37,8 @@ extern class Image implements Canvas implements Resource {
 	
 	// Use depth buffer attached to different image.
 	public function setDepthStencilFrom(image: Image): Void;
+
+	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void;
 	
 	public var width(get, null): Int;
 	


### PR DESCRIPTION
Adds a method to clear (non-rendertarget) textures to specified color. Should be especially useful for compute/imagestore/.. apis, once that gets settled in Kha.

To go with:
https://github.com/Kode/Kore/pull/150
https://github.com/Kode/Krom/pull/21