### PR TITLE
Made HTML5 target respect devicePixelRatio

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -437,17 +437,17 @@ class SystemImpl {
 			if (untyped canvas.getContext) {
 
 				// Lookup the size the browser is displaying the canvas.
-				//TODO deal with window.devicePixelRatio ?
-				var displayWidth  = canvas.clientWidth;
-				var displayHeight = canvas.clientHeight;
+				if(canvas.clientWidth != options.width ||
+				   canvas.clientHeight != options.height) {
 
-				// Check if the canvas is not the same size.
-				if (canvas.width  != displayWidth ||
-					canvas.height != displayHeight) {
+					// set the display size of the canvas.
+					canvas.style.width = options.width + "px";
+					canvas.style.height = options.height + "px";
 
-					// Make the canvas the same size
-					canvas.width  = displayWidth;
-					canvas.height = displayHeight;
+					// set the size of the drawingBuffer
+					var devicePixelRatio = js.Browser.window.devicePixelRatio == null ? 1 : js.Browser.window.devicePixelRatio;
+					canvas.width = options.width * devicePixelRatio;
+					canvas.height = options.height * devicePixelRatio;
 				}
 
 				System.render(0, frame);


### PR DESCRIPTION
As per [https://www.khronos.org/webgl/wiki/HandlingHighDPI](https://www.khronos.org/webgl/wiki/HandlingHighDPI), these changes correctly size the `khanvas` on the screen (using css) and on the buffer (using width/height).