### PR TITLE
Color attachment fix for webgl depth textures

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -187,8 +187,8 @@ class WebGLImage extends Image {
 				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
 				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, texture, 0);
-				// OSX/Linux WebGL implementations throw incomplete framebuffer error, create color attachment
-				if (untyped __js__('navigator.appVersion.indexOf("Win")') == -1) {
+				// Some WebGL implementations throw incomplete framebuffer error, create color attachment
+				if (!SystemImpl.gl2) {
 					var colortex = SystemImpl.gl.createTexture();
 					SystemImpl.gl.bindTexture(GL.TEXTURE_2D, colortex);
 					SystemImpl.gl.texImage2D(GL.TEXTURE_2D, 0, GL.RGBA, realWidth, realHeight, 0, GL.RGBA, GL.UNSIGNED_BYTE, null);

--- a/Backends/HTML5/kha/graphics4/CubeMap.hx
+++ b/Backends/HTML5/kha/graphics4/CubeMap.hx
@@ -79,8 +79,8 @@ class CubeMap implements Canvas implements Resource {
 				SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MAG_FILTER, GL.NEAREST);
 				SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL.TEXTURE_MIN_FILTER, GL.NEAREST);
 				isDepthAttachment = true;
-				// OSX/Linux WebGL implementations throw incomplete framebuffer error, create color attachment
-				if (untyped __js__('navigator.appVersion.indexOf("Win")') == -1) {
+				// Some WebGL implementations throw incomplete framebuffer error, create color attachment
+				if (!SystemImpl.gl2) {
 					var colortex = SystemImpl.gl.createTexture();
 					SystemImpl.gl.bindTexture(GL.TEXTURE_CUBE_MAP, colortex);
 					for (i in 0...6) {


### PR DESCRIPTION
Windows + Edge also fails when there is no color attachment for the depth texture. This patch enables creating color attachments for all webgl1 implementations to be safe.