### PR TITLE
CubeMap support

### DIFF
--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -58,6 +58,10 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 	}
 
+	public function beginFace(face: Int): Void {
+
+	}
+
 	public function beginEye(eye: Int): Void {
 		
 	}
@@ -185,8 +189,12 @@ class Graphics implements kha.graphics4.Graphics {
 		this.indexBuffer = indexBuffer;
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 
 	public function setTexture(stage: kha.graphics4.TextureUnit, texture: kha.Image): Void {

--- a/Backends/Android/kha/graphics4/CubeMap.hx
+++ b/Backends/Android/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Android/kha/graphics4/CubeMap.hx
+++ b/Backends/Android/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Empty/kha/graphics4/CubeMap.hx
+++ b/Backends/Empty/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Empty/kha/graphics4/CubeMap.hx
+++ b/Backends/Empty/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -133,8 +133,12 @@ class Graphics implements kha.graphics4.Graphics {
 		context.setDepthTest(write, getCompareMode(mode));
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+
 	}
 
 	private function getStencilAction(action: StencilAction): Context3DStencilAction {
@@ -417,6 +421,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function begin(additionalRenderTargets: Array<Canvas> = null): Void {
 		if (target == null) context.setRenderToBackBuffer();
 		else context.setRenderToTexture(target.getFlashTexture(), enableDepthStencil(target.depthStencilFormat()));
+	}
+
+	public function beginFace(face: Int): Void {
+
 	}
 
 	public function beginEye(eye: Int): Void {

--- a/Backends/Flash/kha/graphics4/CubeMap.hx
+++ b/Backends/Flash/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Flash/kha/graphics4/CubeMap.hx
+++ b/Backends/Flash/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/HTML5/kha/graphics4/CubeMap.hx
+++ b/Backends/HTML5/kha/graphics4/CubeMap.hx
@@ -1,0 +1,150 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+import js.html.webgl.GL;
+import kha.graphics4.TextureFormat;
+import kha.graphics4.DepthStencilFormat;
+import kha.graphics4.Usage;
+import kha.js.graphics4.Graphics;
+
+class CubeMap implements Canvas implements Resource {
+
+	private var mySize: Int;
+	private var format: TextureFormat;
+	private var renderTarget: Bool;
+	private var depthStencilFormat: DepthStencilFormat;
+	private var graphics4: kha.graphics4.Graphics;
+
+	public var frameBuffer: Dynamic = null;
+	public var texture: Dynamic = null;
+	public var depthTexture: Dynamic = null;
+	public var isDepthAttachment: Bool = false;
+
+	private function new(size: Int, format: TextureFormat, renderTarget: Bool, depthStencilFormat: DepthStencilFormat) {
+		mySize = size;
+		this.format = format;
+		this.renderTarget = renderTarget;
+		this.depthStencilFormat = depthStencilFormat;
+		if (renderTarget) createTexture();
+	}
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		if (format == null) format = TextureFormat.RGBA32;
+		if (depthStencil == null) depthStencil = NoDepthAndStencil;
+		return new CubeMap(size, format, true, depthStencil);
+	}
+
+	private function createTexture() {
+		if (SystemImpl.gl == null) return;
+
+		texture = SystemImpl.gl.createTexture();
+		SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, texture);
+
+		SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.LINEAR);
+		SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.LINEAR);
+		SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+		SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+
+		if (renderTarget) {
+
+			frameBuffer = SystemImpl.gl.createFramebuffer();
+			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+
+			switch (format) {
+			case DEPTH16:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.DEPTH_COMPONENT, mySize, mySize, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_SHORT, null);
+			case RGBA128:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.FLOAT, null);
+			case RGBA64:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
+			case RGBA32:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+			case A32:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, mySize, mySize, 0, GL.ALPHA, GL.FLOAT, null);
+			case A16:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, mySize, mySize, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
+			default:
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+			}
+
+			if (format == DEPTH16) {
+				isDepthAttachment = true;
+				// OSX/Linux WebGL implementations throw incomplete framebuffer error, create color attachment
+				if (untyped __js__('navigator.appVersion.indexOf("Win")') == -1) {
+					var colortex = SystemImpl.gl.createTexture();
+					SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, colortex);
+					for (i in 0...6) {
+						SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+						SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, colortex, 0);
+					}
+					SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, texture);
+				}
+			}
+
+			initDepthStencilBuffer(depthStencilFormat);
+			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, null);
+		}
+
+		SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, null);
+	}
+
+	private function initDepthStencilBuffer(depthStencilFormat: DepthStencilFormat) {
+		switch (depthStencilFormat) {
+		case NoDepthAndStencil: {}
+		case DepthOnly: {
+			depthTexture = SystemImpl.gl.createTexture();
+			SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, depthTexture);
+			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_COMPONENT, mySize, mySize, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+			SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_CUBE_MAP, depthTexture, 0);
+		}
+		case DepthAutoStencilAuto, Depth24Stencil8, Depth32Stencil8:
+			depthTexture = SystemImpl.gl.createTexture();
+			SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, depthTexture);
+			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_STENCIL, mySize, mySize, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
+			SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+			SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_CUBE_MAP, depthTexture, 0);
+		}
+	}
+
+	public function set(stage: Int): Void {
+		SystemImpl.gl.activeTexture(GL.TEXTURE0 + stage);
+		SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, texture);
+	}
+
+	public function setDepth(stage: Int): Void {
+		SystemImpl.gl.activeTexture(GL.TEXTURE0 + stage);
+		SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, depthTexture);
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var size(get, null): Int;
+	private function get_size(): Int { return mySize; }
+	public var width(get, null): Int;
+	private function get_width(): Int { return mySize; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return mySize; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/HTML5/kha/graphics4/CubeMap.hx
+++ b/Backends/HTML5/kha/graphics4/CubeMap.hx
@@ -1,15 +1,13 @@
 package kha.graphics4;
 
-import haxe.io.Bytes;
 import js.html.webgl.GL;
-import kha.graphics4.TextureFormat;
-import kha.graphics4.DepthStencilFormat;
-import kha.graphics4.Usage;
+import haxe.io.Bytes;
 import kha.js.graphics4.Graphics;
 
 class CubeMap implements Canvas implements Resource {
 
-	private var mySize: Int;
+	private var myWidth: Int;
+	private var myHeight: Int;
 	private var format: TextureFormat;
 	private var renderTarget: Bool;
 	private var depthStencilFormat: DepthStencilFormat;
@@ -21,7 +19,8 @@ class CubeMap implements Canvas implements Resource {
 	public var isDepthAttachment: Bool = false;
 
 	private function new(size: Int, format: TextureFormat, renderTarget: Bool, depthStencilFormat: DepthStencilFormat) {
-		mySize = size;
+		myWidth = size;
+		myHeight = size;
 		this.format = format;
 		this.renderTarget = renderTarget;
 		this.depthStencilFormat = depthStencilFormat;
@@ -52,19 +51,19 @@ class CubeMap implements Canvas implements Resource {
 
 			switch (format) {
 			case DEPTH16:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.DEPTH_COMPONENT, mySize, mySize, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_SHORT, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.DEPTH_COMPONENT, myWidth, myHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_SHORT, null);
 			case RGBA128:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.FLOAT, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.FLOAT, null);
 			case RGBA64:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
 			case RGBA32:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
 			case A32:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, mySize, mySize, 0, GL.ALPHA, GL.FLOAT, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, myWidth, myHeight, 0, GL.ALPHA, GL.FLOAT, null);
 			case A16:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, mySize, mySize, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.ALPHA, myWidth, myHeight, 0, GL.ALPHA, SystemImpl.halfFloat.HALF_FLOAT_OES, null);
 			default:
-				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+				for (i in 0...6) SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
 			}
 
 			if (format == DEPTH16) {
@@ -74,7 +73,7 @@ class CubeMap implements Canvas implements Resource {
 					var colortex = SystemImpl.gl.createTexture();
 					SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, colortex);
 					for (i in 0...6) {
-						SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, mySize, mySize, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
+						SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, GL.RGBA, myWidth, myHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);
 						SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_CUBE_MAP_POSITIVE_X + i, colortex, 0);
 					}
 					SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, texture);
@@ -94,7 +93,7 @@ class CubeMap implements Canvas implements Resource {
 		case DepthOnly: {
 			depthTexture = SystemImpl.gl.createTexture();
 			SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, depthTexture);
-			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_COMPONENT, mySize, mySize, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
+			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_COMPONENT, myWidth, myHeight, 0, GL.DEPTH_COMPONENT, GL.UNSIGNED_INT, null);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
@@ -105,7 +104,7 @@ class CubeMap implements Canvas implements Resource {
 		case DepthAutoStencilAuto, Depth24Stencil8, Depth32Stencil8:
 			depthTexture = SystemImpl.gl.createTexture();
 			SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, depthTexture);
-			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_STENCIL, mySize, mySize, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
+			SystemImpl.gl.texImage2D(GL.TEXTURE_CUBE_MAP, 0, GL.DEPTH_STENCIL, myWidth, myHeight, 0, GL.DEPTH_STENCIL, SystemImpl.depthTexture.UNSIGNED_INT_24_8_WEBGL, null);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
 			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_WRAP_S, GL.CLAMP_TO_EDGE);
@@ -129,12 +128,10 @@ class CubeMap implements Canvas implements Resource {
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
 
-	public var size(get, null): Int;
-	private function get_size(): Int { return mySize; }
 	public var width(get, null): Int;
-	private function get_width(): Int { return mySize; }
+	private function get_width(): Int { return myWidth; }
 	public var height(get, null): Int;
-	private function get_height(): Int { return mySize; }
+	private function get_height(): Int { return myHeight; }
 
 	public var g1(get, null): kha.graphics1.Graphics;
 	private function get_g1(): kha.graphics1.Graphics { return null; }

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -93,7 +93,7 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 	}
 
-	public function beginFace(face: Int) {
+	public function beginFace(face: Int): Void {
 		SystemImpl.gl.enable(GL.BLEND);
 		SystemImpl.gl.blendFunc(GL.SRC_ALPHA, GL.ONE_MINUS_SRC_ALPHA);
 		SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, renderTargetFrameBuffer);

--- a/Backends/Java/kha/graphics4/CubeMap.hx
+++ b/Backends/Java/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Java/kha/graphics4/CubeMap.hx
+++ b/Backends/Java/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Kore/kha/graphics4/CubeMap.hx
+++ b/Backends/Kore/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Kore/kha/graphics4/CubeMap.hx
+++ b/Backends/Kore/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -271,8 +271,12 @@ class Graphics implements kha.graphics4.Graphics {
 		return false;
 	}
 	
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 	
 	@:functionCode('
@@ -631,6 +635,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function begin(additionalRenderTargets: Array<Canvas> = null): Void {
 		if (target == null) renderToBackbuffer();
 		else renderToTexture(additionalRenderTargets);
+	}
+
+	public function beginFace(face: Int): Void {
+
 	}
 
 	public function beginEye(eye: Int): Void {

--- a/Backends/KoreHL/kha/graphics4/CubeMap.hx
+++ b/Backends/KoreHL/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/CubeMap.hx
+++ b/Backends/KoreHL/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -182,8 +182,12 @@ class Graphics implements kha.graphics4.Graphics {
 		return false;
 	}
 	
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 	
 	//@:functionCode('Kore::Graphics::setStencilParameters(convertCompareMode(compareMode), convertStencilAction(bothPass), convertStencilAction(depthFail), convertStencilAction(stencilFail), referenceValue, readMask, writeMask);	')
@@ -466,6 +470,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function begin(additionalRenderTargets: Array<Canvas> = null): Void {
 		if (target == null) renderToBackbuffer();
 		else renderToTexture(additionalRenderTargets);
+	}
+
+	public function beginFace(face: Int): Void {
+
 	}
 
 	public function beginEye(eye: Int): Void {

--- a/Backends/Krom/kha/graphics4/CubeMap.hx
+++ b/Backends/Krom/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Krom/kha/graphics4/CubeMap.hx
+++ b/Backends/Krom/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -42,6 +42,10 @@ class Graphics implements kha.graphics4.Graphics {
 		Krom.begin(renderTarget, additionalRenderTargets);
 	}
 
+	public function beginFace(face: Int): Void {
+
+	}
+
 	public function beginEye(eye: Int): Void {
 		
 	}
@@ -126,8 +130,12 @@ class Graphics implements kha.graphics4.Graphics {
 		indexBuffer.set();
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 
 	public function setTexture(stage: kha.graphics4.TextureUnit, texture: kha.Image): Void {

--- a/Backends/Node/kha/graphics4/CubeMap.hx
+++ b/Backends/Node/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Node/kha/graphics4/CubeMap.hx
+++ b/Backends/Node/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -40,6 +40,14 @@ class EmptyGraphics4 implements Graphics {
 		
 	}
 
+	public function beginFace(face: Int): Void {
+
+	}
+
+	public function beginEye(eye: Int): Void {
+		
+	}
+
 	public function end(): Void {
 		
 	}
@@ -116,8 +124,12 @@ class EmptyGraphics4 implements Graphics {
 		
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 	
 	public function renderTargetsInvertedY(): Bool {

--- a/Backends/PSM/kha/graphics4/CubeMap.hx
+++ b/Backends/PSM/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/PSM/kha/graphics4/CubeMap.hx
+++ b/Backends/PSM/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/PSM/kha/psm/graphics4/Graphics.hx
+++ b/Backends/PSM/kha/psm/graphics4/Graphics.hx
@@ -71,8 +71,12 @@ class Graphics implements kha.graphics4.Graphics {
 		
 	}
 	
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 		
 	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
@@ -212,6 +216,10 @@ class Graphics implements kha.graphics4.Graphics {
 	
 	public function begin(): Void {
 		
+	}
+
+	public function beginFace(face: Int): Void {
+
 	}
 
 	public function beginEye(eye: Int): Void {

--- a/Backends/Unity/kha/graphics4/CubeMap.hx
+++ b/Backends/Unity/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/Unity/kha/graphics4/CubeMap.hx
+++ b/Backends/Unity/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Backends/Unity/kha/unity/Graphics.hx
+++ b/Backends/Unity/kha/unity/Graphics.hx
@@ -50,6 +50,10 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 	}
 
+	public function beginFace(face: Int): Void {
+
+	}
+
 	public function beginEye(eye: Int): Void {
 		
 	}
@@ -139,8 +143,12 @@ class Graphics implements kha.graphics4.Graphics {
 
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 
 	public function renderTargetsInvertedY(): Bool {

--- a/Backends/WPF/kha/graphics4/CubeMap.hx
+++ b/Backends/WPF/kha/graphics4/CubeMap.hx
@@ -5,7 +5,7 @@ import haxe.io.Bytes;
 class CubeMap implements Canvas implements Resource {
 
 	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
-		
+		return null;
 	}
 
 	public function set(stage: Int): Void {
@@ -30,10 +30,5 @@ class CubeMap implements Canvas implements Resource {
 	public var g2(get, null): kha.graphics2.Graphics;
 	private function get_g2(): kha.graphics2.Graphics { return null; }
 	public var g4(get, null): kha.graphics4.Graphics;
-	private function get_g4(): kha.graphics4.Graphics {
-		if (graphics4 == null) {
-			graphics4 = new Graphics(this);
-		}
-		return graphics4;
-	}
+	private function get_g4(): kha.graphics4.Graphics { return null; }
 }

--- a/Backends/WPF/kha/graphics4/CubeMap.hx
+++ b/Backends/WPF/kha/graphics4/CubeMap.hx
@@ -1,0 +1,39 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+
+class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = null): CubeMap {
+		
+	}
+
+	public function set(stage: Int): Void {
+
+	}
+
+	public function setDepth(stage: Int): Void {
+
+	}
+
+	public function unload(): Void { }
+	public function lock(level: Int = 0): Bytes { return null; }
+	public function unlock(): Void { }
+
+	public var width(get, null): Int;
+	private function get_width(): Int { return 0; }
+	public var height(get, null): Int;
+	private function get_height(): Int { return 0; }
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	private function get_g1(): kha.graphics1.Graphics { return null; }
+	public var g2(get, null): kha.graphics2.Graphics;
+	private function get_g2(): kha.graphics2.Graphics { return null; }
+	public var g4(get, null): kha.graphics4.Graphics;
+	private function get_g4(): kha.graphics4.Graphics {
+		if (graphics4 == null) {
+			graphics4 = new Graphics(this);
+		}
+		return graphics4;
+	}
+}

--- a/Sources/kha/graphics1/Graphics4.hx
+++ b/Sources/kha/graphics1/Graphics4.hx
@@ -29,6 +29,14 @@ class Graphics4 implements kha.graphics4.Graphics {
 		g1.begin();
 	}
 
+	public function beginFace(face: Int): Void {
+
+	}
+
+	public function beginEye(eye: Int): Void {
+		
+	}
+
 	public function end(): Void {
 		g1.end();
 	}
@@ -85,8 +93,12 @@ class Graphics4 implements kha.graphics4.Graphics {
 		
 	}
 
-	public function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap {
-		return null;
+	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
+	}
+	
+	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
+		
 	}
 	
 	public function renderTargetsInvertedY(): Bool {

--- a/Sources/kha/graphics4/CubeMap.hx
+++ b/Sources/kha/graphics4/CubeMap.hx
@@ -1,9 +1,26 @@
 package kha.graphics4;
 
 import haxe.io.Bytes;
+import kha.graphics4.TextureFormat;
+import kha.graphics4.DepthStencilFormat;
+import kha.graphics4.Usage;
 
-interface CubeMap {
-	var size(get, null): Int;
-	function lock(): Bytes;
-	function unlock(): Void;
+extern class CubeMap implements Canvas implements Resource {
+
+	public static function createRenderTarget(size: Int, format: TextureFormat = TextureFormat.RGBA32, depthStencil: DepthStencilFormat = NoDepthAndStencil): CubeMap;
+
+	public function unload(): Void;
+	public function lock(level: Int = 0): Bytes;
+	public function unlock(): Void;
+
+	public var size(get, null): Int;
+	public var width(get, null): Int;
+	public var height(get, null): Int;
+
+	public var g1(get, null): kha.graphics1.Graphics;
+	public var g2(get, null): kha.graphics2.Graphics;
+	public var g4(get, null): kha.graphics4.Graphics;
+
+	public function set(stage: Int): Void;
+	public function setDepth(stage: Int): Void;
 }

--- a/Sources/kha/graphics4/CubeMap.hx
+++ b/Sources/kha/graphics4/CubeMap.hx
@@ -1,9 +1,6 @@
 package kha.graphics4;
 
 import haxe.io.Bytes;
-import kha.graphics4.TextureFormat;
-import kha.graphics4.DepthStencilFormat;
-import kha.graphics4.Usage;
 
 extern class CubeMap implements Canvas implements Resource {
 

--- a/Sources/kha/graphics4/Graphics.hx
+++ b/Sources/kha/graphics4/Graphics.hx
@@ -14,6 +14,7 @@ import kha.Video;
 
 interface Graphics {
 	function begin(additionalRenderTargets: Array<Canvas> = null): Void;
+	function beginFace(face: Int): Void;
 	function beginEye(eye: Int): Void;
 	function end(): Void;
 	
@@ -34,9 +35,10 @@ interface Graphics {
 	function setTextureDepth(unit: TextureUnit, texture: Image): Void;
 	function setVideoTexture(unit: TextureUnit, texture: Video): Void;
 	function setTextureParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void;
+	function setCubeMap(unit: TextureUnit, cubeMap: CubeMap): Void;
+	function setCubeMapDepth(unit: TextureUnit, cubeMap: CubeMap): Void;
 	//function maxTextureSize(): Int;
 	//function supportsNonPow2Textures(): Bool;
-	function createCubeMap(size: Int, format: TextureFormat, usage: Usage, canRead: Bool = false): CubeMap;
 	
 	function renderTargetsInvertedY(): Bool;
 	function instancedRenderingAvailable(): Bool;


### PR DESCRIPTION
Adds support for handling cubemaps. As usual, took a bit longer than anticipated.

- CubeMap class works exactly like Image class
- WebGL is ready, will also do Kore/Krom
- Tested & working, some PR typos or minor issues can arise though
- Only render target functionality implemented so far

```hx
// Creating a cubemap
var cubemap = CubeMap.createRenderTarget(...);

// Render to cubemap using layered rendering
// Draw to all faces at once using geometry shader
// WebGL is not capable of this
cubemap.g4.begin();

// Render to desired face
// 0: x+, 1: x-, 2: y+, 3: y-, 4: z+, 5: z-
cubemap.g4.beginFace(face);

// Attach cubemap to samplerCube unit
g4.setCubeMap(cubemap);

// Attach cubemap depth buffer to samplerCube unit
g4.setCubeMapDepth(cubemap);
```