### PR TITLE
Fix build script on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ TRUE=0
 if  [ "$target" == "windows" ] ||
 	[ "$target" == "linux" ] ||
 	[ "$target" == "android" ] ||
-	[ "$target" == "windowsrt" ]
+	[ "$target" == "windowsrt" ] ||
 	[ "$target" == "osx" ] ||
 	[ "$target" == "ios" ] ||
 	[ "$target" == "html5" ] ||
@@ -59,7 +59,6 @@ if  [ "$target" == "windows" ] ||
 	[ "$target" == "java" ] ||
 	[ "$target" == "psm" ] ||
 	[ "$target" == "dalvik" ] ||
-	[ "$target" == "tizen" ] ||
 	[ "$target" == "tizen" ]; then
 	TRUE=1
 fi


### PR DESCRIPTION
The script would return with "Unsupported platform..." when Linux was supplied as a target.
Now it builds the project files but it still doesn't build any binary.