### PR TITLE
Return systemId for Krom

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -86,6 +86,7 @@ extern class Krom {
 	static function windowWidth(id: Int): Int;
 	static function windowHeight(id: Int): Int;
 	static function screenDpi(): Int;
+	static function systemId(): String;
 	static function requestShutdown(): Void;
 
 	static function fileSaveBytes(path: String, bytes: haxe.io.BytesData): Void;

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -175,7 +175,7 @@ class SystemImpl {
 	}
 	
 	public static function getSystemId(): String {
-		return "Krom";
+		return Krom.systemId();
 	}
 	
 	public static function requestShutdown(): Void {


### PR DESCRIPTION
Allows to detect host OS, works the same like Kore now.

We can still detect we are running Krom using:
```hx
#if kha_krom
// I am Krom
#end
```

To go with https://github.com/Kode/Krom/pull/46.