### PR TITLE
fix createimagedata for dynamicaly generated image

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -120,7 +120,7 @@ class WebGLImage extends Image {
 
 	function createImageData() {
 		if (Std.is(image, Uint8Array)) {
-			data = new js.html.ImageData(new Uint8ClampedArray(image.buffer), this.width, this.height);
+			data = new js.html.ImageData(new js.html.Uint8ClampedArray(image.buffer), this.width, this.height);
 		} 
 		else {
 			context.strokeStyle = "rgba(0,0,0,0)";

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -119,11 +119,16 @@ class WebGLImage extends Image {
 	}
 
 	function createImageData() {
-		context.strokeStyle = "rgba(0,0,0,0)";
-		context.fillStyle = "rgba(0,0,0,0)";
-		context.fillRect(0, 0, image.width, image.height);
-		context.drawImage(image, 0, 0, image.width, image.height, 0, 0, image.width, image.height);
-		data = context.getImageData(0, 0, image.width, image.height);
+		if (Std.is(image, Uint8Array)) {
+			data = new js.html.ImageData(new Uint8ClampedArray(image.buffer), this.width, this.height);
+		} 
+		else {
+			context.strokeStyle = "rgba(0,0,0,0)";
+			context.fillStyle = "rgba(0,0,0,0)";
+			context.fillRect(0, 0, image.width, image.height);
+			context.drawImage(image, 0, 0, image.width, image.height, 0, 0, image.width, image.height);
+			data = context.getImageData(0, 0, image.width, image.height);
+		}
 	}
 
 	private static function upperPowerOfTwo(v: Int): Int {


### PR DESCRIPTION
in case of dynamicaly generated image (using fromBytes() method) - image object is Uint8Array and is not 'drawable' by context.drawImage. This fixes image.isOpaque() and image.at() methods.