### PR TITLE
handle setMatrix functions like the rest

### DIFF
--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -423,17 +423,24 @@ class Graphics implements kha.graphics4.Graphics {
 		
 	}
 
+	public function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
+		setMatrixPrivate(cast location, matrix);
+	}
+
 	@:functionCode('
 		Kore::mat4 value;
 		value.Set(0, 0, matrix->_00); value.Set(0, 1, matrix->_10); value.Set(0, 2, matrix->_20); value.Set(0, 3, matrix->_30);
 		value.Set(1, 0, matrix->_01); value.Set(1, 1, matrix->_11); value.Set(1, 2, matrix->_21); value.Set(1, 3, matrix->_31);
 		value.Set(2, 0, matrix->_02); value.Set(2, 1, matrix->_12); value.Set(2, 2, matrix->_22); value.Set(2, 3, matrix->_32);
 		value.Set(3, 0, matrix->_03); value.Set(3, 1, matrix->_13); value.Set(3, 2, matrix->_23); value.Set(3, 3, matrix->_33);
-		::kha::kore::graphics4::ConstantLocation_obj* loc = dynamic_cast< ::kha::kore::graphics4::ConstantLocation_obj*>(location->__GetRealObject());
-		Kore::Graphics4::setMatrix(loc->location, value);
+		Kore::Graphics4::setMatrix(location->location, value);
 	')
-	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
-		
+	private function setMatrixPrivate(location: ConstantLocation, matrix: FastMatrix4): Void {
+
+	}
+
+	public function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
+		setMatrix3Private(cast location, matrix);
 	}
 
 	@:functionCode('
@@ -441,10 +448,9 @@ class Graphics implements kha.graphics4.Graphics {
 		value.Set(0, 0, matrix->_00); value.Set(0, 1, matrix->_10); value.Set(0, 2, matrix->_20);
 		value.Set(1, 0, matrix->_01); value.Set(1, 1, matrix->_11); value.Set(1, 2, matrix->_21);
 		value.Set(2, 0, matrix->_02); value.Set(2, 1, matrix->_12); value.Set(2, 2, matrix->_22);
-		::kha::kore::graphics4::ConstantLocation_obj* loc = dynamic_cast< ::kha::kore::graphics4::ConstantLocation_obj*>(location->__GetRealObject());
-		Kore::Graphics4::setMatrix(loc->location, value);
+		Kore::Graphics4::setMatrix(location->location, value);
 	')
-	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
+	private function setMatrix3Private(location: ConstantLocation, matrix: FastMatrix3): Void {
 		
 	}
 	


### PR DESCRIPTION
Tried to build on linux today (ubuntu 16.04, g++ 5.4.0) and i got this:

```bash
../Sources/src/kha/kore/graphics4/Graphics.cpp: In member function ‘void kha::kore::graphics4::Graphics_obj::setMatrix(Dynamic, kha::math::FastMatrix4)’:
../Sources/src/kha/kore/graphics4/Graphics.cpp:382:143: error: cannot dynamic_cast ‘location.Dynamic::<anonymous>.hx::ObjectPtr<O>::operator-><hx::Object>()->hx::Object::__GetRealObject()’ (of type ‘class hx::Object*’) to type ‘class kha::kore::graphics4::ConstantLocation_obj*’ (target is not pointer or reference to complete type)
   ::kha::kore::graphics4::ConstantLocation_obj* loc = dynamic_cast< ::kha::kore::graphics4::ConstantLocation_obj*>(location->__GetRealObject());
                                                                                                                                               ^
../Sources/src/kha/kore/graphics4/Graphics.cpp:383:33: error: invalid use of incomplete type ‘class kha::kore::graphics4::ConstantLocation_obj’
   Kore::Graphics4::setMatrix(loc->location, value);
                                 ^
In file included from ../../../Kha/Backends/Kore/khacpp/include/hxcpp.h:334:0:
../Sources/include/kha/graphics4/PipelineState.h:25:38: note: forward declaration of ‘class kha::kore::graphics4::ConstantLocation_obj’
 HX_DECLARE_CLASS3(kha,kore,graphics4,ConstantLocation)
                                      ^
../../../Kha/Backends/Kore/khacpp/include/hx/Macros.h:16:8: note: in definition of macro ‘HX_DECLARE_CLASS0’
  class klass##_obj; \
        ^
../../../Kha/Backends/Kore/khacpp/include/hx/Macros.h:19:58: note: in expansion of macro ‘HX_DECLARE_CLASS1’
 #define HX_DECLARE_CLASS2(ns2,ns1,klass) namespace ns2 { HX_DECLARE_CLASS1(ns1,klass) }
                                                          ^
../../../Kha/Backends/Kore/khacpp/include/hx/Macros.h:20:62: note: in expansion of macro ‘HX_DECLARE_CLASS2’
 #define HX_DECLARE_CLASS3(ns3,ns2,ns1,klass) namespace ns3 { HX_DECLARE_CLASS2(ns2,ns1,klass) }
                                                              ^
../Sources/include/kha/graphics4/PipelineState.h:25:1: note: in expansion of macro ‘HX_DECLARE_CLASS3’
 HX_DECLARE_CLASS3(kha,kore,graphics4,ConstantLocation)
 ^

makefile:1211: recipe for target 'graphics___.o' failed

make: *** [graphics___.o] Error 1

```
I'm not sure if there's a better way to fix this, but for now i just implemented the 2 setMatrix functions in the same ```setSomethingPrivate(cast location, ...)``` manner like the other functions.
