### PR TITLE
Asset loading failure callbacks

### DIFF
--- a/Backends/Android/kha/LoaderImpl.hx
+++ b/Backends/Android/kha/LoaderImpl.hx
@@ -15,21 +15,21 @@ import kha.Kravur;
 
 class LoaderImpl {
 	private static var assetManager: AssetManager;
-	
+
 	public static function init(context: Context) {
 		assetManager = context.getAssets();
 		Image.assets = assetManager;
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void) {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void, failed: Dynamic -> Void) {
 		done(Image.createFromFile(desc.files[0]));
 	}
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound->Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound->Void, failed: Dynamic -> Void) {
 		var sound: kha.Sound = null;
 		try {
 			sound = new kha.android.Sound(assetManager.openFd(desc.files[0]));
@@ -39,7 +39,7 @@ class LoaderImpl {
 		}
 		done(sound);
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["wav"];
 	}
@@ -54,8 +54,8 @@ class LoaderImpl {
 		}
 		done(music);
 	}*/
-	
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void) {
+
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void, failed: Dynamic -> Void) {
 		var video: kha.Video = null;
 		try {
 			video = new kha.android.Video(assetManager.openFd(desc.files[0]));
@@ -65,16 +65,16 @@ class LoaderImpl {
 		}
 		done(video);
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["ts"];
 	}
-	
+
 	/*function loadFont(name: String, style: FontStyle, size: Float): kha.Font {
 		return Kravur.get(name, style, size);
 	}*/
-	
-	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob->Void): Void {
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob->Void, failed: Dynamic -> Void): Void {
 		var bytes: Array<Int> = new Array<Int>();
 		try {
 			var stream: java.io.InputStream = new java.io.BufferedInputStream(assetManager.open(desc.files[0]));
@@ -92,17 +92,17 @@ class LoaderImpl {
 		var hbytes = Bytes.ofData(array);
 		done(new kha.Blob(hbytes));
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
-	
+
 	/*override public function showKeyboard(): Void {
 		Starter.showKeyboard = true;
 	}
-	
+
 	override public function hideKeyboard(): Void {
 		Starter.showKeyboard = false;
 	}*/

--- a/Backends/Android/kha/LoaderImpl.hx
+++ b/Backends/Android/kha/LoaderImpl.hx
@@ -21,7 +21,7 @@ class LoaderImpl {
 		Image.assets = assetManager;
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void, failed: AssetError -> Void) {
 		done(Image.createFromFile(desc.files[0]));
 	}
 
@@ -29,7 +29,7 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound->Void, failed: Dynamic -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound->Void, failed: AssetError -> Void) {
 		var sound: kha.Sound = null;
 		try {
 			sound = new kha.android.Sound(assetManager.openFd(desc.files[0]));
@@ -55,7 +55,7 @@ class LoaderImpl {
 		done(music);
 	}*/
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void, failed: Dynamic -> Void) {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void, failed: AssetError -> Void) {
 		var video: kha.Video = null;
 		try {
 			video = new kha.android.Video(assetManager.openFd(desc.files[0]));
@@ -74,7 +74,7 @@ class LoaderImpl {
 		return Kravur.get(name, style, size);
 	}*/
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob->Void, failed: Dynamic -> Void): Void {
+	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob->Void, failed: AssetError -> Void): Void {
 		var bytes: Array<Int> = new Array<Int>();
 		try {
 			var stream: java.io.InputStream = new java.io.BufferedInputStream(assetManager.open(desc.files[0]));
@@ -93,7 +93,7 @@ class LoaderImpl {
 		done(new kha.Blob(hbytes));
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);

--- a/Backends/Empty/kha/LoaderImpl.hx
+++ b/Backends/Empty/kha/LoaderImpl.hx
@@ -10,32 +10,32 @@ class LoaderImpl {
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void) {
-		
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
+
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["mp4", "ogg"];
 	}
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
-		
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["mp4", "webm"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
-		
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+
 	}
-    
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
-		
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
-		
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+
 	}
 }

--- a/Backends/Empty/kha/LoaderImpl.hx
+++ b/Backends/Empty/kha/LoaderImpl.hx
@@ -11,7 +11,7 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void) {
 
 	}
 
@@ -19,7 +19,7 @@ class LoaderImpl {
 		return ["mp4", "ogg"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void) {
 
 	}
 
@@ -27,15 +27,15 @@ class LoaderImpl {
 		return ["mp4", "webm"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void): Void {
 
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
 
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 
 	}
 }

--- a/Backends/Flash/kha/LoaderImpl.hx
+++ b/Backends/Flash/kha/LoaderImpl.hx
@@ -26,22 +26,22 @@ class LoaderImpl {
 		Assets.visit();
 		#end
 	}*/
-	
+
 	private static function adjustFilename(filename: String): String {
 		filename = filename.replace(".", "_");
 		filename = filename.replace("-", "_");
 		filename = filename.replace("/", "_");
 		return filename;
 	}
-	
+
 	/*public static function loadMusicFromDescription(desc: Dynamic, done: kha.Music -> Void) {
 		#if KHA_EMBEDDED_ASSETS
-		
+
 		var file: String = adjustFilename(desc.files[0]);
 		done(new kha.flash.Music(Bytes.ofData(cast Type.createInstance(Type.resolveClass("Assets_" + file), []))));
-		
+
 		#else
-		
+
 		var mp3file: String = null;
 		var oggfile: String = null;
 		for (i in 0...desc.files.length) {
@@ -53,7 +53,7 @@ class LoaderImpl {
 				mp3file = file;
 			}
 		}
-		
+
 		var urlRequest = new URLRequest(oggfile);
 		var urlLoader = new URLLoader();
 		urlLoader.dataFormat = URLLoaderDataFormat.BINARY;
@@ -76,39 +76,39 @@ class LoaderImpl {
 
 		#end
 	}*/
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void) {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		
+
 		#if KHA_EMBEDDED_ASSETS
-		
+
 		var file: String = adjustFilename(desc.files[0]);
 		done(Image.fromBitmapData(cast Type.createInstance(Type.resolveClass("Assets_" + file), [0, 0]), readable));
 
 		#else
-		
+
 		var urlRequest = new URLRequest(desc.files[0]);
 		var loader = new flash.display.Loader();
 		loader.contentLoaderInfo.addEventListener(Event.COMPLETE, function(e: Event) {
 			done(Image.fromBitmap(loader.content, readable));
 		});
 		loader.load(urlRequest);
-		
+
 		#end
 	}
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
-	
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
 		#if KHA_EMBEDDED_ASSETS
-		
+
 		var file: String = adjustFilename(desc.files[0]);
 		done(Blob.fromBytes(Bytes.ofData(cast Type.createInstance(Type.resolveClass("Assets_" + file), []))));
-		
+
 		#else
-		
+
 		var urlRequest = new URLRequest(desc.files[0]);
 		var urlLoader = new URLLoader();
 		urlLoader.dataFormat = URLLoaderDataFormat.BINARY;
@@ -116,24 +116,24 @@ class LoaderImpl {
 			done(new Blob(urlLoader.data));
 		});
 		urlLoader.load(urlRequest);
-		
+
 		#end
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		#if KHA_EMBEDDED_ASSETS
-		
+
 		var file: String = adjustFilename(desc.files[0]);
 		done(new kha.flash.Sound(Bytes.ofData(cast Type.createInstance(Type.resolveClass("Assets_" + file), []))));
-		
+
 		#else
-		
+
 		for (i in 0...desc.files.length) {
 			var file: String = desc.files[i];
 			if (file.endsWith(".mp3")) {
@@ -149,7 +149,7 @@ class LoaderImpl {
 				return;
 			}
 		}
-		
+
 		for (i in 0...desc.files.length) {
 			var file: String = desc.files[i];
 			if (file.endsWith(".ogg")) {
@@ -165,26 +165,26 @@ class LoaderImpl {
 				return;
 			}
 		}
-		
+
 		#end
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["mp3", "ogg"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void) {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void) {
 		done(new kha.flash.Video(desc.files[0]));
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["mp4"];
 	}
-	
+
 	/*override function loadFont(name: String, style: FontStyle, size: Float): kha.Font {
 		return Kravur.get(name, style, size);
 	}
-  
+
 	override public function loadURL(url: String): Void {
 		try {
 			flash.Lib.getURL(new flash.net.URLRequest(url), "_top");
@@ -193,15 +193,15 @@ class LoaderImpl {
 			trace(ex);
 		}
 	}
-	
+
 	override function setNormalCursor() {
 		Mouse.cursor = "auto";
 	}
-	
+
 	override function setHandCursor() {
 		Mouse.cursor = "button";
 	}
-	
+
 	override function setCursorBusy(busy: Bool) {
 		if (busy)
 			Mouse.hide();

--- a/Backends/Flash/kha/LoaderImpl.hx
+++ b/Backends/Flash/kha/LoaderImpl.hx
@@ -77,7 +77,7 @@ class LoaderImpl {
 		#end
 	}*/
 
-	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: AssetError -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
 
 		#if KHA_EMBEDDED_ASSETS
@@ -101,7 +101,7 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
 		#if KHA_EMBEDDED_ASSETS
 
 		var file: String = adjustFilename(desc.files[0]);
@@ -120,7 +120,7 @@ class LoaderImpl {
 		#end
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);
@@ -173,7 +173,7 @@ class LoaderImpl {
 		return ["mp3", "ogg"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void) {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void) {
 		done(new kha.flash.Video(desc.files[0]));
 	}
 

--- a/Backends/HTML5-Worker/kha/LoaderImpl.hx
+++ b/Backends/HTML5-Worker/kha/LoaderImpl.hx
@@ -17,7 +17,7 @@ class LoaderImpl {
 		return ["png", "jpg", "hdr"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void) {
 		++kha.Image._lastId;
 		loadingImages[kha.Image._lastId] = done;
 		Worker.postMessage({ command: 'loadImage', file: desc.files[0], id: kha.Image._lastId });
@@ -33,7 +33,7 @@ class LoaderImpl {
 		return ["mp4"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		++soundId;
 		loadingSounds[soundId] = done;
 		Worker.postMessage({ command: 'loadSound', file: desc.files[0], id: soundId });
@@ -54,13 +54,13 @@ class LoaderImpl {
 		return ["mp4"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void): Void {
 		++videoId;
 		loadingVideos[videoId] = done;
 		Worker.postMessage({ command: 'loadVideo', file: desc.files[0], id: videoId });
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
 		++blobId;
 		loadingBlobs[blobId] = done;
 		Worker.postMessage({ command: 'loadBlob', file: desc.files[0], id: blobId });
@@ -72,7 +72,7 @@ class LoaderImpl {
 		loadingBlobs.remove(value.id);
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		});

--- a/Backends/HTML5-Worker/kha/LoaderImpl.hx
+++ b/Backends/HTML5-Worker/kha/LoaderImpl.hx
@@ -12,28 +12,28 @@ class LoaderImpl {
 	static var loadingBlobs: Map<Int, Blob->Void> = new Map();
 	static var blobId = -1;
 	static var sounds: Map<Int, Sound> = new Map();
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg", "hdr"];
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void) {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		++kha.Image._lastId;
 		loadingImages[kha.Image._lastId] = done;
 		Worker.postMessage({ command: 'loadImage', file: desc.files[0], id: kha.Image._lastId });
 	}
-	
+
 	public static function _loadedImage(value: Dynamic) {
 		var image = new Image(value.id, -1, value.width, value.height, value.realWidth, value.realHeight, TextureFormat.RGBA32);
 		loadingImages[value.id](image);
 		loadingImages.remove(value.id);
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["mp4"];
 	}
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		++soundId;
 		loadingSounds[soundId] = done;
 		Worker.postMessage({ command: 'loadSound', file: desc.files[0], id: soundId });
@@ -45,22 +45,22 @@ class LoaderImpl {
 		loadingSounds.remove(value.id);
 		sounds.set(value.id, sound);
 	}
-	
+
 	public static function _uncompressedSound(value: Dynamic): Void {
 		cast(sounds[value.id], kha.html5worker.Sound)._callback();
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["mp4"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
 		++videoId;
 		loadingVideos[videoId] = done;
 		Worker.postMessage({ command: 'loadVideo', file: desc.files[0], id: videoId });
 	}
-    
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
 		++blobId;
 		loadingBlobs[blobId] = done;
 		Worker.postMessage({ command: 'loadBlob', file: desc.files[0], id: blobId });
@@ -71,8 +71,8 @@ class LoaderImpl {
 		loadingBlobs[value.id](blob);
 		loadingBlobs.remove(value.id);
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		});

--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -182,7 +182,7 @@ class LoaderImpl {
 			});
 		}
 #else
-		loadRemote(desc, done failed);
+		loadRemote(desc, done, failed);
 #end
 	}
 

--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -23,19 +23,18 @@ class LoaderImpl {
 		return ["png", "jpg", "hdr"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
 		if (StringTools.endsWith(desc.files[0], ".hdr")) {
 			loadBlobFromDescription(desc, function(blob) {
 				var hdrImage = kha.internal.HdrFormat.parse(blob.toBytes());
 				done(Image.fromBytes(hdrImage.data.view.buffer, hdrImage.width, hdrImage.height, TextureFormat.RGBA128, readable ? Usage.DynamicUsage : Usage.StaticUsage));
-			});
+			}, failed);
 		}
 		else {
 			var img: ImageElement = cast Browser.document.createElement("img");
-			img.onload = function(event: Dynamic) {
-				done(Image.fromImage(img, readable));
-			};
+			img.onerror = function( event: Dynamic ) failed(desc.files[0]);
+			img.onload = function(event: Dynamic) done(Image.fromImage(img, readable));
 			img.src = desc.files[0];
 			img.crossOrigin = "";
 		}
@@ -52,7 +51,7 @@ class LoaderImpl {
 		return formats;
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		if (SystemImpl._hasWebAudio) {
 			var element = Browser.document.createAudioElement();
 			#if !kha_debug_html5
@@ -60,7 +59,7 @@ class LoaderImpl {
 				for (i in 0...desc.files.length) {
 					var file: String = desc.files[i];
 					if (file.endsWith(".mp4")) {
-						new WebAudioSound(file, done);
+						new WebAudioSound(file, done, failed);
 						return;
 					}
 				}
@@ -69,7 +68,7 @@ class LoaderImpl {
 				for (i in 0...desc.files.length) {
 					var file: String = desc.files[i];
 					if (file.endsWith(".mp3")) {
-						new WebAudioSound(file, done);
+						new WebAudioSound(file, done, failed);
 						return;
 					}
 				}
@@ -78,7 +77,7 @@ class LoaderImpl {
 			for (i in 0...desc.files.length) {
 				var file: String = desc.files[i];
 				if (file.endsWith(".ogg")) {
-					new WebAudioSound(file, done);
+					new WebAudioSound(file, done, failed);
 					return;
 				}
 			}
@@ -89,7 +88,7 @@ class LoaderImpl {
 				for (i in 0...desc.files.length) {
 					var file: String = desc.files[i];
 					if (file.endsWith(".mp4")) {
-						new MobileWebAudioSound(file, done);
+						new MobileWebAudioSound(file, done, failed);
 						return;
 					}
 				}
@@ -98,7 +97,7 @@ class LoaderImpl {
 				for (i in 0...desc.files.length) {
 					var file: String = desc.files[i];
 					if (file.endsWith(".mp3")) {
-						new MobileWebAudioSound(file, done);
+						new MobileWebAudioSound(file, done, failed);
 						return;
 					}
 				}
@@ -106,13 +105,13 @@ class LoaderImpl {
 			for (i in 0...desc.files.length) {
 				var file: String = desc.files[i];
 				if (file.endsWith(".ogg")) {
-					new MobileWebAudioSound(file, done);
+					new MobileWebAudioSound(file, done, failed);
 					return;
 				}
 			}
 		}
 		else {
-			new kha.js.Sound(desc.files, done);
+			new kha.js.Sound(desc.files, done, failed);
 		}
 	}
 
@@ -124,11 +123,11 @@ class LoaderImpl {
 		#end
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
 		kha.js.Video.fromFile(desc.files, done);
 	}
 
-	public static function loadRemote( desc: Dynamic, done: Blob -> Void ) {
+	public static function loadRemote( desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void ) {
 		var request = untyped new XMLHttpRequest();
 		request.open("GET", desc.files[0], true);
 		request.responseType = "arraybuffer";
@@ -142,38 +141,44 @@ class LoaderImpl {
 				if (arrayBuffer != null) {
 					var byteArray: Dynamic = untyped __js__("new Uint8Array(arrayBuffer)");
 					bytes = Bytes.ofData(byteArray);
-				}
-				else if (request.responseBody != null) {
+				} else if (request.responseBody != null) {
 					var data: Dynamic = untyped __js__("VBArray(request.responseBody).toArray()");
 					bytes = Bytes.alloc(data.length);
 					for (i in 0...data.length) bytes.set(i, data[i]);
+				} else {
+					// trace("Error loading " + desc.files[0]);
+					// Browser.console.log("loadBlob failed");
+					failed(desc.files[0]);
+					return;
 				}
-				else {
-					trace("Error loading " + desc.files[0]);
-					Browser.console.log("loadBlob failed");
-				}
+
 				done(new Blob(bytes));
+			} else {
+				// trace("Error loading " + desc.files[0]);
+				// Browser.console.log("loadBlob failed");
+				failed(desc.files[0]);
 			}
-			else {
-				trace("Error loading " + desc.files[0]);
-				Browser.console.log("loadBlob failed");
-			}
-		};
+		}
 		request.send(null);
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic->Void) {
 #if kha_debug_html5
 		var isUrl = desc.files[0].startsWith('http');
 
 		if (isUrl) {
-			loadRemote(desc, done);
+			loadRemote(desc, done, failed);
 		} else {
 			var fs = untyped __js__("require('fs')");
 			var path = untyped __js__("require('path')");
 			var app = untyped __js__("require('electron').remote.require('electron').app");
 			var url = if (path.isAbsolute(desc.files[0])) desc.files[0] else path.join(app.getAppPath(), desc.files[0]);
 			fs.readFile(url, function (err, data) {
+				if (err != null) {
+					failed(err);
+					return;
+				}
+
 				var byteArray: Dynamic = untyped __js__("new Uint8Array(data)");
 				var bytes = Bytes.alloc(byteArray.byteLength);
 				for (i in 0...byteArray.byteLength) bytes.set(i, byteArray[i]);
@@ -181,14 +186,14 @@ class LoaderImpl {
 			});
 		}
 #else
-		loadRemote(desc, done);
+		loadRemote(desc, done failed);
 #end
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Font(blob));
-		});
+		}, failed);
 	}
 
 	/*override public function loadURL(url: String): Void {

--- a/Backends/HTML5/kha/js/MobileWebAudioSound.hx
+++ b/Backends/HTML5/kha/js/MobileWebAudioSound.hx
@@ -1,30 +1,21 @@
 package kha.js;
 
-import haxe.ds.Vector;
 import haxe.io.Bytes;
-import haxe.io.BytesOutput;
-import js.Browser;
-import js.html.ArrayBuffer;
-import js.html.audio.AudioBuffer;
-import js.html.AudioElement;
 import js.html.XMLHttpRequest;
-import js.Lib;
-
-using StringTools;
 
 class MobileWebAudioSound extends kha.Sound {
 	public var _buffer: Dynamic;
 
-	public function new(filename: String, done: kha.Sound -> Void) {
+	public function new(filename: String, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		super();
 		var request = untyped new XMLHttpRequest();
 		request.open("GET", filename, true);
 		request.responseType = "arraybuffer";
-		
+
 		request.onerror = function() {
-			trace("Error loading " + filename);
+			failed(filename);
 		};
-		
+
 		request.onload = function() {
 			compressedData = Bytes.ofData(request.response);
 			uncompressedData = null;
@@ -34,13 +25,13 @@ class MobileWebAudioSound extends kha.Sound {
 					done(this);
 				},
 				function () {
-					throw "Audio format not supported";
+					throw "Audio format not supported"; // TODO (DK) use 'failed' callback as well?
 				}
 			);
 		};
 		request.send(null);
 	}
-	
+
 	override public function uncompress(done: Void->Void): Void {
 		done();
 	}

--- a/Backends/HTML5/kha/js/MobileWebAudioSound.hx
+++ b/Backends/HTML5/kha/js/MobileWebAudioSound.hx
@@ -6,14 +6,14 @@ import js.html.XMLHttpRequest;
 class MobileWebAudioSound extends kha.Sound {
 	public var _buffer: Dynamic;
 
-	public function new(filename: String, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public function new(filename: String, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		super();
 		var request = untyped new XMLHttpRequest();
 		request.open("GET", filename, true);
 		request.responseType = "arraybuffer";
 
 		request.onerror = function() {
-			failed(filename);
+			failed({ url: filename });
 		};
 
 		request.onload = function() {
@@ -25,7 +25,7 @@ class MobileWebAudioSound extends kha.Sound {
 					done(this);
 				},
 				function () {
-					throw "Audio format not supported"; // TODO (DK) use 'failed' callback as well?
+					failed({ url: filename, error: 'Audio format not supported' });
 				}
 			);
 		};

--- a/Backends/HTML5/kha/js/Sound.hx
+++ b/Backends/HTML5/kha/js/Sound.hx
@@ -11,17 +11,17 @@ using StringTools;
 
 /*class SoundChannel extends kha.SoundChannel {
 	private var element: Dynamic;
-	
+
 	public function new(element: Dynamic) {
 		super();
 		this.element = element;
 	}
-	
+
 	override public function play(): Void {
 		super.play();
 		element.play();
 	}
-	
+
 	override public function pause(): Void {
 		try {
 			element.pause();
@@ -30,7 +30,7 @@ using StringTools;
 			trace(e);
 		}
 	}
-	
+
 	override public function stop(): Void {
 		try {
 			element.pause();
@@ -41,11 +41,11 @@ using StringTools;
 			trace(e);
 		}
 	}
-	
+
 	override public function getCurrentPos(): Int {
 		return Math.ceil(element.currentTime * 1000);  // Miliseconds
 	}
-	
+
 	override public function getLength(): Int {
 		if (Math.isFinite(element.duration)) {
 			return Math.floor(element.duration * 1000); // Miliseconds
@@ -60,30 +60,32 @@ class Sound extends kha.Sound {
 	private var filenames: Array<String>;
 	static var loading: Array<Sound> = new Array();
 	private var done: kha.Sound -> Void;
+	private var failed: Dynamic -> Void;
 	public var element: AudioElement;
-	
-	public function new(filenames: Array<String>, done: kha.Sound -> Void) {
+
+	public function new(filenames: Array<String>, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		super();
-		
+
 		this.done = done;
+		this.failed = failed;
 		loading.push(this); // prevent gc from removing this
-		
+
 		element = Browser.document.createAudioElement();
-		
+
 		this.filenames = [];
 		for (filename in filenames) {
 			if (element.canPlayType("audio/ogg") != "" && filename.endsWith(".ogg")) this.filenames.push(filename);
 			if (element.canPlayType("audio/mp4") != "" && filename.endsWith(".mp4")) this.filenames.push(filename);
 		}
-		
+
 		element.addEventListener("error", errorListener, false);
 		element.addEventListener("canplay", canPlayThroughListener, false);
-		
+
 		element.src = this.filenames[0];
 		element.preload = "auto";
 		element.load();
 	}
-	
+
 	//override public function play(): kha.SoundChannel {
 	//	try {
 	//		element.play();
@@ -93,7 +95,7 @@ class Sound extends kha.Sound {
 	//	}
 	//	return new SoundChannel(element);
 	//}
-	
+
 	private function errorListener(eventInfo: ErrorEvent): Void {
 		if (element.error.code == MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED) {
 			for (i in 0...filenames.length - 1) {
@@ -104,24 +106,22 @@ class Sound extends kha.Sound {
 				}
 			}
 		}
-		
-		trace("Error loading " + element.src);
-		Browser.console.log("loadSound failed");
-	
+
+		failed(element.src);
 		finishAsset();
 	}
-	
+
 	private function canPlayThroughListener(eventInfo: Event): Void {
 		finishAsset();
 	}
-	
+
 	private function finishAsset() {
 		element.removeEventListener("error", errorListener, false);
 		element.removeEventListener("canplaythrough", canPlayThroughListener, false);
 		done(this);
 		loading.remove(this);
 	}
-	
+
 	override public function uncompress(done: Void->Void): Void {
 		done();
 	}

--- a/Backends/HTML5/kha/js/Sound.hx
+++ b/Backends/HTML5/kha/js/Sound.hx
@@ -60,10 +60,10 @@ class Sound extends kha.Sound {
 	private var filenames: Array<String>;
 	static var loading: Array<Sound> = new Array();
 	private var done: kha.Sound -> Void;
-	private var failed: Dynamic -> Void;
+	private var failed: AssetError -> Void;
 	public var element: AudioElement;
 
-	public function new(filenames: Array<String>, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public function new(filenames: Array<String>, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		super();
 
 		this.done = done;
@@ -107,7 +107,7 @@ class Sound extends kha.Sound {
 			}
 		}
 
-		failed(element.src);
+		failed({ url: element.src });
 		finishAsset();
 	}
 

--- a/Backends/HTML5/kha/js/WebAudioSound.hx
+++ b/Backends/HTML5/kha/js/WebAudioSound.hx
@@ -58,14 +58,14 @@ class WebAudioChannel extends kha.SoundChannel {
 */
 
 class WebAudioSound extends kha.Sound {
-	public function new(filename: String, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public function new(filename: String, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		super();
 		var request = untyped new XMLHttpRequest();
 		request.open("GET", filename, true);
 		request.responseType = "arraybuffer";
 
 		request.onerror = function() {
-			failed(filename);
+			failed({ url: filename });
 		};
 
 		request.onload = function() {

--- a/Backends/HTML5/kha/js/WebAudioSound.hx
+++ b/Backends/HTML5/kha/js/WebAudioSound.hx
@@ -2,17 +2,9 @@ package kha.js;
 
 import haxe.ds.Vector;
 import haxe.io.Bytes;
-import haxe.io.BytesOutput;
 import js.Browser;
-import js.html.ArrayBuffer;
-import js.html.audio.AudioBuffer;
-import js.html.AudioElement;
 import js.html.XMLHttpRequest;
-import js.Lib;
 import kha.audio2.Audio;
-import kha.audio2.ogg.vorbis.Reader;
-
-using StringTools;
 
 /*
 class WebAudioChannel extends kha.SoundChannel {
@@ -20,7 +12,7 @@ class WebAudioChannel extends kha.SoundChannel {
 	private var startTime: Float;
 	private var offset: Float;
 	private var source: Dynamic;
-	
+
 	public function new(buffer: Dynamic) {
 		super();
 		this.offset = 0;
@@ -31,21 +23,21 @@ class WebAudioChannel extends kha.SoundChannel {
 		this.source.connect(Audio._context.destination);
 		this.source.start(0);
 	}
-	
+
 	override public function play(): Void {
 		if (source != null) return;
 		super.play();
 		startTime = Audio._context.currentTime - offset;
 		source.start(0, offset);
 	}
-	
+
 	override public function pause(): Void {
 		source.stop();
 		offset = Audio._context.currentTime - startTime;
 		startTime = -1;
 		source = null;
 	}
-	
+
 	override public function stop(): Void {
 		source.stop();
 		source = null;
@@ -53,12 +45,12 @@ class WebAudioChannel extends kha.SoundChannel {
 		startTime = -1;
 		super.stop();
 	}
-	
+
 	override public function getCurrentPos(): Int {
 		if (startTime < 0) return Math.ceil(offset * 1000);
 		else return Math.ceil((Audio._context.currentTime - startTime) * 1000); //Miliseconds
 	}
-	
+
 	override public function getLength(): Int {
 		return Math.floor(buffer.duration * 1000); //Miliseconds
 	}
@@ -66,16 +58,16 @@ class WebAudioChannel extends kha.SoundChannel {
 */
 
 class WebAudioSound extends kha.Sound {
-	public function new(filename: String, done: kha.Sound -> Void) {
+	public function new(filename: String, done: kha.Sound -> Void, failed: Dynamic -> Void) {
 		super();
 		var request = untyped new XMLHttpRequest();
 		request.open("GET", filename, true);
 		request.responseType = "arraybuffer";
-		
+
 		request.onerror = function() {
-			trace("Error loading " + filename);
+			failed(filename);
 		};
-		
+
 		request.onload = function() {
 			compressedData = Bytes.ofData(request.response);
 			uncompressedData = null;
@@ -83,11 +75,11 @@ class WebAudioSound extends kha.Sound {
 		};
 		request.send(null);
 	}
-	
+
 	private function superUncompress(done: Void->Void): Void {
 		super.uncompress(done);
 	}
-	
+
 	override public function uncompress(done: Void->Void): Void {
 		Audio._context.decodeAudioData(compressedData.getData(),
 		function (buffer) {
@@ -146,5 +138,5 @@ class WebAudioSound extends kha.Sound {
 			superUncompress(done);
 		});
 	}
-	
+
 }

--- a/Backends/Kore/kha/LoaderImpl.hx
+++ b/Backends/Kore/kha/LoaderImpl.hx
@@ -11,7 +11,7 @@ import sys.io.File;
 ')
 
 class LoaderImpl {
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		done(new kha.kore.Sound(desc.files[0]));
 	}
 
@@ -19,7 +19,7 @@ class LoaderImpl {
 		return ["wav", "ogg"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
 		done(kha.Image.fromFile(desc.files[0], readable));
 	}
@@ -28,17 +28,17 @@ class LoaderImpl {
 		return ["png", "jpg", "hdr"];
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
 		done(new Blob(File.getBytes(desc.files[0])));
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: Dynamic -> Void) {
+	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: AssetError -> Void) {
 		done(new kha.kore.Video(desc.files[0]))
 	}
 

--- a/Backends/Kore/kha/LoaderImpl.hx
+++ b/Backends/Kore/kha/LoaderImpl.hx
@@ -12,10 +12,7 @@ import sys.io.File;
 
 class LoaderImpl {
 	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
-		try
-			done(new kha.kore.Sound(desc.files[0]))
-		catch (x: Dynamic)
-			failed(x);
+		done(new kha.kore.Sound(desc.files[0]));
 	}
 
 	public static function getSoundFormats(): Array<String> {
@@ -24,10 +21,7 @@ class LoaderImpl {
 
 	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		try
-			done(kha.Image.fromFile(desc.files[0], readable))
-		catch (x: Dynamic)
-			failed(x);
+		done(kha.Image.fromFile(desc.files[0], readable));
 	}
 
 	public static function getImageFormats(): Array<String> {
@@ -35,10 +29,7 @@ class LoaderImpl {
 	}
 
 	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
-		try
-			done(new Blob(File.getBytes(desc.files[0])))
-		catch (x: Dynamic)
-			failed(x);
+		done(new Blob(File.getBytes(desc.files[0])));
 	}
 
 	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
@@ -48,10 +39,7 @@ class LoaderImpl {
 	}
 
 	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: Dynamic -> Void) {
-		try
-			done(new kha.kore.Video(desc.files[0]))
-		catch (x: Dynamic)
-			failed(x);
+		done(new kha.kore.Video(desc.files[0]))
 	}
 
 	@:functionCode('return ::String(Kore::System::videoFormats()[0]);')

--- a/Backends/Kore/kha/LoaderImpl.hx
+++ b/Backends/Kore/kha/LoaderImpl.hx
@@ -11,42 +11,54 @@ import sys.io.File;
 ')
 
 class LoaderImpl {
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
-		done(new kha.kore.Sound(desc.files[0]));
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+		try
+			done(new kha.kore.Sound(desc.files[0]))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["wav", "ogg"];
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void) {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		done(kha.Image.fromFile(desc.files[0], readable));
+		try
+			done(kha.Image.fromFile(desc.files[0], readable))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg", "hdr"];
 	}
-	
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
-		done(new Blob(File.getBytes(desc.files[0])));
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+		try
+			done(new Blob(File.getBytes(desc.files[0])))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
-	
-	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void) {
-		done(new kha.kore.Video(desc.files[0]));
+
+	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: Dynamic -> Void) {
+		try
+			done(new kha.kore.Video(desc.files[0]))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
+
 	@:functionCode('return ::String(Kore::System::videoFormats()[0]);')
 	private static function videoFormat(): String {
 		return "";
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return [videoFormat()];
 	}

--- a/Backends/Krom/kha/LoaderImpl.hx
+++ b/Backends/Krom/kha/LoaderImpl.hx
@@ -10,35 +10,44 @@ class LoaderImpl {
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void) {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)));
+		try
+			done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["wav", "ogg"];
 	}
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void) {
-		done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))));
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+		try
+			done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["webm"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
-		
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+
 	}
-    
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void) {
-		done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))));
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+		try
+			done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))))
+		catch (x: Dynamic)
+			failed(x);
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
 }

--- a/Backends/Krom/kha/LoaderImpl.hx
+++ b/Backends/Krom/kha/LoaderImpl.hx
@@ -11,7 +11,7 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
 		done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)))
 	}
@@ -20,7 +20,7 @@ class LoaderImpl {
 		return ["wav", "ogg"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void) {
 		done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))))
 	}
 
@@ -28,15 +28,15 @@ class LoaderImpl {
 		return ["webm"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void): Void {
 
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
 		done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))))
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);

--- a/Backends/Krom/kha/LoaderImpl.hx
+++ b/Backends/Krom/kha/LoaderImpl.hx
@@ -13,10 +13,7 @@ class LoaderImpl {
 
 	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		try
-			done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)))
-		catch (x: Dynamic)
-			failed(x);
+		done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)))
 	}
 
 	public static function getSoundFormats(): Array<String> {
@@ -24,10 +21,7 @@ class LoaderImpl {
 	}
 
 	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void) {
-		try
-			done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))))
-		catch (x: Dynamic)
-			failed(x);
+		done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))))
 	}
 
 	public static function getVideoFormats(): Array<String> {
@@ -39,10 +33,7 @@ class LoaderImpl {
 	}
 
 	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void) {
-		try
-			done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))))
-		catch (x: Dynamic)
-			failed(x);
+		done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))))
 	}
 
 	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {

--- a/Backends/Node/kha/LoaderImpl.hx
+++ b/Backends/Node/kha/LoaderImpl.hx
@@ -23,7 +23,7 @@ class LoaderImpl {
 		return ["nix"];
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void): Void {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Sound());
 		}, 0);
@@ -33,7 +33,7 @@ class LoaderImpl {
 		return ["nix"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void): Void {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Image(100, 100, TextureFormat.RGBA32));
 		}, 0);
@@ -43,19 +43,19 @@ class LoaderImpl {
 		return ["nix"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Video());
 		}, 0);
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void): Void {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void): Void {
 		Fs.readFile(desc.files[0], function (error: Error, data: Buffer) {
 			done(Blob._fromBuffer(data));
 		});
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);

--- a/Backends/Node/kha/LoaderImpl.hx
+++ b/Backends/Node/kha/LoaderImpl.hx
@@ -22,42 +22,42 @@ class LoaderImpl {
 	public static function getSoundFormats(): Array<String> {
 		return ["nix"];
 	}
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void): Void {
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Sound());
 		}, 0);
-	}		
-	
+	}
+
 	public static function getImageFormats(): Array<String> {
 		return ["nix"];
 	}
-	
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void): Void {
+
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Image(100, 100, TextureFormat.RGBA32));
 		}, 0);
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["nix"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
 		Node.setTimeout(function () {
 			done(new Video());
 		}, 0);
 	}
-	
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void): Void {
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void): Void {
 		Fs.readFile(desc.files[0], function (error: Error, data: Buffer) {
 			done(Blob._fromBuffer(data));
 		});
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
 }

--- a/Backends/Unity/kha/LoaderImpl.hx
+++ b/Backends/Unity/kha/LoaderImpl.hx
@@ -3,7 +3,7 @@ package kha;
 import haxe.io.Bytes;
 
 class LoaderImpl {
-	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: Dynamic -> Void): Void {
+	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: AssetError -> Void): Void {
 		done(Image.fromFilename(desc.files[0], desc.original_width, desc.original_height));
 	}
 
@@ -11,17 +11,17 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void): Void {
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void): Void {
 		done(new Blob(Bytes.ofData(UnityBackend.loadBlob(desc.files[0]))));
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);
 	}
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: Sound -> Void, failed: Dynamic -> Void): Void {
+	public static function loadSoundFromDescription(desc: Dynamic, done: Sound -> Void, failed: AssetError -> Void): Void {
 		done(new kha.unity.Sound(desc.files[0]));
 	}
 
@@ -29,7 +29,7 @@ class LoaderImpl {
 		return ["wav", "ogg"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: AssetError -> Void): Void {
 		done(new Video());
 	}
 

--- a/Backends/Unity/kha/LoaderImpl.hx
+++ b/Backends/Unity/kha/LoaderImpl.hx
@@ -3,36 +3,36 @@ package kha;
 import haxe.io.Bytes;
 
 class LoaderImpl {
-	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void): Void { 
+	public static function loadImageFromDescription(desc: Dynamic, done: Image -> Void, failed: Dynamic -> Void): Void {
 		done(Image.fromFilename(desc.files[0], desc.original_width, desc.original_height));
 	}
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
-	
-	public static function loadBlobFromDescription(desc: Dynamic, done: Blob  -> Void): Void {
+
+	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: Dynamic -> Void): Void {
 		done(new Blob(Bytes.ofData(UnityBackend.loadBlob(desc.files[0]))));
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: Sound -> Void): Void {
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: Sound -> Void, failed: Dynamic -> Void): Void {
 		done(new kha.unity.Sound(desc.files[0]));
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["wav", "ogg"];
 	}
-	
-	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void): Void {
+
+	public static function loadVideoFromDescription(desc: Dynamic, done: Video -> Void, failed: Dynamic -> Void): Void {
 		done(new Video());
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["mp4"];
 	}

--- a/Backends/WPF/kha/LoaderImpl.hx
+++ b/Backends/WPF/kha/LoaderImpl.hx
@@ -19,7 +19,7 @@ class LoaderImpl {
 	private static var savedCursor: Cursor;
 	private static var busyCursor: Bool = false;
 
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void): Void {
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: AssetError -> Void): Void {
 		done(new kha.wpf.Sound(path + desc.files[0]));
 	}
 
@@ -27,7 +27,7 @@ class LoaderImpl {
 		return ["wav"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void): Void {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: AssetError -> Void): Void {
 		done(Image.fromFilename(path + desc.files[0]));
 	}
 
@@ -35,11 +35,11 @@ class LoaderImpl {
 		return ["png", "jpg"];
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob -> Void, failed: Dynamic -> Void): Void {
+	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob -> Void, failed: AssetError -> Void): Void {
 		done(new Blob(Bytes.ofData(File.ReadAllBytes(path + desc.files[0]))));
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: AssetError -> Void): Void {
 		done(new kha.wpf.Video(path + desc.files[0]));
 	}
 
@@ -47,7 +47,7 @@ class LoaderImpl {
 		return ["wmv"];
 	}
 
-	public static function loadFontFromDescription(desc: Dynamic, done: kha.Font -> Void, failed: Dynamic -> Void): Void {
+	public static function loadFontFromDescription(desc: Dynamic, done: kha.Font -> Void, failed: AssetError -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
 		}, failed);

--- a/Backends/WPF/kha/LoaderImpl.hx
+++ b/Backends/WPF/kha/LoaderImpl.hx
@@ -18,56 +18,56 @@ class LoaderImpl {
 	public static var forceBusyCursor: Bool = false;
 	private static var savedCursor: Cursor;
 	private static var busyCursor: Bool = false;
-	
-	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void): Void {
+
+	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound -> Void, failed: Dynamic -> Void): Void {
 		done(new kha.wpf.Sound(path + desc.files[0]));
 	}
-	
+
 	public static function getSoundFormats(): Array<String> {
 		return ["wav"];
 	}
 
-	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void): Void {
+	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image -> Void, failed: Dynamic -> Void): Void {
 		done(Image.fromFilename(path + desc.files[0]));
 	}
-	
+
 	public static function getImageFormats(): Array<String> {
 		return ["png", "jpg"];
 	}
 
-	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob -> Void): Void {
+	public static function loadBlobFromDescription(desc: Dynamic, done: kha.Blob -> Void, failed: Dynamic -> Void): Void {
 		done(new Blob(Bytes.ofData(File.ReadAllBytes(path + desc.files[0]))));
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void): Void {
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video -> Void, failed: Dynamic -> Void): Void {
 		done(new kha.wpf.Video(path + desc.files[0]));
 	}
-	
+
 	public static function getVideoFormats(): Array<String> {
 		return ["wmv"];
 	}
-	
-	public static function loadFontFromDescription(desc: Dynamic, done: kha.Font -> Void): Void {
+
+	public static function loadFontFromDescription(desc: Dynamic, done: kha.Font -> Void, failed: Dynamic -> Void): Void {
 		loadBlobFromDescription(desc, function (blob: Blob) {
 			done(new Kravur(blob));
-		});
+		}, failed);
 	}
 
 	@:functionCode('global::System.Diagnostics.Process.Start(new global::System.Uri(url).AbsoluteUri);')
 	public static function loadURL(url: String): Void {
-		
+
 	}
 
 	public static function setNormalCursor() {
 		savedCursor = Cursors.Arrow;
 		//if (!busyCursor && !forceBusyCursor) Starter.frameworkElement.Cursor = Cursors.Arrow;
 	}
-	
+
 	public static function setHandCursor() {
 		savedCursor = Cursors.Hand;
 		//if (!busyCursor && !forceBusyCursor) Starter.frameworkElement.Cursor = Cursors.Hand;
 	}
-	
+
 	public static function setCursorBusy(busy: Bool) {
 		/*busyCursor = busy;
 		if (busy || forceBusyCursor) {

--- a/Sources/kha/AssetError.hx
+++ b/Sources/kha/AssetError.hx
@@ -1,0 +1,6 @@
+package kha;
+
+typedef AssetError = {
+	url: String,
+	?error: Dynamic,
+}

--- a/Sources/kha/Assets.hx
+++ b/Sources/kha/Assets.hx
@@ -83,7 +83,7 @@ class Assets {
 	Additionally by default all sounds are decompressed. The uncompressSoundsFilter can be used to avoid that.
 	Uncompressed sounds can still be played using Audio.stream which is recommended for music.
 	*/
-	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null, ?failed: AssetError -> Void, ?pos: haxe.PosInfos ): Void {
+	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null, ?failed: AssetError -> Void): Void {
 		var fileCount = 0;
 		for (blob in Type.getInstanceFields(BlobList)) {
 			if (blob.endsWith("Load")) {
@@ -131,7 +131,7 @@ class Assets {
 
 				if (filter == null || filter(description)) {
 					Reflect.field(blobs, blob)(onLoaded, function(err) {
-						reporter(failed, pos);
+						reporter(failed);
 						onLoaded();
 					});
 				} else {
@@ -146,7 +146,7 @@ class Assets {
 
 				if (filter == null || filter(description)) {
 					Reflect.field(images, image)(onLoaded, function(err) {
-						reporter(failed, pos);
+						reporter(failed);
 						onLoaded();
 					});
 				} else {
@@ -166,7 +166,7 @@ class Assets {
 						} else {
 							onLoaded();
 						}
-					}, reporter(failed, pos));
+					}, reporter(failed));
 				} else {
 					onLoaded();
 				}
@@ -178,7 +178,7 @@ class Assets {
 				var description = Reflect.field(fonts, name + "Description");
 				if (filter == null || filter(description)) {
 					Reflect.field(fonts, font)(onLoaded, function(err) {
-						reporter(failed, pos);
+						reporter(failed);
 						onLoaded();
 					});
 				} else {
@@ -192,7 +192,7 @@ class Assets {
 				var description = Reflect.field(videos, name + "Description");
 				if (filter == null || filter(description)) {
 					Reflect.field(videos, video)(onLoaded, function(err) {
-						reporter(failed, pos);
+						reporter(failed);
 						onLoaded();
 					});
 				} else {

--- a/Sources/kha/Assets.hx
+++ b/Sources/kha/Assets.hx
@@ -83,7 +83,7 @@ class Assets {
 	Additionally by default all sounds are decompressed. The uncompressSoundsFilter can be used to avoid that.
 	Uncompressed sounds can still be played using Audio.stream which is recommended for music.
 	*/
-	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null, ?failed: Dynamic->Void, ?pos: haxe.PosInfos ): Void {
+	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null, ?failed: AssetError -> Void, ?pos: haxe.PosInfos ): Void {
 		var fileCount = 0;
 		for (blob in Type.getInstanceFields(BlobList)) {
 			if (blob.endsWith("Load")) {
@@ -208,7 +208,7 @@ class Assets {
 	 * @param	name The name as defined by the khafile.
 	 * @param	done A callback.
 	 */
-	public static function loadImage(name: String, done: Image -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadImage(name: String, done: Image -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(images, name + "Description");
 		LoaderImpl.loadImageFromDescription(description, function (image: Image) {
 			Reflect.setField(images, name, image);
@@ -223,7 +223,7 @@ class Assets {
 	 * @param   readable If true, a copy of the image will be kept in main memory for image read operations.
 	 * @param	done A callback.
 	 */
-	public static function loadImageFromPath(path: String, readable: Bool, done: Image -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadImageFromPath(path: String, readable: Bool, done: Image -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ], readable: readable };
 		LoaderImpl.loadImageFromDescription(description, done, reporter(failed, pos));
 	}
@@ -234,7 +234,7 @@ class Assets {
 		return LoaderImpl.getImageFormats();
 	}
 
-	public static function loadBlob(name: String, done: Blob -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadBlob(name: String, done: Blob -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(blobs, name + "Description");
 		LoaderImpl.loadBlobFromDescription(description, function (blob: Blob) {
 			Reflect.setField(blobs, name, blob);
@@ -242,12 +242,12 @@ class Assets {
 		}, reporter(failed, pos));
 	}
 
-	public static function loadBlobFromPath(path: String, done: Blob -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadBlobFromPath(path: String, done: Blob -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
 		LoaderImpl.loadBlobFromDescription(description, done, reporter(failed, pos));
 	}
 
-	public static function loadSound(name: String, done: Sound -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadSound(name: String, done: Sound -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(sounds, name + "Description");
 		return LoaderImpl.loadSoundFromDescription(description, function (sound: Sound) {
 			Reflect.setField(sounds, name, sound);
@@ -255,7 +255,7 @@ class Assets {
 		}, reporter(failed, pos));
 	}
 
-	public static function loadSoundFromPath(path: String, done: Sound -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadSoundFromPath(path: String, done: Sound -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
 		return LoaderImpl.loadSoundFromDescription(description, done, reporter(failed, pos));
 	}
@@ -266,7 +266,7 @@ class Assets {
 		return LoaderImpl.getSoundFormats();
 	}
 
-	public static function loadFont(name: String, done: Font -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadFont(name: String, done: Font -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(fonts, name + "Description");
 		return LoaderImpl.loadFontFromDescription(description, function (font: Font) {
 			Reflect.setField(fonts, name, font);
@@ -274,7 +274,7 @@ class Assets {
 		}, reporter(failed, pos));
 	}
 
-	public static function loadFontFromPath(path: String, done: Font -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadFontFromPath(path: String, done: Font -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
 		return LoaderImpl.loadFontFromDescription(description, done, reporter(failed, pos));
 	}
@@ -285,7 +285,7 @@ class Assets {
 		return ["ttf"];
 	}
 
-	public static function loadVideo(name: String, done: Video -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadVideo(name: String, done: Video -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(videos, name + "Description");
 		return LoaderImpl.loadVideoFromDescription(description, function (video: Video) {
 			Reflect.setField(videos, name, video);
@@ -293,7 +293,7 @@ class Assets {
 		}, reporter(failed, pos));
 	}
 
-	public static function loadVideoFromPath(path: String, done: Video -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
+	public static function loadVideoFromPath(path: String, done: Video -> Void, ?failed: AssetError -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
 		return LoaderImpl.loadVideoFromDescription(description, done, reporter(failed, pos));
 	}
@@ -304,6 +304,6 @@ class Assets {
 		return LoaderImpl.getVideoFormats();
 	}
 
-	public static inline function reporter(custom: Dynamic -> Void, ?pos: haxe.PosInfos)
+	public static inline function reporter(custom: AssetError -> Void, ?pos: haxe.PosInfos)
 		return custom != null ? custom : haxe.Log.trace.bind(_, pos);
 }

--- a/Sources/kha/Assets.hx
+++ b/Sources/kha/Assets.hx
@@ -9,7 +9,7 @@ using StringTools;
 @:build(kha.internal.AssetsBuilder.build("image"))
 private class ImageList {
 	public function new() {
-		
+
 	}
 
 	public function get(name: String): Image {
@@ -21,7 +21,7 @@ private class ImageList {
 @:build(kha.internal.AssetsBuilder.build("sound"))
 private class SoundList {
 	public function new() {
-		
+
 	}
 
 	public function get(name: String): Sound {
@@ -33,7 +33,7 @@ private class SoundList {
 @:build(kha.internal.AssetsBuilder.build("blob"))
 private class BlobList {
 	public function new() {
-		
+
 	}
 
 	public function get(name: String): Blob {
@@ -45,7 +45,7 @@ private class BlobList {
 @:build(kha.internal.AssetsBuilder.build("font"))
 private class FontList {
 	public function new() {
-		
+
 	}
 
 	public function get(name: String): Font {
@@ -57,7 +57,7 @@ private class FontList {
 @:build(kha.internal.AssetsBuilder.build("video"))
 private class VideoList {
 	public function new() {
-		
+
 	}
 
 	public function get(name: String): Video {
@@ -72,7 +72,7 @@ class Assets {
 	public static var blobs: BlobList = new BlobList();
 	public static var fonts: FontList = new FontList();
 	public static var videos: VideoList = new VideoList();
-	
+
 	public static var progress: Float; // moves from 0 to 1, use for loading screens
 
 	/**
@@ -83,7 +83,7 @@ class Assets {
 	Additionally by default all sounds are decompressed. The uncompressSoundsFilter can be used to avoid that.
 	Uncompressed sounds can still be played using Audio.stream which is recommended for music.
 	*/
-	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null): Void {
+	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null, ?failed: Dynamic->Void, ?pos: haxe.PosInfos ): Void {
 		var fileCount = 0;
 		for (blob in Type.getInstanceFields(BlobList)) {
 			if (blob.endsWith("Load")) {
@@ -110,29 +110,32 @@ class Assets {
 				++fileCount;
 			}
 		}
-		
+
 		if (fileCount == 0) {
 			callback();
 			return;
 		}
 
 		var filesLeft = fileCount;
-		
+
+		function onLoaded() {
+			--filesLeft;
+			progress = 1 - filesLeft / fileCount;
+			if (filesLeft == 0) callback();
+		}
+
 		for (blob in Type.getInstanceFields(BlobList)) {
 			if (blob.endsWith("Load")) {
 				var name = blob.substr(0, blob.length - 4);
 				var description = Reflect.field(blobs, name + "Description");
+
 				if (filter == null || filter(description)) {
-					Reflect.field(blobs, blob)(function () {
-						--filesLeft;
-						progress = 1 - filesLeft / fileCount;
-						if (filesLeft == 0) callback();
+					Reflect.field(blobs, blob)(onLoaded, function(err) {
+						reporter(failed, pos);
+						onLoaded();
 					});
-				}
-				else {
-					--filesLeft;
-					progress = 1 - filesLeft / fileCount;
-					if (filesLeft == 0) callback();
+				} else {
+					onLoaded();
 				}
 			}
 		}
@@ -140,17 +143,14 @@ class Assets {
 			if (image.endsWith("Load")) {
 				var name = image.substr(0, image.length - 4);
 				var description = Reflect.field(images, name + "Description");
+
 				if (filter == null || filter(description)) {
-					Reflect.field(images, image)(function () {
-						--filesLeft;
-						progress = 1 - filesLeft / fileCount;
-						if (filesLeft == 0) callback();
+					Reflect.field(images, image)(onLoaded, function(err) {
+						reporter(failed, pos);
+						onLoaded();
 					});
-				}
-				else {
-					--filesLeft;
-					progress = 1 - filesLeft / fileCount;
-					if (filesLeft == 0) callback();
+				} else {
+					onLoaded();
 				}
 			}
 		}
@@ -162,23 +162,13 @@ class Assets {
 					Reflect.field(sounds, sound)(function () {
 						if (uncompressSoundsFilter == null || uncompressSoundsFilter(description)) {
 							var sound: Sound = Reflect.field(sounds, sound.substring(0, sound.length - 4));
-							sound.uncompress(function () {
-								--filesLeft;
-								progress = 1 - filesLeft / fileCount;
-								if (filesLeft == 0) callback();
-							});
+							sound.uncompress(onLoaded);
+						} else {
+							onLoaded();
 						}
-						else {
-							--filesLeft;
-							progress = 1 - filesLeft / fileCount;
-							if (filesLeft == 0) callback();
-						}
-					});
-				}
-				else {
-					--filesLeft;
-					progress = 1 - filesLeft / fileCount;
-					if (filesLeft == 0) callback();
+					}, reporter(failed, pos));
+				} else {
+					onLoaded();
 				}
 			}
 		}
@@ -187,16 +177,12 @@ class Assets {
 				var name = font.substr(0, font.length - 4);
 				var description = Reflect.field(fonts, name + "Description");
 				if (filter == null || filter(description)) {
-					Reflect.field(fonts, font)(function () {
-						--filesLeft;
-						progress = 1 - filesLeft / fileCount;
-						if (filesLeft == 0) callback();
+					Reflect.field(fonts, font)(onLoaded, function(err) {
+						reporter(failed, pos);
+						onLoaded();
 					});
-				}
-				else {
-					--filesLeft;
-					progress = 1 - filesLeft / fileCount;
-					if (filesLeft == 0) callback();
+				} else {
+					onLoaded();
 				}
 			}
 		}
@@ -205,120 +191,119 @@ class Assets {
 				var name = video.substr(0, video.length - 4);
 				var description = Reflect.field(videos, name + "Description");
 				if (filter == null || filter(description)) {
-					Reflect.field(videos, video)(function () {
-						--filesLeft;
-						progress = 1 - filesLeft / fileCount;
-						if (filesLeft == 0) callback();
+					Reflect.field(videos, video)(onLoaded, function(err) {
+						reporter(failed, pos);
+						onLoaded();
 					});
-				}
-				else {
-					--filesLeft;
-					progress = 1 - filesLeft / fileCount;
-					if (filesLeft == 0) callback();
+				} else {
+					onLoaded();
 				}
 			}
 		}
 	}
-		
+
 	/**
 	 * Loads an image by name which was preprocessed by khamake.
-	 * 
+	 *
 	 * @param	name The name as defined by the khafile.
 	 * @param	done A callback.
 	 */
-	public static function loadImage(name: String, done: Image -> Void): Void {
+	public static function loadImage(name: String, done: Image -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(images, name + "Description");
 		LoaderImpl.loadImageFromDescription(description, function (image: Image) {
 			Reflect.setField(images, name, image);
 			done(image);
-		});
+		}, reporter(failed, pos));
 	}
-	
+
 	/**
 	 * Loads an image from a path. Most targets support PNG and JPEG formats.
-	 * 
+	 *
 	 * @param	path The path to the image file.
 	 * @param   readable If true, a copy of the image will be kept in main memory for image read operations.
 	 * @param	done A callback.
 	 */
-	public static function loadImageFromPath(path: String, readable: Bool, done: Image -> Void): Void {
+	public static function loadImageFromPath(path: String, readable: Bool, done: Image -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ], readable: readable };
-		LoaderImpl.loadImageFromDescription(description, done);
+		LoaderImpl.loadImageFromDescription(description, done, reporter(failed, pos));
 	}
-	
+
 	public static var imageFormats(get, null): Array<String>;
-	
+
 	private static function get_imageFormats(): Array<String> {
 		return LoaderImpl.getImageFormats();
 	}
-	
-	public static function loadBlob(name: String, done: Blob -> Void): Void {
+
+	public static function loadBlob(name: String, done: Blob -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(blobs, name + "Description");
 		LoaderImpl.loadBlobFromDescription(description, function (blob: Blob) {
 			Reflect.setField(blobs, name, blob);
 			done(blob);
-		});
+		}, reporter(failed, pos));
 	}
-	
-	public static function loadBlobFromPath(path: String, done: Blob -> Void): Void {
+
+	public static function loadBlobFromPath(path: String, done: Blob -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
-		LoaderImpl.loadBlobFromDescription(description, done);
+		LoaderImpl.loadBlobFromDescription(description, done, reporter(failed, pos));
 	}
-	
-	public static function loadSound(name: String, done: Sound -> Void): Void {
+
+	public static function loadSound(name: String, done: Sound -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(sounds, name + "Description");
 		return LoaderImpl.loadSoundFromDescription(description, function (sound: Sound) {
 			Reflect.setField(sounds, name, sound);
 			done(sound);
-		});
+		}, reporter(failed, pos));
 	}
-	
-	public static function loadSoundFromPath(path: String, done: Sound -> Void): Void {
+
+	public static function loadSoundFromPath(path: String, done: Sound -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
-		return LoaderImpl.loadSoundFromDescription(description, done);
+		return LoaderImpl.loadSoundFromDescription(description, done, reporter(failed, pos));
 	}
-	
+
 	public static var soundFormats(get, null): Array<String>;
-	
+
 	private static function get_soundFormats(): Array<String> {
 		return LoaderImpl.getSoundFormats();
 	}
-	
-	public static function loadFont(name: String, done: Font -> Void): Void {
+
+	public static function loadFont(name: String, done: Font -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(fonts, name + "Description");
 		return LoaderImpl.loadFontFromDescription(description, function (font: Font) {
 			Reflect.setField(fonts, name, font);
 			done(font);
-		});
+		}, reporter(failed, pos));
 	}
-	
-	public static function loadFontFromPath(path: String, done: Font -> Void): Void {
+
+	public static function loadFontFromPath(path: String, done: Font -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
-		return LoaderImpl.loadFontFromDescription(description, done);
+		return LoaderImpl.loadFontFromDescription(description, done, reporter(failed, pos));
 	}
-	
+
 	public static var fontFormats(get, null): Array<String>;
-	
+
 	private static function get_fontFormats(): Array<String> {
 		return ["ttf"];
 	}
-	
-	public static function loadVideo(name: String, done: Video -> Void): Void {
+
+	public static function loadVideo(name: String, done: Video -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = Reflect.field(videos, name + "Description");
 		return LoaderImpl.loadVideoFromDescription(description, function (video: Video) {
 			Reflect.setField(videos, name, video);
 			done(video);
-		});
+		}, reporter(failed, pos));
 	}
-	
-	public static function loadVideoFromPath(path: String, done: Video -> Void): Void {
+
+	public static function loadVideoFromPath(path: String, done: Video -> Void, ?failed: Dynamic -> Void, ?pos: haxe.PosInfos): Void {
 		var description = { files: [ path ] };
-		return LoaderImpl.loadVideoFromDescription(description, done);
+		return LoaderImpl.loadVideoFromDescription(description, done, reporter(failed, pos));
 	}
-	
+
 	public static var videoFormats(get, null): Array<String>;
-	
+
 	private static function get_videoFormats(): Array<String> {
 		return LoaderImpl.getVideoFormats();
 	}
+
+	public static inline function reporter(custom: Dynamic -> Void, ?pos: haxe.PosInfos)
+		return custom != null ? custom : haxe.Log.trace.bind(_, pos);
 }

--- a/Sources/kha/internal/AssetErrorCallback.hx
+++ b/Sources/kha/internal/AssetErrorCallback.hx
@@ -1,0 +1,3 @@
+package kha.internal;
+
+typedef AssetErrorCallback = AssetError -> Void;

--- a/Sources/kha/internal/AssetsBuilder.hx
+++ b/Sources/kha/internal/AssetsBuilder.hx
@@ -163,7 +163,7 @@ class AssetsBuilder {
 							name: "done"
 						}, {
 							value: null,
-							type: Context.toComplexType(Context.getType("kha.internal.DynamicToVoidCallback")),
+							type: Context.toComplexType(Context.getType("kha.internal.AssetErrorCallback")),
 							opt: null,
 							name: "failure"
 						}]

--- a/Sources/kha/internal/AssetsBuilder.hx
+++ b/Sources/kha/internal/AssetsBuilder.hx
@@ -41,22 +41,22 @@ class AssetsBuilder {
 		return "";
 		#end
 	}
-	
+
 	macro static public function build(type: String): Array<Field> {
 		var fields = Context.getBuildFields();
 		var content = Json.parse(File.getContent(findResources() + "files.json"));
 		var files: Iterable<Dynamic> = content.files;
-		
+
 		var names = new Array<Expr>();
-		
+
 		for (file in files) {
 			var name = file.name;
 			var filename = file.files[0];
-			
+
 			if (file.type == type) {
-				
+
 				names.push(macro $v{name});
-				
+
 				switch (type) {
 					case "image":
 						fields.push({
@@ -104,7 +104,7 @@ class AssetsBuilder {
 							pos: Context.currentPos()
 						});
 				}
-				
+
 				fields.push({
 					name: name + "Name",
 					doc: null,
@@ -113,7 +113,7 @@ class AssetsBuilder {
 					kind: FVar(macro: String, macro $v { name }),
 					pos: Context.currentPos()
 				});
-				
+
 				fields.push({
 					name: name + "Description",
 					doc: null,
@@ -122,41 +122,31 @@ class AssetsBuilder {
 					kind: FVar(macro: Dynamic, macro $v { file }),
 					pos: Context.currentPos()
 				});
-				
+
 				var loadExpressions = macro { };
 				switch (type) {
 					case "image":
 						loadExpressions = macro {
-							Assets.loadImage($v{name}, function (image: Image) {
-								done();
-							});
+							Assets.loadImage($v{name}, function (image: Image) done(), kha.Assets.reporter(failure));
 						};
 					case "sound":
 						loadExpressions = macro {
-							Assets.loadSound($v{name}, function (sound: Sound) {
-								done();
-							});
+							Assets.loadSound($v{name}, function (sound: Sound) done(), kha.Assets.reporter(failure));
 						};
 					case "blob":
 						loadExpressions = macro {
-							Assets.loadBlob($v{name}, function (blob: Blob) {
-								done();
-							});
+							Assets.loadBlob($v{name}, function (blob: Blob) done(), kha.Assets.reporter(failure));
 						};
 					case "font":
 						loadExpressions = macro {
-							Assets.loadFont($v{name}, function (font: Font) {
-								done();
-							});
+							Assets.loadFont($v{name}, function (font: Font) done(), kha.Assets.reporter(failure));
 						};
 					case "video":
 						loadExpressions = macro {
-							Assets.loadVideo($v{name}, function (video: Video) {
-								done();
-							});
+							Assets.loadVideo($v{name}, function (video: Video) done(), kha.Assets.reporter(failure));
 						};
 				}
-				
+
 				fields.push({
 					name: name + "Load",
 					doc: null,
@@ -171,11 +161,16 @@ class AssetsBuilder {
 							type: Context.toComplexType(Context.getType("kha.internal.VoidCallback")),
 							opt: null,
 							name: "done"
+						}, {
+							value: null,
+							type: Context.toComplexType(Context.getType("kha.internal.DynamicToVoidCallback")),
+							opt: null,
+							name: "failure"
 						}]
 					}),
 					pos: Context.currentPos()
 				});
-				
+
 				fields.push({
 					name: name + "Unload",
 					doc: null,
@@ -194,16 +189,16 @@ class AssetsBuilder {
 				});
 			}
 		}
-		
+
 		fields.push({
 			name: "names",
 			doc: null,
 			meta: [],
 			access: [APublic],
 			kind: FVar(macro: Array<String>, macro $a { names }),
-			pos: Context.currentPos()		
+			pos: Context.currentPos()
 		});
-		
+
 		return fields;
 	}
 }

--- a/Sources/kha/internal/DynamicToVoidCallback.hx
+++ b/Sources/kha/internal/DynamicToVoidCallback.hx
@@ -1,3 +1,0 @@
-package kha.internal;
-
-typedef DynamicToVoidCallback = Dynamic -> Void;

--- a/Sources/kha/internal/DynamicToVoidCallback.hx
+++ b/Sources/kha/internal/DynamicToVoidCallback.hx
@@ -1,0 +1,3 @@
+package kha.internal;
+
+typedef DynamicToVoidCallback = Dynamic -> Void;


### PR DESCRIPTION
#690 

Did some changes to my old and created a new branch for this PR.

i replaced the Dynamic with a new AssetError class. As errors are highly platform specific, the thing the user cares about most is the failed file i guess, You can get that via `url: String` field now instead of parsing whatever the actual error (exception, error event, ...) is. `Assets.loadEverything` also has a `failed` callback, that will get called for every failed asset. The original error object is still available under the `error: Dynamic` field.

```haxe
typedef AssetError = {
    url: String,
    error: Dynamic,
}
```

I also reverted the wrapping for Kore as this didn't actually work to begin with. Missing assets will cause `Kore::error()` to be called and that in turn just kill's the app via `::exit()`. This should be changed, tbh. The user could still exit the app in the failure callback, but it shouldn't be called/forced on Kha's side imo. I tried to comment out the exit call, but that blows up in FileReader/Image and wherenot and probably needs a bigger overhaul.

Sry about the whitespace noise.