### PR TITLE
Faster loadBlob for HTML5

### DIFF
--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -133,8 +133,7 @@ class LoaderImpl {
 				var arrayBuffer = request.response;
 				if (arrayBuffer != null) {
 					var byteArray: Dynamic = untyped __js__("new Uint8Array(arrayBuffer)");
-					bytes = Bytes.alloc(byteArray.byteLength);
-					for (i in 0...byteArray.byteLength) bytes.set(i, byteArray[i]);
+					bytes = Bytes.ofData(byteArray);
 				}
 				else if (request.responseBody != null) {
 					var data: Dynamic = untyped __js__("VBArray(request.responseBody).toArray()");


### PR DESCRIPTION
Using Bytes.ofData(), chewing through 124MB blob went from 0.24643 to 0.07405 on my machine.