### PR TITLE
L8 render target for Kore

### DIFF
--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -80,6 +80,8 @@ class Image implements Canvas implements Resource {
 			return 3;
 		case DEPTH16:	// Target16BitDepth
 			return 4;
+		case L8:
+			return 5;	// Target8BitRed
 		default:
 			return 0;
 		}

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -30,6 +30,8 @@ class Image implements Canvas implements Resource {
 			return 3;
 		case DEPTH16:	// Target16BitDepth
 			return 4;
+		case L8:
+			return 5;	// Target8BitRed
 		default:
 			return 0;
 		}


### PR DESCRIPTION
Adds a single-channel render target format. (WebGL is not capable of this, but it 'falls back' to RGBA32.)
To go with https://github.com/Kode/Kore/pull/166.