### PR TITLE
Conservative rasterization for Kore and Krom

### DIFF
--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -475,12 +475,17 @@ class Graphics implements kha.graphics4.Graphics {
 		setDepthMode(pipe.depthWrite, pipe.depthMode);
 		setStencilParameters(pipe.stencilMode, pipe.stencilBothPass, pipe.stencilDepthFail, pipe.stencilFail, pipe.stencilReferenceValue, pipe.stencilReadMask, pipe.stencilWriteMask);
 		setBlendingMode(pipe.blendSource, pipe.blendDestination, pipe.blendOperation, pipe.alphaBlendSource, pipe.alphaBlendDestination, pipe.alphaBlendOperation);
-		setColorMask(pipe.colorWriteMaskRed, pipe.colorWriteMaskGreen, pipe.colorWriteMaskBlue, pipe.colorWriteMaskAlpha);        
+		setColorMask(pipe.colorWriteMaskRed, pipe.colorWriteMaskGreen, pipe.colorWriteMaskBlue, pipe.colorWriteMaskAlpha);
+		setConservativeRasterization(pipe.conservativeRasterization);
 		pipe.set();
 	}
 	
 	@:functionCode('Kore::Graphics4::setColorMask(red, green, blue, alpha);')
-	function setColorMask(red : Bool, green : Bool, blue : Bool, alpha : Bool) {
+	function setColorMask(red: Bool, green: Bool, blue: Bool, alpha: Bool) {
+	}
+
+	@:functionCode('Kore::Graphics4::setConservativeRasterization(on);')
+	function setConservativeRasterization(on: Bool) {
 	}
 
 	public function setBool(location: kha.graphics4.ConstantLocation, value: Bool): Void {

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -43,6 +43,7 @@ extern class Krom {
 	static function setStencilParameters(compareMode: Int, bothPass: Int, depthFail: Int, stencilFail: Int, referenceValue: Int, readMask: Int, writeMask: Int): Void;
 	static function setBlendingMode(source: Int, destination: Int, alphaSource: Int, alphaDestination: Int): Void;
 	static function setColorMask(red: Bool, green: Bool, blue: Bool, alpha: Bool): Void;
+	static function setConservativeRasterization(on: Bool): Void;
 	static function createRenderTarget(width: Int, height: Int, depthBufferBits: Int, format: Int, stencilBufferBits: Int, contextId: Int): Dynamic;
 	static function createRenderTargetCubeMap(cubeMapSize: Int, depthBufferBits: Int, format: Int, stencilBufferBits: Int, contextId: Int): Dynamic;
 	static function createTexture(width: Int, height: Int, format: Int): Dynamic;

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -172,11 +172,16 @@ class Graphics implements kha.graphics4.Graphics {
 		setStencilParameters(pipeline.stencilMode, pipeline.stencilBothPass, pipeline.stencilDepthFail, pipeline.stencilFail, pipeline.stencilReferenceValue, pipeline.stencilReadMask, pipeline.stencilWriteMask);
 		setBlendingMode(pipeline.blendSource, pipeline.blendDestination, pipeline.alphaBlendSource, pipeline.alphaBlendDestination);
 		setColorMask(pipeline.colorWriteMaskRed, pipeline.colorWriteMaskGreen, pipeline.colorWriteMaskBlue, pipeline.colorWriteMaskAlpha);
+		setConservativeRasterization(pipeline.conservativeRasterization);
 		pipeline.set();
 	}
 
 	function setColorMask(red: Bool, green: Bool, blue: Bool, alpha: Bool) {
 		Krom.setColorMask(red, green, blue, alpha);
+	}
+
+	function setConservativeRasterization(on: Bool) {
+		Krom.setConservativeRasterization(on);
 	}
 
 	public function setBool(location: kha.graphics4.ConstantLocation, value: Bool): Void {

--- a/Sources/kha/graphics4/PipelineStateBase.hx
+++ b/Sources/kha/graphics4/PipelineStateBase.hx
@@ -30,6 +30,8 @@ class PipelineStateBase {
 		alphaBlendOperation = BlendingOperation.Add;
 		
 		colorWriteMask = true;
+
+		conservativeRasterization = false;
 	}
 
 	public var inputLayout: Array<VertexStructure>;
@@ -60,13 +62,15 @@ class PipelineStateBase {
 	public var alphaBlendDestination: BlendingFactor;
 	public var alphaBlendOperation: BlendingOperation;
 	
-	public var colorWriteMask(never, set) : Bool;
-	public var colorWriteMaskRed : Bool;
-	public var colorWriteMaskGreen : Bool;
-	public var colorWriteMaskBlue : Bool;
-	public var colorWriteMaskAlpha : Bool;
+	public var colorWriteMask(never, set): Bool;
+	public var colorWriteMaskRed: Bool;
+	public var colorWriteMaskGreen: Bool;
+	public var colorWriteMaskBlue: Bool;
+	public var colorWriteMaskAlpha: Bool;
 
-	inline function set_colorWriteMask( value : Bool ) : Bool {
+	inline function set_colorWriteMask(value: Bool ): Bool {
 		return colorWriteMaskRed = colorWriteMaskBlue = colorWriteMaskGreen = colorWriteMaskAlpha = value;
 	}
+
+	public var conservativeRasterization: Bool;
 }


### PR DESCRIPTION
To go with https://github.com/Kode/Kore/pull/178 and https://github.com/Kode/Krom/pull/39.

Reference: https://developer.nvidia.com/content/dont-be-conservative-conservative-rasterization
NVIDIA example: https://github.com/NVIDIAGameWorks/GraphicsSamples/tree/master/samples/gl4-maxwell/ConservativeRaster