### PR TITLE
handle absolute paths in loadBlobFromDescription()

### DIFF
--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -114,7 +114,8 @@ class LoaderImpl {
 		var fs = untyped __js__("require('fs')");
         var path = untyped __js__("require('path')");
         var app = untyped __js__("require('electron').remote.require('electron').app");
-        fs.readFile(path.join(app.getAppPath(), desc.files[0]), function (err, data) {
+		var url = if (path.isAbsolute(desc.files[0])) desc.files[0] else path.join(app.getAppPath(), desc.files[0]);
+        fs.readFile(url, function (err, data) {
 			var byteArray: Dynamic = untyped __js__("new Uint8Array(data)");
             var bytes = Bytes.alloc(byteArray.byteLength);
             for (i in 0...byteArray.byteLength) bytes.set(i, byteArray[i]);


### PR DESCRIPTION
This PR handles absolute paths in loadBlobFromDescription() now.
The issue i had was using ```Assets.loadBlobFromPath('e:/projects/xxx/something.json');```
This would try to load ```'e:/projects/xxx/build/debug-html5/e:/projects/xxx/something.json'```.
