### PR TITLE
send keypress events on keyDown instead of keyUp

### DIFF
--- a/Backends/Flash/kha/SystemImpl.hx
+++ b/Backends/Flash/kha/SystemImpl.hx
@@ -133,14 +133,14 @@ class SystemImpl {
 		if (pressedKeys[event.keyCode]) return;
 		pressedKeys[event.keyCode] = true;
 		keyboard.sendDownEvent(cast event.keyCode);
+		if (event.charCode != 0) {
+			keyboard.sendPressEvent(String.fromCharCode(event.charCode));
+		}
 	}
 
 	private static function keyUpHandler(event: KeyboardEvent): Void {
 		pressedKeys[event.keyCode] = false;
 		keyboard.sendUpEvent(cast event.keyCode);
-		if (event.charCode != 0) {
-			keyboard.sendPressEvent(String.fromCharCode(event.charCode));
-		}
 	}
 
 	private static var mouseX: Int;


### PR DESCRIPTION
Was it intentional in the keyUpHandler? Seems kinda wrong to me.
At least now lubos's zui textInput controls are working in flash like any other target.
