### PR TITLE
canvas clear now clear all the canvas

### DIFF
--- a/Backends/HTML5/kha/CanvasImage.hx
+++ b/Backends/HTML5/kha/CanvasImage.hx
@@ -59,7 +59,7 @@ class CanvasImage extends Image {
 			var context = canvas.getContext("2d");
 			canvas.width = width;
 			canvas.height = height;
-			g2canvas = new CanvasGraphics(context, width, height);
+			g2canvas = new CanvasGraphics(context);
 		}
 		return g2canvas;
 	}

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -328,7 +328,7 @@ class SystemImpl {
 			frame.init(new kha.graphics2.Graphics1(frame), new kha.js.graphics4.Graphics2(frame), g4); // new kha.graphics1.Graphics4(frame));
 		}
 		else {
-			var g2 = new CanvasGraphics(canvas.getContext("2d"), System.windowWidth(), System.windowHeight());
+			var g2 = new CanvasGraphics(canvas.getContext("2d"));
 			frame = new Framebuffer(0, null, g2, null);
 			frame.init(new kha.graphics2.Graphics1(frame), g2, null);
 		}

--- a/Backends/HTML5/kha/js/CanvasGraphics.hx
+++ b/Backends/HTML5/kha/js/CanvasGraphics.hx
@@ -13,17 +13,13 @@ import kha.Rotation;
 class CanvasGraphics extends Graphics {
 	private var canvas: Dynamic;
 	private var webfont: kha.js.Font;
-	private var width: Int;
-	private var height: Int;
 	private var myColor: Color;
 	private var scaleQuality: ImageScaleQuality;
 	private static var instance: CanvasGraphics;
 	
-	public function new(canvas: Dynamic, width: Int, height: Int) {
+	public function new(canvas: Dynamic) { 
 		super();
 		this.canvas = canvas;
-		this.width = width;
-		this.height = height;
 		instance = this;
 		myColor = Color.fromBytes(0, 0, 0);
 		canvas.save();
@@ -48,9 +44,9 @@ class CanvasGraphics extends Graphics {
 		canvas.strokeStyle = "rgba(" + color.Rb + "," + color.Gb + "," + color.Bb + "," + color.A + ")";
 		canvas.fillStyle = "rgba(" + color.Rb + "," + color.Gb + "," + color.Bb + "," + color.A + ")";
 		if (color.A == 0) // if color is transparent, clear the screen. Note: in Canvas, transparent colors will overlay, not overwrite.
-			canvas.clearRect(0, 0, width, height);
+			canvas.clearRect(0, 0, canvas.canvas.width, canvas.canvas.height);
 		else
-			canvas.fillRect(0, 0, width, height);
+			canvas.fillRect(0, 0, canvas.canvas.width, canvas.canvas.height);
 		this.color = myColor;
 	}
 	


### PR DESCRIPTION
clearing the canvas was only clearing with the width and height passed in via constructor. This was quicly out of sync with the actual width and height of the canvas resulting in clearing only a portion of the screen.

Now it use the current canvas size to clear all of it.