### PR TITLE
flash: invert wheel delta to make it consistent with other targets

### DIFF
--- a/Backends/Flash/kha/SystemImpl.hx
+++ b/Backends/Flash/kha/SystemImpl.hx
@@ -257,7 +257,7 @@ class SystemImpl {
 
 	private static function mouseWheelHandler(event: MouseEvent): Void {
 		setMousePosition(event);
-		mouse.sendWheelEvent(0, event.delta);
+		mouse.sendWheelEvent(0, -event.delta);
 	}
 
 	private static function resizeHandler(event: Event): Void {


### PR DESCRIPTION
The wheel delta is inverted when you compare with html5 and windows targets (haven't tested linux/osx).
Rolling up now produces negative values, rolling down positive.
