### PR TITLE
Use kha.arrays

### DIFF
--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -1,7 +1,7 @@
 package kha.android;
 
 import android.opengl.GLES20;
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import java.NativeArray;
 import kha.android.graphics4.ConstantLocation;
 import kha.android.graphics4.TextureUnit;
@@ -324,7 +324,7 @@ class Graphics implements kha.graphics4.Graphics {
 
 	private var valuesCache = new NativeArray<Single>(128);
 
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		for (i in 0...values.length) {
 			valuesCache[i] = values[i];
 		}

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -419,7 +419,9 @@ class Graphics implements kha.graphics4.Graphics {
 
 	public function setFloats(location: kha.graphics4.ConstantLocation, values: kha.arrays.Float32Array): Void {
 		var flashLocation: ConstantLocation = cast location;
-		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, values);
+		var vals = new flash.Vector<Float>(values.length);
+		for (i in 0...values.length) vals[i] = values.get(i);
+		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, vals);
 	}
 
 	//public function renderToBackbuffer(): Void {

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -417,9 +417,9 @@ class Graphics implements kha.graphics4.Graphics {
 		
 	}
 
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: haxe.ds.Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: kha.arrays.Float32Array): Void {
 		var flashLocation: ConstantLocation = cast location;
-		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, values.toData());
+		context.setProgramConstantsFromVector(flashLocation.type, flashLocation.value, values);
 	}
 
 	//public function renderToBackbuffer(): Void {

--- a/Backends/HTML5-Worker/kha/html5worker/Graphics.hx
+++ b/Backends/HTML5-Worker/kha/html5worker/Graphics.hx
@@ -1,6 +1,6 @@
 package kha.html5worker;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Canvas;
 import kha.graphics4.IndexBuffer;
 import kha.graphics4.MipMapFilter;
@@ -155,7 +155,7 @@ class Graphics implements kha.graphics4.Graphics {
 			_0: value1, _1: value2, _2: value3, _3: value4});
 	}
 
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		Worker.postMessage({ command: 'setFloats', location: cast(location, kha.html5worker.ConstantLocation)._id,
 			values: values});
 	}

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -1,6 +1,6 @@
 package kha.js.graphics4;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import js.html.webgl.GL;
 import kha.Blob;
 import kha.graphics4.BlendingFactor;
@@ -467,7 +467,7 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniform4f(cast(location, ConstantLocation).value, value1, value2, value3, value4);
 	}
 
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		var webglLocation = cast(location, ConstantLocation);
 		switch (webglLocation.type) {
 			case GL.FLOAT_VEC2:
@@ -495,23 +495,23 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniform4f(cast(location, ConstantLocation).value, value.x, value.y, value.z, value.w);
 	}
 
-	private var matrixCache = new Vector<Float>(16);
+	private var matrixCache = new Float32Array(16);
 
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
 		matrixCache[ 0] = matrix._00; matrixCache[ 1] = matrix._01; matrixCache[ 2] = matrix._02; matrixCache[ 3] = matrix._03;
 		matrixCache[ 4] = matrix._10; matrixCache[ 5] = matrix._11; matrixCache[ 6] = matrix._12; matrixCache[ 7] = matrix._13;
 		matrixCache[ 8] = matrix._20; matrixCache[ 9] = matrix._21; matrixCache[10] = matrix._22; matrixCache[11] = matrix._23;
 		matrixCache[12] = matrix._30; matrixCache[13] = matrix._31; matrixCache[14] = matrix._32; matrixCache[15] = matrix._33;
-		SystemImpl.gl.uniformMatrix4fv(cast(location, ConstantLocation).value, false, matrixCache.toData());
+		SystemImpl.gl.uniformMatrix4fv(cast(location, ConstantLocation).value, false, cast matrixCache);
 	}
 
-	private var matrix3Cache = new Vector<Float>(9);
+	private var matrix3Cache = new Float32Array(9);
 
 	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
 		matrix3Cache[0] = matrix._00; matrix3Cache[1] = matrix._01; matrix3Cache[2] = matrix._02;
 		matrix3Cache[3] = matrix._10; matrix3Cache[4] = matrix._11; matrix3Cache[5] = matrix._12;
 		matrix3Cache[6] = matrix._20; matrix3Cache[7] = matrix._21; matrix3Cache[8] = matrix._22;
-		SystemImpl.gl.uniformMatrix3fv(cast(location, ConstantLocation).value, false, matrix3Cache.toData());
+		SystemImpl.gl.uniformMatrix3fv(cast(location, ConstantLocation).value, false, cast matrix3Cache);
 	}
 
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {

--- a/Backends/Kore/kha/arrays/Float32Array.hx
+++ b/Backends/Kore/kha/arrays/Float32Array.hx
@@ -19,14 +19,19 @@ extern class Float32ArrayData {
 		return 0;
 	}
 	
+	public function alloc(elements: Int): Void;
+
+	public function free(): Void;
+
 	public function get(index: Int): FastFloat;
 		
 	public function set(index: Int, value: FastFloat): FastFloat;
 }
 
 abstract Float32Array(Float32ArrayData) {
-	public inline function new() {
+	public inline function new(elements: Int = 0) {
 		this = Float32ArrayData.create();
+		if (elements > 0) this.alloc(elements);
 	}
 	
 	public var length(get, never): Int;

--- a/Backends/Kore/kha/arrays/Float32Array.hx
+++ b/Backends/Kore/kha/arrays/Float32Array.hx
@@ -1,7 +1,5 @@
 package kha.arrays;
 
-import cpp.RawPointer;
-import haxe.ds.Vector;
 import kha.FastFloat;
 
 @:unreflective
@@ -28,37 +26,51 @@ extern class Float32ArrayData {
 	public function set(index: Int, value: FastFloat): FastFloat;
 }
 
-abstract Float32Array(Float32ArrayData) {
+class Float32ArrayPrivate {
+
+	public var self: Float32ArrayData;
+
 	public inline function new(elements: Int = 0) {
-		this = Float32ArrayData.create();
-		if (elements > 0) this.alloc(elements);
+		self = Float32ArrayData.create();
+		if (elements > 0) self.alloc(elements);
 	}
-	
+}
+
+abstract Float32Array(Float32ArrayPrivate) {
+
+	public inline function new(elements: Int = 0) {
+		this = new Float32ArrayPrivate(elements);
+	}
+
+	public inline function free(): Void {
+		this.self.free();
+	}
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
-		return this.length;
+		return this.self.length;
 	}
 	
 	public inline function set(index: Int, value: FastFloat): FastFloat {
-		return this.set(index, value);
+		return this.self.set(index, value);
 	}
 	
 	public inline function get(index: Int): FastFloat {
-		return this.get(index);
+		return this.self.get(index);
 	}
 	
 	@:arrayAccess
 	public inline function arrayRead(index: Int): FastFloat {
-		return this.get(index);
+		return this.self.get(index);
 	}
 
 	@:arrayAccess
 	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this.set(index, value);
+		return this.self.set(index, value);
 	}
 
 	//public inline function subarray(start: Int, ?end: Int): Float32Array {
-	//	return cast this.subarray(start, end);
+	//	return cast this.self.subarray(start, end);
 	//}
 }

--- a/Backends/Kore/kha/arrays/Uint32Array.hx
+++ b/Backends/Kore/kha/arrays/Uint32Array.hx
@@ -27,41 +27,50 @@ extern class Uint32ArrayData {
 	public function set(index: Int, value: Int): Int;
 }
 
-abstract Uint32Array(Uint32ArrayData) {
+class Uint32ArrayPrivate {
+
+	public var self: Uint32ArrayData;
+
 	public inline function new(elements: Int = 0) {
-		this = Uint32ArrayData.create();
-		if (elements > 0) this.alloc(elements);
+		self = Uint32ArrayData.create();
+		if (elements > 0) self.alloc(elements);
+	}
+}
+
+abstract Uint32Array(Uint32ArrayPrivate) {
+	public inline function new(elements: Int = 0) {
+		this = new Uint32ArrayPrivate(elements);
 	}
 
 	public inline function free(): Void {
-		this.free();
+		this.self.free();
 	}
 	
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
-		return this.length;
+		return this.self.length;
 	}
 	
 	public inline function set(index: Int, value: Int): Int {
-		return this.set(index, value);
+		return this.self.set(index, value);
 	}
 	
 	public inline function get(index: Int): Int {
-		return this.get(index);
+		return this.self.get(index);
 	}
 	
 	@:arrayAccess
 	public inline function arrayRead(index: Int): Int {
-		return this.get(index);
+		return this.self.get(index);
 	}
 
 	@:arrayAccess
 	public inline function arrayWrite(index: Int, value: Int): Int {
-		return this.set(index, value);
+		return this.self.set(index, value);
 	}
 
 	//public inline function subarray(start: Int, ?end: Int): Uint32Array {
-	//	return cast this.subarray(start, end);
+	//	return cast this.self.subarray(start, end);
 	//}
 }

--- a/Backends/Kore/kha/arrays/Uint32Array.hx
+++ b/Backends/Kore/kha/arrays/Uint32Array.hx
@@ -17,6 +17,10 @@ extern class Uint32ArrayData {
 	function get_length(): Int {
 		return 0;
 	}
+
+	public function alloc(elements: Int): Void;
+
+	public function free(): Void;
 	
 	public function get(index: Int): Int;
 		
@@ -24,8 +28,13 @@ extern class Uint32ArrayData {
 }
 
 abstract Uint32Array(Uint32ArrayData) {
-	public inline function new() {
+	public inline function new(elements: Int = 0) {
 		this = Uint32ArrayData.create();
+		if (elements > 0) this.alloc(elements);
+	}
+
+	public inline function free(): Void {
+		this.free();
 	}
 	
 	public var length(get, never): Int;

--- a/Backends/Kore/kha/compute/Compute.hx
+++ b/Backends/Kore/kha/compute/Compute.hx
@@ -54,8 +54,8 @@ class Compute {
 		untyped __cpp__('Kore::Compute::setFloat4(location->location, value1, value2, value3, value4);');
 	}
 
-	public static function setFloats(location: ConstantLocation, values: Vector<FastFloat>) {
-		untyped __cpp__('Kore::Compute::setFloats(location->location, values->Pointer(), values->length);');
+	public static function setFloats(location: ConstantLocation, values: Float32Array) {
+		untyped __cpp__('Kore::Compute::setFloats(location->location, values.data, values.length());');
 	}
 
 	public static function setVector2(location: ConstantLocation, value: FastVector2): Void {

--- a/Backends/Kore/kha/compute/Compute.hx
+++ b/Backends/Kore/kha/compute/Compute.hx
@@ -55,7 +55,7 @@ class Compute {
 	}
 
 	public static function setFloats(location: ConstantLocation, values: Float32Array) {
-		untyped __cpp__('Kore::Compute::setFloats(location->location, values.data, values.length());');
+		untyped __cpp__('Kore::Compute::setFloats(location->location, values->self.data, values->self.length());');
 	}
 
 	public static function setVector2(location: ConstantLocation, value: FastVector2): Void {

--- a/Backends/Kore/kha/graphics4/IndexBuffer.hx
+++ b/Backends/Kore/kha/graphics4/IndexBuffer.hx
@@ -23,8 +23,8 @@ class IndexBuffer {
 	}
 	
 	@:functionCode('
-		data.data = (unsigned int*)buffer->lock() + start;
-		data.myLength = count;
+		data->self.data = (unsigned int*)buffer->lock() + start;
+		data->self.myLength = count;
 		return data;
 	')
 	private function lock2(start: Int, count: Int): Uint32Array {

--- a/Backends/Kore/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics4/VertexBuffer.hx
@@ -53,8 +53,8 @@ class VertexBuffer {
 	}
 
 	@:functionCode('
-		data.data = buffer->lock() + start * buffer->stride() / 4;
-		data.myLength = count * buffer->stride() / 4;
+		data->self.data = buffer->lock() + start * buffer->stride() / 4;
+		data->self.myLength = count * buffer->stride() / 4;
 		return data;
 	')
 	private function lock2(start: Int, count: Int): Float32Array {

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -1,6 +1,6 @@
 package kha.kore.graphics4;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Blob;
 import kha.Canvas;
 import kha.Color;
@@ -418,14 +418,14 @@ class Graphics implements kha.graphics4.Graphics {
 		
 	}
 	
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		setFloatsPrivate(cast location, values);
 	}
 	
 	@:functionCode('
-		Kore::Graphics4::setFloats(location->location, values->Pointer(), values->length);
+		Kore::Graphics4::setFloats(location->location, values.data, values.length());
 	')
-	private function setFloatsPrivate(location: ConstantLocation, values: Vector<FastFloat>): Void {
+	private function setFloatsPrivate(location: ConstantLocation, values: Float32Array): Void {
 		
 	}
 

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -423,7 +423,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	@:functionCode('
-		Kore::Graphics4::setFloats(location->location, values.data, values.length());
+		Kore::Graphics4::setFloats(location->location, values->self.data, values->self.length());
 	')
 	private function setFloatsPrivate(location: ConstantLocation, values: Float32Array): Void {
 		

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -411,21 +411,21 @@ class Graphics implements kha.graphics4.Graphics {
 		kore_graphics_set_float4(location._location, x, y, z, w);
 	}
 	
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		setFloatsPrivate(cast location, values);
 	}
 	
-	//@:functionCode('Kore::Graphics::setFloats(location->location, values->Pointer(), values->length);')
-	private function setFloatsPrivate(location: ConstantLocation, values: Vector<FastFloat>): Void {
+	//@:functionCode('Kore::Graphics::setFloats(location->location, values.data, values.length());')
+	private function setFloatsPrivate(location: ConstantLocation, values: Float32Array): Void {
 		
 	}
 
-	public function setFloat4s(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
+	public function setFloat4s(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
 		setFloat4sPrivate(cast location, values);
 	}
 	
-	//@:functionCode('Kore::Graphics::setFloat4s(location->location, values->Pointer(), values->length);')
-	private function setFloat4sPrivate(location: ConstantLocation, values: Vector<FastFloat>): Void {
+	//@:functionCode('Kore::Graphics::setFloat4s(location->location, values.data, values.length());')
+	private function setFloat4sPrivate(location: ConstantLocation, values: Float32Array): Void {
 		
 	}
 	

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -1,6 +1,6 @@
 package kha.krom;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Blob;
 import kha.graphics4.BlendingFactor;
 import kha.graphics4.BlendingOperation;
@@ -154,10 +154,8 @@ class Graphics implements kha.graphics4.Graphics {
 		Krom.setFloat4(location, value1, value2, value3, value4);
 	}
 
-	public function setFloats(location: kha.graphics4.ConstantLocation, values: Vector<FastFloat>): Void {
-		var vals = new kha.arrays.Float32Array(values.length);
-		for (i in 0...values.length) vals.set(i, values[i]);
-		Krom.setFloats(location, vals);
+	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
+		Krom.setFloats(location, values);
 	}
 
 	public function setVector2(location: kha.graphics4.ConstantLocation, value: FastVector2): Void {

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -1,6 +1,6 @@
 package kha.js;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.graphics4.BlendingOperation;
 import kha.graphics4.CompareMode;
 import kha.graphics4.ConstantLocation;
@@ -176,7 +176,7 @@ class EmptyGraphics4 implements Graphics {
 		
 	}
 
-	public function setFloats(location: ConstantLocation, floats: Vector<FastFloat>): Void {
+	public function setFloats(location: ConstantLocation, floats: Float32Array): Void {
 		
 	}
 

--- a/Sources/kha/compute/Compute.hx
+++ b/Sources/kha/compute/Compute.hx
@@ -1,6 +1,6 @@
 package kha.compute;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Image;
 import kha.FastFloat;
 import kha.math.FastMatrix3;
@@ -20,7 +20,7 @@ extern class Compute {
 	public static function setFloat2(location: ConstantLocation, value1: FastFloat, value2: FastFloat): Void;
 	public static function setFloat3(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void;
 	public static function setFloat4(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void;
-	public static function setFloats(location: ConstantLocation, values: Vector<FastFloat>): Void;
+	public static function setFloats(location: ConstantLocation, values: Float32Array): Void;
 	public static function setVector2(location: ConstantLocation, value: FastVector2): Void;
 	public static function setVector3(location: ConstantLocation, value: FastVector3): Void;
 	public static function setVector4(location: ConstantLocation, value: FastVector4): Void;

--- a/Sources/kha/graphics1/Graphics4.hx
+++ b/Sources/kha/graphics1/Graphics4.hx
@@ -1,6 +1,6 @@
 package kha.graphics1;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Blob;
 import kha.Color;
 import kha.FastFloat;
@@ -149,11 +149,11 @@ class Graphics4 implements kha.graphics4.Graphics {
 		
 	}
 	
-	public function setFloats(location: ConstantLocation, floats: Vector<FastFloat>): Void {
+	public function setFloats(location: ConstantLocation, floats: Float32Array): Void {
 		
 	}
 
-	public function setFloat4s(location: ConstantLocation, float4s: Vector<FastFloat>): Void {
+	public function setFloat4s(location: ConstantLocation, float4s: Float32Array): Void {
 
 	}
 	

--- a/Sources/kha/graphics4/Graphics.hx
+++ b/Sources/kha/graphics4/Graphics.hx
@@ -1,6 +1,6 @@
 package kha.graphics4;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.Blob;
 import kha.Color;
 import kha.FastFloat;
@@ -54,7 +54,7 @@ interface Graphics {
 	function setFloat2(location: ConstantLocation, value1: FastFloat, value2: FastFloat): Void;
 	function setFloat3(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void;
 	function setFloat4(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void;
-	function setFloats(location: ConstantLocation, floats: Vector<FastFloat>): Void;
+	function setFloats(location: ConstantLocation, floats: Float32Array): Void;
 	function setVector2(location: ConstantLocation, value: FastVector2): Void;
 	function setVector3(location: ConstantLocation, value: FastVector3): Void;
 	function setVector4(location: ConstantLocation, value: FastVector4): Void;

--- a/Sources/kha/graphics5/ConstantBuffer.hx
+++ b/Sources/kha/graphics5/ConstantBuffer.hx
@@ -1,6 +1,6 @@
 package kha.graphics5;
 
-import haxe.ds.Vector;
+import kha.arrays.Float32Array;
 import kha.math.FastVector2;
 import kha.math.FastVector3;
 import kha.math.FastVector4;
@@ -14,7 +14,7 @@ interface ConstantBuffer {
 	function setFloat2(location: ConstantLocation, value1: FastFloat, value2: FastFloat): Void;
 	function setFloat3(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void;
 	function setFloat4(location: ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void;
-	function setFloats(location: ConstantLocation, floats: Vector<FastFloat>): Void;
+	function setFloats(location: ConstantLocation, floats: Float32Array): Void;
 	function setVector2(location: ConstantLocation, value: FastVector2): Void;
 	function setVector3(location: ConstantLocation, value: FastVector3): Void;
 	function setVector4(location: ConstantLocation, value: FastVector4): Void;


### PR DESCRIPTION
Attempt to unify the arrays to get rid of the shenanigans we have to deal with in the backends code (ie copying to native data type all the time).

`g4.setFloats(location: ConstantLocation, floats: Vector<FastFloat>): Void;`

becomes

`g4.setFloats(location: ConstantLocation, floats: Float32Array): Void;`

To go with: https://github.com/Kode/khacpp/pull/6

HTML5 and Krom works, hxcpp does not. It passes `kha.arrays.Float32Array` as `( ::Dynamic)(( (cpp::Struct<  float32array >)(fa)`, Which throws `no suitable user-defined conversion from "Dynamic" to "float32array" exists`. It does that because of `@:structAccess` on the `Float32Array`, but we need that.

May contain more dumb stuff, did not polish yet.