### PR TITLE
fontGlyphs fix for HTML5 CanvasGraphics

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -306,11 +306,7 @@ class SystemImpl {
 
 		#if kha_webgl
 		try {
-			#if kha_webgl2
-			SystemImpl.gl = canvas.getContext("webgl", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
-			#else
 			SystemImpl.gl = canvas.getContext("webgl2", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
-			#end
 			SystemImpl.gl.pixelStorei(GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
 
 			halfFloat = {HALF_FLOAT_OES: 0x140B}; // GL_HALF_FLOAT
@@ -324,21 +320,14 @@ class SystemImpl {
 			if (anisotropicFilter == null) anisotropicFilter = SystemImpl.gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
 			
 			gl = true;
-
-			#if kha_webgl2
 			gl2 = true;
-			#else
-			gl2 = false;
-			#end
-
 			Shaders.init();
 		}
 		catch (e: Dynamic) {
 			trace("Could not initialize WebGL 2, falling back to WebGL.");
-			gl = false;
 		}
 
-		if (!gl) {
+		if (!gl2) {
 			try {
 				SystemImpl.gl = canvas.getContext("experimental-webgl", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
 				if (SystemImpl.gl != null) {
@@ -374,6 +363,7 @@ class SystemImpl {
 			frame.init(new kha.graphics2.Graphics1(frame), new kha.js.graphics4.Graphics2(frame), g4); // new kha.graphics1.Graphics4(frame));
 		}
 		else {
+			untyped __js__ ("kha_Kravur = kha_js_Font");
 			var g2 = new CanvasGraphics(canvas.getContext("2d"));
 			frame = new Framebuffer(0, null, g2, null);
 			frame.init(new kha.graphics2.Graphics1(frame), g2, null);

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -306,7 +306,11 @@ class SystemImpl {
 
 		#if kha_webgl
 		try {
+			#if kha_webgl2
+			SystemImpl.gl = canvas.getContext("webgl", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
+			#else
 			SystemImpl.gl = canvas.getContext("webgl2", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
+			#end
 			SystemImpl.gl.pixelStorei(GL.UNPACK_PREMULTIPLY_ALPHA_WEBGL, 1);
 
 			halfFloat = {HALF_FLOAT_OES: 0x140B}; // GL_HALF_FLOAT
@@ -320,14 +324,21 @@ class SystemImpl {
 			if (anisotropicFilter == null) anisotropicFilter = SystemImpl.gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
 			
 			gl = true;
+
+			#if kha_webgl2
 			gl2 = true;
+			#else
+			gl2 = false;
+			#end
+
 			Shaders.init();
 		}
 		catch (e: Dynamic) {
 			trace("Could not initialize WebGL 2, falling back to WebGL.");
+			gl = false;
 		}
 
-		if (!gl2) {
+		if (!gl) {
 			try {
 				SystemImpl.gl = canvas.getContext("experimental-webgl", { alpha: false, antialias: options.samplesPerPixel > 1, stencil: true, preserveDrawingBuffer: true } );
 				if (SystemImpl.gl != null) {

--- a/Backends/HTML5/kha/js/CanvasGraphics.hx
+++ b/Backends/HTML5/kha/js/CanvasGraphics.hx
@@ -159,13 +159,18 @@ class CanvasGraphics extends Graphics {
 		//canvas.fillText(text, tx + x, ty + y + webfont.getHeight());
 		//canvas.drawImage(cast(webfont.getTexture(), Image).image, 0, 0, 50, 50, tx + x, ty + y, 50, 50);
 		
-		var image = webfont.getImage(fontSize, myColor);
+		var image = webfont.getImage(fontSize, myColor, fontGlyphs);
 		if (image.width > 0) {
 			// the image created in getImage() is not imediately useable
 			var xpos = x;
 			var ypos = y;
 			for (i in 0...text.length) {
-				var q = webfont.kravur._get(fontSize).getBakedQuad(text.charCodeAt(i) - 32, xpos, ypos);
+				var q;
+				if (fontGlyphs != null)
+					q = webfont.kravur._get(fontSize, fontGlyphs).getBakedQuad(fontGlyphs.indexOf(text.charCodeAt(i)), xpos, ypos);
+				else
+					q = webfont.kravur._get(fontSize).getBakedQuad(text.charCodeAt(i) - 32, xpos, ypos);
+
 				if (q != null) {
 					if (q.s1 - q.s0 > 0 && q.t1 - q.t0 > 0 && q.x1 - q.x0 > 0 && q.y1 - q.y0 > 0)
 						canvas.drawImage(image, q.s0 * image.width, q.t0 * image.height, (q.s1 - q.s0) * image.width, (q.t1 - q.t0) * image.height, q.x0, q.y0, q.x1 - q.x0, q.y1 - q.y0);

--- a/Backends/HTML5/kha/js/Font.hx
+++ b/Backends/HTML5/kha/js/Font.hx
@@ -30,12 +30,13 @@ class Font implements kha.Font {
 		return kravur._get(fontSize).getBaselinePosition();
 	}
 	
-	public function getImage(fontSize: Int, color: Color): ImageElement {
-		if (!images.exists(fontSize)) {
-			images[fontSize] = new Map();
+	public function getImage(fontSize: Int, color: Color, glyphs: Array<Int> = null): ImageElement {
+		var imageIndex = glyphs == null ? fontSize : fontSize * 10000 + glyphs.length;
+		if (!images.exists(imageIndex)) {
+			images[imageIndex] = new Map();
 		}
-		if (!images[fontSize].exists(color.value)) {
-			var kravur = this.kravur._get(fontSize);
+		if (!images[imageIndex].exists(color.value)) {
+			var kravur = this.kravur._get(fontSize, glyphs);
 			var canvas: Dynamic = Browser.document.createElement("canvas");
 			canvas.width = kravur.width;
 			canvas.height = kravur.height;
@@ -55,10 +56,10 @@ class Font implements kha.Font {
 		
 			var img: ImageElement = cast Browser.document.createElement("img");
 			img.src = canvas.toDataURL("image/png");
-			images[fontSize][color.value] = img;
+			images[imageIndex][color.value] = img;
 			return img;
 		}
-		return images[fontSize][color.value];
+		return images[imageIndex][color.value];
 	}
 	
 	public function unload(): Void {

--- a/Sources/kha/Kravur.hx
+++ b/Sources/kha/Kravur.hx
@@ -124,14 +124,15 @@ class Kravur implements Font {
 	}
 	
 	public function _get(fontSize: Int, glyphs: Array<Int> = null): KravurImage {
-		if (!images.exists(fontSize)) {
+		var imageIndex = glyphs == null ? fontSize : fontSize * 10000 + glyphs.length;
+		if (!images.exists(imageIndex)) {
 			if (glyphs == null) {
 				glyphs = [];
 				for (i in 32...256) {
 					glyphs.push(i);
 				}
 			}
-			
+
 			var width: Int = 64;
 			var height: Int = 32;
 			var baked = new Vector<Stbtt_bakedchar>(glyphs.length);
@@ -161,10 +162,10 @@ class Kravur implements Font {
 			var lineGap = Math.round(metrics.lineGap * scale);
 			
 			var image = new KravurImage(Std.int(fontSize), ascent, descent, lineGap, width, height, baked, pixels);
-			images[fontSize] = image;
+			images[imageIndex] = image;
 			return image;
 		}
-		return images[fontSize];
+		return images[imageIndex];
 	}
 
 	public function height(fontSize: Int): Float {


### PR DESCRIPTION
fontGlyphs for HTML5 worked only with WebGL (graphics4)
these changes allow it to work in Canvas without WebGL