### PR TITLE
hl fixes

### DIFF
--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -252,7 +252,7 @@ class Image implements Canvas implements Resource {
 	}
 	
 	@:hlNative("std", "kore_texture_create") static function kore_texture_create(width: Int, height: Int, format: Int, readable: Bool): Pointer { return null; }
-	@:hlNative("std", "kore_texture_create_from_file") static function kore_texture_create_from_file(filename: hl.types.Bytes, readable: Bool): Pointer { return null; }
+	@:hlNative("std", "kore_texture_create_from_file") static function kore_texture_create_from_file(filename: hl.Bytes, readable: Bool): Pointer { return null; }
 	@:hlNative("std", "kore_non_pow2_textures_supported") static function kore_non_pow2_textures_supported(): Bool { return false; }
 	@:hlNative("std", "kore_texture_get_width") static function kore_texture_get_width(texture: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_texture_get_height") static function kore_texture_get_height(texture: Pointer): Int { return 0; }

--- a/Backends/KoreHL/kha/Pointer.hx
+++ b/Backends/KoreHL/kha/Pointer.hx
@@ -1,3 +1,3 @@
 package kha;
 
-typedef Pointer = hl.types.Bytes;
+typedef Pointer = hl.Bytes;

--- a/Backends/KoreHL/kha/SystemImpl.hx
+++ b/Backends/KoreHL/kha/SystemImpl.hx
@@ -142,8 +142,12 @@ class SystemImpl {
 	public static function loadUrl(url: String): Void {
 		
 	}
+
+	public static function getGamepadId(index: Int): String {
+		return "unknown";
+	}
 	
-	@:hlNative("std", "init_kore") static function init_kore(title: hl.types.Bytes, width: Int, height: Int): Void { }
+	@:hlNative("std", "init_kore") static function init_kore(title: hl.Bytes, width: Int, height: Int): Void { }
 	@:hlNative("std", "kore_get_time") static function kore_get_time(): Float { return 0; }
 	@:hlNative("std", "kore_get_window_width") static function kore_get_window_width(window: Int): Int { return 0; }
 	@:hlNative("std", "kore_get_window_height") static function kore_get_window_height(window: Int): Int { return 0; }

--- a/Backends/KoreHL/kha/graphics4/FragmentShader.hx
+++ b/Backends/KoreHL/kha/graphics4/FragmentShader.hx
@@ -6,17 +6,17 @@ import kha.Blob;
 class FragmentShader {
 	public var _shader: Pointer;
 	
-	public function new(source: Blob) {
-		initFragmentShader(source);
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		initFragmentShader(sources[0]);
 	}
 	
 	private function initFragmentShader(source: Blob): Void {
-		_shader = kore_create_fragmentshader(source.bytes.getData().b, source.bytes.getData().length); 
+		_shader = kore_create_fragmentshader(source.bytes.getData(), source.bytes.getData().length); 
 	}
 	
 	public function unused(): Void {
 		var include: Bytes = Bytes.ofString("");
 	}
 	
-	@:hlNative("std", "kore_create_fragmentshader") static function kore_create_fragmentshader(data: hl.types.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_create_fragmentshader") static function kore_create_fragmentshader(data: hl.Bytes, length: Int): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/IndexBuffer.hx
+++ b/Backends/KoreHL/kha/graphics4/IndexBuffer.hx
@@ -36,6 +36,6 @@ class IndexBuffer {
 	}
 	
 	@:hlNative("std", "kore_create_indexbuffer") static function kore_create_indexbuffer(count: Int): Pointer { return null; }
-	@:hlNative("std", "kore_indexbuffer_lock") static function kore_indexbuffer_lock(buffer: Pointer): hl.types.Bytes { return null; }
+	@:hlNative("std", "kore_indexbuffer_lock") static function kore_indexbuffer_lock(buffer: Pointer): hl.Bytes { return null; }
 	@:hlNative("std", "kore_indexbuffer_unlock") static function kore_indexbuffer_unlock(buffer: Pointer): Void { }
 }

--- a/Backends/KoreHL/kha/graphics4/PipelineState.hx
+++ b/Backends/KoreHL/kha/graphics4/PipelineState.hx
@@ -67,18 +67,18 @@ class PipelineState extends PipelineStateBase {
 	
 	public function unused(): Void {
 		var include1 = new VertexElement("include", VertexData.Float2);
-		var include2 = new VertexShader(null);
-		var include3 = new FragmentShader(null);
-		var include4 = new GeometryShader(null);
-		var include5 = new TessellationControlShader(null);
-		var include6 = new TessellationEvaluationShader(null);
+		var include2 = new VertexShader(null, null);
+		var include3 = new FragmentShader(null, null);
+		// var include4 = new GeometryShader(null);
+		// var include5 = new TessellationControlShader(null);
+		// var include6 = new TessellationEvaluationShader(null);
 	}
 	
 	@:hlNative("std", "kore_create_program") static function kore_create_program(): Pointer { return null; }
 	@:hlNative("std", "kore_program_set_fragment_shader") static function kore_program_set_fragment_shader(program: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_program_set_vertex_shader") static function kore_program_set_vertex_shader(program: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_program_link") static function kore_program_link(program: Pointer, structure: Pointer): Void { }
-	@:hlNative("std", "kore_program_get_constantlocation") static function kore_program_get_constantlocation(program: Pointer, name: hl.types.Bytes): Pointer { return null; }
-	@:hlNative("std", "kore_program_get_textureunit") static function kore_program_get_textureunit(program: Pointer, name: hl.types.Bytes): Pointer { return null; }
+	@:hlNative("std", "kore_program_get_constantlocation") static function kore_program_get_constantlocation(program: Pointer, name: hl.Bytes): Pointer { return null; }
+	@:hlNative("std", "kore_program_get_textureunit") static function kore_program_get_textureunit(program: Pointer, name: hl.Bytes): Pointer { return null; }
 	@:hlNative("std", "kore_program_set") static function kore_program_set(program: Pointer): Void { }
 }

--- a/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
@@ -59,9 +59,9 @@ class VertexBuffer {
 	}
 	
 	@:hlNative("std", "kore_create_vertexstructure") public static function kore_create_vertexstructure(): Pointer { return null; }
-	@:hlNative("std", "kore_vertexstructure_add") public static function kore_vertexstructure_add(structure: Pointer, name: hl.types.Bytes, data: Int): Void { }
+	@:hlNative("std", "kore_vertexstructure_add") public static function kore_vertexstructure_add(structure: Pointer, name: hl.Bytes, data: Int): Void { }
 	@:hlNative("std", "kore_create_vertexbuffer") static function kore_create_vertexbuffer(vertexCount: Int, structure: Pointer, stepRate: Int): Pointer { return null; }
-	@:hlNative("std", "kore_vertexbuffer_lock") static function kore_vertexbuffer_lock(buffer: Pointer): hl.types.Bytes { return null; }
+	@:hlNative("std", "kore_vertexbuffer_lock") static function kore_vertexbuffer_lock(buffer: Pointer): hl.Bytes { return null; }
 	@:hlNative("std", "kore_vertexbuffer_unlock") static function kore_vertexbuffer_unlock(buffer: Pointer): Void { }
 	@:hlNative("std", "kore_vertexbuffer_stride") static function kore_vertexbuffer_stride(buffer: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_vertexbuffer_count") static function kore_vertexbuffer_count(buffer: Pointer): Int { return 0; }

--- a/Backends/KoreHL/kha/graphics4/VertexShader.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexShader.hx
@@ -6,17 +6,17 @@ import kha.Blob;
 class VertexShader {
 	public var _shader: Pointer;
 	
-	public function new(source: Blob) {
-		initVertexShader(source);
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		initVertexShader(sources[0]);
 	}
 	
 	private function initVertexShader(source: Blob): Void {
-		_shader = kore_create_vertexshader(source.bytes.getData().b, source.bytes.getData().length);
+		_shader = kore_create_vertexshader(source.bytes.getData(), source.bytes.getData().length);
 	}
 	
 	public function unused(): Void {
 		var include: Bytes = Bytes.ofString("");
 	}
 	
-	@:hlNative("std", "kore_create_vertexshader") static function kore_create_vertexshader(data: hl.types.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_create_vertexshader") static function kore_create_vertexshader(data: hl.Bytes, length: Int): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -105,8 +105,8 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	
-	private function getBlendingMode(op: BlendingFactor): Int {
-		switch (op) {
+	private static function getBlendFunc(factor: BlendingFactor): Int {
+		switch (factor) {
 		case BlendOne, Undefined:
 			return 0;
 		case BlendZero:
@@ -119,6 +119,16 @@ class Graphics implements kha.graphics4.Graphics {
 			return 4;
 		case InverseDestinationAlpha:
 			return 5;
+		case SourceColor:
+			return 6;
+		case DestinationColor:
+			return 7;
+		case InverseSourceColor:
+			return 8;
+		case InverseDestinationColor:
+			return 9;
+		default:
+			return 0;
 		}
 	}
 	
@@ -136,7 +146,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	private function setBlendingMode(source: BlendingFactor, destination: BlendingFactor): Void {
-		setBlendingModeNative(getBlendingMode(source), getBlendingMode(destination));
+		setBlendingModeNative(getBlendFunc(source), getBlendFunc(destination));
 	}
 	
 	//@:functionCode('Kore::Graphics::clear(flags, color, z, stencil);')
@@ -297,6 +307,10 @@ class Graphics implements kha.graphics4.Graphics {
 	public function setTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
 		if (texture == null) return;
 		setTextureInternal(cast unit, texture);
+	}
+
+	public function setTextureArray(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
+	
 	}
 	
 	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {

--- a/Backends/KoreHL/korefile.js
+++ b/Backends/KoreHL/korefile.js
@@ -1,4 +1,4 @@
-var project = new Project('Kha');
+let project = new Project('Kha', __dirname);
 
 project.addFiles('KoreC/**', 'hl/include/**', 'hl/src/std/**', 'hl/src/alloc.c', 'hl/src/hl.h', 'hl/src/hlc.h', 'hl/src/hlmodule.h', 'hl/src/opcodes.h');
 project.addExcludes('hl/src/std/unicase.c');
@@ -18,4 +18,4 @@ if (platform === Platform.Windows) {
 	project.addLib('ws2_32');
 }
 
-return project;
+resolve(project);


### PR DESCRIPTION
wip, to go with https://github.com/Kode/khamake/pull/124. 

`node Kha\make windows-hl` runs without issues now. The resulting .sln file won't compile due to mismatched hl files. Bindings also need some updating as Kore now does pipeline states etc. I think it's best to wait for Haxe 4.0 update in Kha so it can be fixed for the latest hl.