### PR TITLE
Image.getPixels proposal

### DIFF
--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -381,6 +381,10 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		
 	}

--- a/Backends/Empty/kha/Image.hx
+++ b/Backends/Empty/kha/Image.hx
@@ -39,6 +39,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
+	public function getPixels(): Bytes { return null; }
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }

--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -238,6 +238,10 @@ class Image implements Canvas implements Resource {
 		if (!readable) bytes = null;
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 
 	}

--- a/Backends/HTML5-Worker/kha/Image.hx
+++ b/Backends/HTML5-Worker/kha/Image.hx
@@ -54,6 +54,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
+	public function getPixels(): Bytes { return null; }
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -92,6 +92,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return null; }
 	public function unlock(): Void { }
+	public function getPixels(): Bytes { return null; }
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -356,6 +356,16 @@ class WebGLImage extends Image {
 		}
 	}
 
+	private var pixels: Uint8Array = null;
+	
+	override public function getPixels(): Bytes {
+		if (frameBuffer == null) return null;
+		if (pixels == null) pixels = new Uint8Array(format == RGBA32 ? 4 * width * height : width * height);
+		SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+		SystemImpl.gl.readPixels(0, 0, myWidth, myHeight, GL.RGBA, GL.UNSIGNED_BYTE, pixels);
+		return Bytes.ofData(pixels.buffer);
+	}
+
 	override public function unload(): Void {
 		if (texture != null) SystemImpl.gl.deleteTexture(texture);
 		if (depthTexture != null) SystemImpl.gl.deleteTexture(depthTexture);

--- a/Backends/Java/kha/Image.hx
+++ b/Backends/Java/kha/Image.hx
@@ -132,6 +132,10 @@ class Image implements Canvas implements Resource {
 		
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		
 	}

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -304,6 +304,24 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	private var pixels: Bytes = null;
+	private var pixelsAllocated: Bool = false;
+
+	@:functionCode('
+		if (renderTarget == nullptr) return nullptr;
+		if (!this->pixelsAllocated) {
+			int size = 4 * renderTarget->width * renderTarget->height;
+			this->pixels = ::haxe::io::Bytes_obj::alloc(size);
+			this->pixelsAllocated = true;
+		}
+		Kore::u8* b = this->pixels->b->Pointer();
+		renderTarget->getPixels(b);
+		return this->pixels;
+	')
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		untyped __cpp__("texture->generateMipmaps(levels)");
 	}

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -223,6 +223,10 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		//untyped __cpp__("texture->generateMipmaps(levels)");
 	}

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -48,6 +48,7 @@ extern class Krom {
 	static function createTexture(width: Int, height: Int, format: Int): Dynamic;
 	static function createTexture3D(width: Int, height: Int, depth: Int, format: Int): Dynamic;
 	static function createTextureFromBytes(data: haxe.io.BytesData, width: Int, height: Int, format: Int, readable: Bool): Dynamic;
+	static function getRenderTargetPixels(renderTarget: Dynamic, data: haxe.io.BytesData): Void;
 	static function unlockTexture(texture: Dynamic, data: haxe.io.BytesData): Void;
 	static function generateMipmaps(texture: Dynamic, levels: Int): Void;
 	static function setMipmaps(texture: Dynamic, mipmaps: Array<kha.Image>): Void;
@@ -88,4 +89,8 @@ extern class Krom {
 	static function windowWidth(id: Int): Int;
 	static function windowHeight(id: Int): Int;
 	static function screenDpi(): Int;
+	static function requestShutdown(): Void;
+
+	static function fileSaveBytes(path: String, bytes: haxe.io.BytesData): Void;
+	static function sysCommand(cmd: String, ?args: Array<String>): Int;
 }

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -142,6 +142,15 @@ class Image implements Canvas implements Resource {
 	public function unlock(): Void {
 		Krom.unlockTexture(texture_, bytes.getData());
 	}
+
+	private var pixels: Bytes = null;
+
+	public function getPixels(): Bytes {
+		if (renderTarget_ == null) return null;
+		if (pixels == null) pixels = Bytes.alloc(format == TextureFormat.RGBA32 ? 4 * width * height : width * height);
+		Krom.getRenderTargetPixels(renderTarget_, pixels.getData());
+		return pixels;
+	}
 	
 	public function generateMipmaps(levels: Int): Void {
 		Krom.generateMipmaps(texture_, levels);

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -182,7 +182,7 @@ class SystemImpl {
 	}
 	
 	public static function requestShutdown(): Void {
-		
+		Krom.requestShutdown();
 	}
 	
 	public static function getMouse(num: Int): Mouse {

--- a/Backends/Node/kha/Image.hx
+++ b/Backends/Node/kha/Image.hx
@@ -59,6 +59,7 @@ class Image implements Canvas implements Resource {
 	public function unload(): Void { }
 	public function lock(level: Int = 0): Bytes { return bytes; }
 	public function unlock(): Void { }
+	public function getPixels(): Bytes { return null; }
 	public function generateMipmaps(levels: Int): Void { }
 	public function setMipmaps(mipmaps: Array<Image>): Void { }
 	public function setDepthStencilFrom(image: Image): Void { }

--- a/Backends/PSM/kha/Image.hx
+++ b/Backends/PSM/kha/Image.hx
@@ -79,6 +79,10 @@ class Image {
 		
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		
 	}

--- a/Backends/Unity/kha/Image.hx
+++ b/Backends/Unity/kha/Image.hx
@@ -136,6 +136,10 @@ class Image implements Canvas implements Resource {
 
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		
 	}

--- a/Backends/WPF/kha/Image.hx
+++ b/Backends/WPF/kha/Image.hx
@@ -156,6 +156,10 @@ class Image implements Resource {
 		
 	}
 
+	public function getPixels(): Bytes {
+		return null;
+	}
+
 	public function generateMipmaps(levels: Int): Void {
 		
 	}

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -29,6 +29,8 @@ extern class Image implements Canvas implements Resource {
 	public function lock(level: Int = 0): Bytes;
 	
 	public function unlock(): Void;
+
+	public function getPixels(): Bytes;
 	
 	public function generateMipmaps(levels: Int): Void;
 	


### PR DESCRIPTION
I have experimented with several namings but so far this is the cleanest I think.
- lock()/unlock() to manipulate GPU data using CPU
- getPixels() to pull data from GPU, no upload

Alternative is to use .lock(read = true), but lock() implies I am also responsible to call unlock(). We would have to make sure unlock() does nothing in case of read = true.

I implemented getPixels() for RGBA32 render targets on WebGL, Krom and Kore.

To go with https://github.com/Kode/Kore/pull/175 and https://github.com/Kode/Krom/pull/35.

---

Also included for Krom (should have been separate):
- requestShutdown()
- fileSaveBytes() - mirrors haxe.io.File.saveBytes()
- sysCommand() - mirrors Sys.command()
