### PR TITLE
Creating 3D textures from data for Kore and Krom

### DIFF
--- a/Backends/Android/kha/Image.hx
+++ b/Backends/Android/kha/Image.hx
@@ -254,6 +254,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+
 	public var g1(get, null): kha.graphics1.Graphics;
 
 	private function get_g1(): kha.graphics1.Graphics {

--- a/Backends/Empty/kha/Image.hx
+++ b/Backends/Empty/kha/Image.hx
@@ -22,6 +22,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+
 	public static var maxSize(get, null): Int;
 
 	public static function get_maxSize(): Int {

--- a/Backends/Flash/kha/Image.hx
+++ b/Backends/Flash/kha/Image.hx
@@ -44,6 +44,10 @@ class Image implements Canvas implements Resource {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public static function fromEncodedBytes(bytes: Bytes, fileExtention: String, doneCallback: Image -> Void, errorCallback: String->Void, readable:Bool = false): Void {
 		function handleError(e:flash.events.Event) errorCallback(e.toString());

--- a/Backends/HTML5-Worker/kha/Image.hx
+++ b/Backends/HTML5-Worker/kha/Image.hx
@@ -37,6 +37,10 @@ class Image implements Canvas implements Resource {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public static var maxSize(get, null): Int;
 	

--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -52,6 +52,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+
 	public static function fromEncodedBytes(bytes: Bytes, fileExtention: String, doneCallback: Image -> Void, errorCallback: String->Void, readable:Bool = false): Void {
 		var dataUrl = "data:image;base64," + haxe.crypto.Base64.encode(bytes);
 		var imageElement = cast(js.Browser.document.createElement('img'), ImageElement);

--- a/Backends/Java/kha/Image.hx
+++ b/Backends/Java/kha/Image.hx
@@ -42,6 +42,10 @@ class Image implements Canvas implements Resource {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public var g1(get, null): kha.graphics1.Graphics;
 	

--- a/Backends/Kore/kha/Image.hx
+++ b/Backends/Kore/kha/Image.hx
@@ -52,6 +52,19 @@ class Image implements Canvas implements Resource {
 	private function initFromBytes(bytes: BytesData, width: Int, height: Int, format: Int): Void {
 		
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		var readable = true;
+		var image = new Image(readable);
+		image.format = format;
+		image.initFromBytes3D(bytes.getData(), width, height, depth, getTextureFormat(format));
+		return image;
+	}
+
+	@:functionCode('texture = new Kore::Graphics4::Texture(bytes.GetPtr()->GetBase(), width, height, depth, format, readable);')
+	private function initFromBytes3D(bytes: BytesData, width: Int, height: Int, depth: Int, format: Int): Void {
+		
+	}
 	
 	public static function fromEncodedBytes(bytes: Bytes, format: String, doneCallback: Image -> Void, errorCallback: String->Void, readable: Bool = false): Void {
 		var image = new Image(readable);

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -40,6 +40,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+
 	private function new(readable: Bool) {
 		this.readable = readable;
 	}

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -43,6 +43,7 @@ extern class Krom {
 	static function createTexture(width: Int, height: Int, format: Int): Dynamic;
 	static function createTexture3D(width: Int, height: Int, depth: Int, format: Int): Dynamic;
 	static function createTextureFromBytes(data: haxe.io.BytesData, width: Int, height: Int, format: Int, readable: Bool): Dynamic;
+	static function createTextureFromBytes3D(data: haxe.io.BytesData, width: Int, height: Int, depth: Int, format: Int, readable: Bool): Dynamic;
 	static function getRenderTargetPixels(renderTarget: Dynamic, data: haxe.io.BytesData): Void;
 	static function unlockTexture(texture: Dynamic, data: haxe.io.BytesData): Void;
 	static function generateMipmaps(texture: Dynamic, levels: Int): Void;

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -92,6 +92,15 @@ class Image implements Canvas implements Resource {
 		image.texture_ = Krom.createTextureFromBytes(bytes.getData(), width, height, getTextureFormat(format), readable);
 		return image;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		if (format == null) format = TextureFormat.RGBA32;
+		var readable = true;
+		var image = new Image(null);
+		image.format = format;
+		image.texture_ = Krom.createTextureFromBytes3D(bytes.getData(), width, height, depth, getTextureFormat(format), readable);
+		return image;
+	}
 	
 	public static function create(width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		if (format == null) format = TextureFormat.RGBA32;

--- a/Backends/Node/kha/Image.hx
+++ b/Backends/Node/kha/Image.hx
@@ -42,6 +42,10 @@ class Image implements Canvas implements Resource {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public static var maxSize(get, null): Int;
 	

--- a/Backends/PSM/kha/Image.hx
+++ b/Backends/PSM/kha/Image.hx
@@ -28,6 +28,10 @@ class Image {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public function new(filename: String) {
 		texture = new Texture2D("/Application/resources/" + filename, false);

--- a/Backends/Unity/kha/Image.hx
+++ b/Backends/Unity/kha/Image.hx
@@ -34,6 +34,10 @@ class Image implements Canvas implements Resource {
 		return null;
 	}
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
+
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;
 		v |= v >>> 1;

--- a/Backends/WPF/kha/Image.hx
+++ b/Backends/WPF/kha/Image.hx
@@ -36,6 +36,10 @@ class Image implements Resource {
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
 		return null;
 	}
+
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
+		return null;
+	}
 	
 	public function new(width: Int, height: Int, format: TextureFormat) {
 		myWidth = width;

--- a/Sources/kha/Image.hx
+++ b/Sources/kha/Image.hx
@@ -12,6 +12,8 @@ extern class Image implements Canvas implements Resource {
 
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = TextureFormat.RGBA32, usage: Usage = Usage.StaticUsage): Image;
 
+	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = TextureFormat.RGBA32, usage: Usage = Usage.StaticUsage): Image;
+
 	public static function fromEncodedBytes(bytes: Bytes, fileExtention: String, doneCallback: Image -> Void, errorCallback: String->Void, readable:Bool = false): Void;
 
 	// Create a new image instance and set things up so you can render to the image.


### PR DESCRIPTION
Adds possibility to load precomputed volume data and upload into 3D texture using Image.fromBytes3D().

To go with https://github.com/Kode/Kore/pull/200 and https://github.com/Kode/Krom/pull/55.