### PR TITLE
Finish HashLink support

### DIFF
--- a/Backends/Flash/kha/arrays/Float32Array.hx
+++ b/Backends/Flash/kha/arrays/Float32Array.hx
@@ -28,6 +28,16 @@ abstract Float32Array(ByteArray) {
 		this.position = index * elementSize;
 		return this.readFloat();
 	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): FastFloat {
+		return get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
+		return set(index, value);
+	}
 	
 	public inline function data(): ByteArray {
 		return this;

--- a/Backends/Flash/kha/flash/Sound.hx
+++ b/Backends/Flash/kha/flash/Sound.hx
@@ -2,7 +2,6 @@ package kha.flash;
 
 import flash.media.SoundTransform;
 import flash.utils.ByteArray;
-import haxe.ds.Vector;
 import haxe.io.Bytes;
 import haxe.io.BytesInput;
 import haxe.io.BytesOutput;
@@ -40,7 +39,7 @@ class Sound extends kha.Sound {
 			var length = 44100 * _mp3.length;
 			var array = new ByteArray();
 			var extractedLength: Int = cast (_mp3.extract(array, length));
-			uncompressedData = new Vector<Float>(extractedLength);
+			uncompressedData = new kha.arrays.Float32Array(extractedLength);
 			array.position = 0;
 			for (i in 0...extractedLength) {
 				uncompressedData.set(i, array.readFloat());

--- a/Backends/HTML5/kha/js/WebAudioSound.hx
+++ b/Backends/HTML5/kha/js/WebAudioSound.hx
@@ -85,7 +85,7 @@ class WebAudioSound extends kha.Sound {
 		function (buffer) {
 			var ch0 = buffer.getChannelData(0);
 			var len = ch0.length;
-			uncompressedData = new Vector<Float>(len * 2);
+			uncompressedData = new kha.arrays.Float32Array(len * 2);
 			if (buffer.numberOfChannels == 1) {
 				var idx = 0;
 				var i = 0;

--- a/Backends/Kore/kha/audio2/StreamChannel.hx
+++ b/Backends/Kore/kha/audio2/StreamChannel.hx
@@ -1,6 +1,5 @@
 package kha.audio2;
 
-import haxe.ds.Vector;
 import haxe.io.Bytes;
 
 @:headerCode('#define STB_VORBIS_HEADER_ONLY\n#include <Kore/Audio1/stb_vorbis.c>')
@@ -24,7 +23,7 @@ class StreamChannel implements kha.audio1.AudioChannel {
 	}
 	
 	@:functionCode('
-		int read = stb_vorbis_get_samples_float_interleaved(vorbis, 2, samples->Pointer(), length);
+		int read = stb_vorbis_get_samples_float_interleaved(vorbis, 2, samples->self.data, length);
 		if (read < length / 2) {
 			if (loop) {
 				stb_vorbis_seek_start(vorbis);
@@ -33,15 +32,15 @@ class StreamChannel implements kha.audio1.AudioChannel {
 				atend = true;
 			}
 			for (int i = read; i < length; ++i) {
-				samples->Pointer()[i] = 0;
+				samples->self.data[i] = 0;
 			}
 		}
 	')
-	private function nextVorbisSamples(samples: Vector<FastFloat>, length: Int): Void {
+	private function nextVorbisSamples(samples: kha.arrays.Float32Array, length: Int): Void {
 		
 	}
 
-	public function nextSamples(samples: Vector<FastFloat>, length: Int, sampleRate: Int): Void {
+	public function nextSamples(samples: kha.arrays.Float32Array, length: Int, sampleRate: Int): Void {
 		if (paused) {
 			for (i in 0...length) {
 				samples[i] = 0;

--- a/Backends/Kore/kha/kore/Sound.hx
+++ b/Backends/Kore/kha/kore/Sound.hx
@@ -1,6 +1,5 @@
 package kha.kore;
 
-import haxe.ds.Vector;
 import sys.io.File;
 
 using StringTools;
@@ -17,9 +16,9 @@ class Sound extends kha.Sound {
 		this->_createData(sound->size * 2);
 		Kore::s16* left = (Kore::s16*)&sound->left[0];
 		Kore::s16* right = (Kore::s16*)&sound->right[0];
-		for (int i = 0; i < sound->size; i += 2) {
-			uncompressedData[i * 2 + 0] = left [i] / 32767.0;
-			uncompressedData[i * 2 + 1] = right[i] / 32767.0;
+		for (int i = 0; i < sound->size; i += 1) {
+			uncompressedData->self.data[i * 2 + 0] = (float)(left [i] / 32767.0);
+			uncompressedData->self.data[i * 2 + 1] = (float)(right[i] / 32767.0);
 		}
 		delete sound;
 	')
@@ -45,6 +44,6 @@ class Sound extends kha.Sound {
 	}
 	
 	function _createData(size: Int): Void {
-		uncompressedData = new Vector<Float>(size);
+		uncompressedData = new kha.arrays.Float32Array(size);
 	}
 }

--- a/Backends/KoreHL/KoreC/arrays.cpp
+++ b/Backends/KoreHL/KoreC/arrays.cpp
@@ -1,0 +1,40 @@
+#include <Kore/pch.h>
+#include <hl.h>
+
+extern "C" vbyte* hl_kore_float32array_alloc(int elements) {
+	float* data = new float[elements];
+	return (vbyte *)data;
+}
+
+extern "C" void hl_kore_float32array_free(vbyte* f32array) {
+	delete[] f32array;
+}
+
+extern "C" void hl_kore_float32array_set(vbyte* f32array, int index, float value) {
+	float* arr = (float*)f32array;
+	arr[index] = value;
+}
+
+extern "C" float hl_kore_float32array_get(vbyte* f32array, int index) {
+	float* arr = (float*)f32array;
+	return arr[index];
+}
+
+extern "C" vbyte* hl_kore_uint32array_alloc(int elements) {
+	unsigned int* data = new unsigned int [elements];
+	return (vbyte*)data;
+}
+
+extern "C" void hl_kore_uint32array_free(vbyte* u32array) {
+	delete[] u32array;
+}
+
+extern "C" void hl_kore_uint32array_set(vbyte* u32array, int index, unsigned int value) {
+	unsigned int* arr = (unsigned int*)u32array;
+	arr[index] = value;
+}
+
+extern "C" unsigned int  hl_kore_uint32array_get(vbyte* u32array, int index) {
+	unsigned int* arr = (unsigned int*)u32array;
+	return arr[index];
+}

--- a/Backends/KoreHL/KoreC/compute.cpp
+++ b/Backends/KoreHL/KoreC/compute.cpp
@@ -1,0 +1,161 @@
+#include <Kore/pch.h>
+#include <Kore/Compute/Compute.h>
+#include <Kore/Graphics4/Graphics.h>
+#include <hl.h>
+#include <Kore/Log.h>
+
+extern "C" vbyte* hl_kore_compute_create_shader(vbyte* data, int length) {
+	return (vbyte*)new Kore::ComputeShader(data, length);
+}
+
+extern "C" void hl_kore_compute_delete_shader(vbyte* shader) {
+	Kore::ComputeShader* sh = (Kore::ComputeShader*)shader;
+	delete sh;
+}
+
+extern "C" vbyte* hl_kore_compute_get_constantlocation(vbyte* shader, vbyte* name) {
+	Kore::ComputeShader* sh = (Kore::ComputeShader*)shader;
+	return (vbyte*)new Kore::ComputeConstantLocation(sh->getConstantLocation((char*)name));	
+}
+
+extern "C" vbyte* hl_kore_compute_get_textureunit(vbyte* shader, vbyte* name) {
+	Kore::ComputeShader* sh = (Kore::ComputeShader*)shader;
+	return (vbyte*)new Kore::ComputeTextureUnit(sh->getTextureUnit((char*)name));
+}
+
+extern "C" void hl_kore_compute_set_bool(vbyte *location, bool value) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setBool(*loc, value);
+}
+
+extern "C" void hl_kore_compute_set_int(vbyte *location, int value) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setInt(*loc, value);
+}
+
+extern "C" void hl_kore_compute_set_float(vbyte *location, float value) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setFloat(*loc, value);
+}
+
+extern "C" void hl_kore_compute_set_float2(vbyte *location, float value1, float value2) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setFloat2(*loc, value1, value2);
+}
+
+extern "C" void hl_kore_compute_set_float3(vbyte *location, float value1, float value2, float value3) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setFloat3(*loc, value1, value2, value3);
+}
+
+extern "C" void hl_kore_compute_set_float4(vbyte *location, float value1, float value2, float value3, float value4) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setFloat4(*loc, value1, value2, value3, value4);
+}
+
+extern "C" void hl_kore_compute_set_floats(vbyte *location, vbyte *values, int count) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::Compute::setFloats(*loc, (float*)values, count);
+}
+
+extern "C" void hl_kore_compute_set_matrix(vbyte *location,
+	float _00, float _10, float _20, float _30,
+	float _01, float _11, float _21, float _31,
+	float _02, float _12, float _22, float _32,
+	float _03, float _13, float _23, float _33) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::mat4 value;
+	value.Set(0, 0, _00); value.Set(1, 0, _01); value.Set(2, 0, _02); value.Set(3, 0, _03);
+	value.Set(0, 1, _10); value.Set(1, 1, _11); value.Set(2, 1, _12); value.Set(3, 1, _13);
+	value.Set(0, 2, _20); value.Set(1, 2, _21); value.Set(2, 2, _22); value.Set(3, 2, _23);
+	value.Set(0, 3, _30); value.Set(1, 3, _31); value.Set(2, 3, _32); value.Set(3, 3, _33);
+	Kore::Compute::setMatrix(*loc, value);
+}
+
+extern "C" void hl_kore_compute_set_matrix3(vbyte *location,
+	float _00, float _10, float _20,
+	float _01, float _11, float _21,
+	float _02, float _12, float _22) {
+	Kore::ComputeConstantLocation* loc = (Kore::ComputeConstantLocation*)location;
+	Kore::mat3 value;
+	value.Set(0, 0, _00); value.Set(1, 0, _01); value.Set(2, 0, _02);
+	value.Set(0, 1, _10); value.Set(1, 1, _11); value.Set(2, 1, _12);
+	value.Set(0, 2, _20); value.Set(1, 2, _21); value.Set(2, 2, _22);
+	Kore::Compute::setMatrix(*loc, value);
+}
+
+extern "C" void hl_kore_compute_set_texture(vbyte *unit, vbyte *texture, int access) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	Kore::Compute::setTexture(*u, tex, (Kore::Compute::Access)access);
+}
+
+extern "C" void hl_kore_compute_set_target(vbyte *unit, vbyte *renderTarget, int access) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	Kore::Compute::setTexture(*u, rt, (Kore::Compute::Access)access);
+}
+
+extern "C" void hl_kore_compute_set_sampled_texture(vbyte *unit, vbyte *texture) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	Kore::Compute::setSampledTexture(*u, tex);
+}
+
+extern "C" void hl_kore_compute_set_sampled_target(vbyte *unit, vbyte *renderTarget) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	Kore::Compute::setSampledTexture(*u, rt);
+}
+
+extern "C" void hl_kore_compute_set_sampled_depth_target(vbyte *unit, vbyte *renderTarget) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	Kore::Compute::setSampledDepthTexture(*u, rt);
+}
+
+extern "C" void hl_kore_compute_set_sampled_cubemap_texture(vbyte *unit, vbyte *texture) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	Kore::Compute::setSampledTexture(*u, tex);
+}
+
+extern "C" void hl_kore_compute_set_sampled_cubemap_target(vbyte *unit, vbyte *renderTarget) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	Kore::Compute::setSampledTexture(*u, rt);
+}
+
+extern "C" void hl_kore_compute_set_sampled_cubemap_depth_target(vbyte *unit, vbyte *renderTarget) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	Kore::Compute::setSampledDepthTexture(*u, rt);
+}
+
+extern "C" void hl_kore_compute_set_texture_parameters(vbyte *unit, int uAddressing, int vAddressing, int minificationFilter, int magnificationFilter, int mipmapFilter) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Compute::setTextureAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
+	Kore::Compute::setTextureAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
+	Kore::Compute::setTextureMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
+	Kore::Compute::setTextureMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
+	Kore::Compute::setTextureMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
+}
+
+extern "C" void hl_kore_compute_set_texture3d_parameters(vbyte *unit, int uAddressing, int vAddressing,int wAddressing, int minificationFilter, int magnificationFilter, int mipmapFilter) {
+	Kore::ComputeTextureUnit* u = (Kore::ComputeTextureUnit*)unit;
+	Kore::Compute::setTexture3DAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
+	Kore::Compute::setTexture3DAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
+	Kore::Compute::setTexture3DAddressing(*u, Kore::Graphics4::W, (Kore::Graphics4::TextureAddressing)wAddressing);
+	Kore::Compute::setTexture3DMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
+	Kore::Compute::setTexture3DMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
+	Kore::Compute::setTexture3DMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
+}
+
+extern "C" void hl_kore_compute_set_shader(vbyte *shader) {
+	Kore::ComputeShader* sh = (Kore::ComputeShader*)shader;
+	Kore::Compute::setShader(sh);
+}
+
+extern "C" void hl_kore_compute_compute(int x, int y, int z) {
+	Kore::Compute::compute(x, y, z);
+}

--- a/Backends/KoreHL/KoreC/graphics.cpp
+++ b/Backends/KoreHL/KoreC/graphics.cpp
@@ -61,12 +61,12 @@ extern "C" void hl_kore_graphics_set_texture_parameters(vbyte *unit, int uAddres
 
 extern "C" void hl_kore_graphics_set_texture3d_parameters(vbyte *unit, int uAddressing, int vAddressing,int wAddressing, int minificationFilter, int magnificationFilter, int mipmapFilter) {
 	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
-	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
-	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
-	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::W, (Kore::Graphics4::TextureAddressing)wAddressing);
-	Kore::Graphics4::setTextureMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
-	Kore::Graphics4::setTextureMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
-	Kore::Graphics4::setTextureMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
+	Kore::Graphics4::setTexture3DAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
+	Kore::Graphics4::setTexture3DAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
+	Kore::Graphics4::setTexture3DAddressing(*u, Kore::Graphics4::W, (Kore::Graphics4::TextureAddressing)wAddressing);
+	Kore::Graphics4::setTexture3DMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
+	Kore::Graphics4::setTexture3DMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
+	Kore::Graphics4::setTexture3DMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
 }
 
 extern "C" void hl_kore_graphics_set_texture(vbyte *unit, vbyte *texture) {

--- a/Backends/KoreHL/KoreC/graphics.cpp
+++ b/Backends/KoreHL/KoreC/graphics.cpp
@@ -23,6 +23,16 @@ extern "C" void hl_kore_graphics_set_vertexbuffer(vbyte *buffer) {
 	Kore::Graphics4::setVertexBuffer(*buf);
 }
 
+extern "C" void hl_kore_graphics_set_vertexbuffers(vbyte *b0, vbyte *b1, vbyte *b2, vbyte *b3, int count) {
+	Kore::Graphics4::VertexBuffer* vertexBuffers[4] = {
+		(Kore::Graphics4::VertexBuffer*)b0,
+		(Kore::Graphics4::VertexBuffer*)b1,
+		(Kore::Graphics4::VertexBuffer*)b2,
+		(Kore::Graphics4::VertexBuffer*)b3
+	};
+	Kore::Graphics4::setVertexBuffers(vertexBuffers, count);
+}
+
 extern "C" void hl_kore_graphics_set_indexbuffer(vbyte *buffer) {
 	Kore::Graphics4::IndexBuffer* buf = (Kore::Graphics4::IndexBuffer*)buffer;
 	Kore::Graphics4::setIndexBuffer(*buf);

--- a/Backends/KoreHL/KoreC/graphics.cpp
+++ b/Backends/KoreHL/KoreC/graphics.cpp
@@ -2,7 +2,7 @@
 #include <Kore/Graphics4/Graphics.h>
 #include <hl.h>
 
-extern "C" void hl_kore_graphics_clear(int flags, int color, double z, int stencil) {
+extern "C" void hl_kore_graphics_clear(int flags, int color, float z, int stencil) {
 	Kore::Graphics4::clear(flags, color, z, stencil);
 }
 
@@ -40,6 +40,25 @@ extern "C" bool hl_kore_graphics_render_targets_inverted_y() {
 	return Kore::Graphics4::renderTargetsInvertedY();
 }
 
+extern "C" void hl_kore_graphics_set_texture_parameters(vbyte *unit, int uAddressing, int vAddressing, int minificationFilter, int magnificationFilter, int mipmapFilter) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
+	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
+	Kore::Graphics4::setTextureMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
+	Kore::Graphics4::setTextureMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
+	Kore::Graphics4::setTextureMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
+}
+
+extern "C" void hl_kore_graphics_set_texture3d_parameters(vbyte *unit, int uAddressing, int vAddressing,int wAddressing, int minificationFilter, int magnificationFilter, int mipmapFilter) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::U, (Kore::Graphics4::TextureAddressing)uAddressing);
+	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::V, (Kore::Graphics4::TextureAddressing)vAddressing);
+	Kore::Graphics4::setTextureAddressing(*u, Kore::Graphics4::W, (Kore::Graphics4::TextureAddressing)wAddressing);
+	Kore::Graphics4::setTextureMinificationFilter(*u, (Kore::Graphics4::TextureFilter)minificationFilter);
+	Kore::Graphics4::setTextureMagnificationFilter(*u, (Kore::Graphics4::TextureFilter)magnificationFilter);
+	Kore::Graphics4::setTextureMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
+}
+
 extern "C" void hl_kore_graphics_set_texture(vbyte *unit, vbyte *texture) {
 	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
 	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
@@ -50,6 +69,12 @@ extern "C" void hl_kore_graphics_set_texture_depth(vbyte *unit, vbyte *renderTar
 	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
 	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
 	rt->useDepthAsTexture(*u);
+}
+
+extern "C" void hl_kore_graphics_set_texture_array(vbyte *unit, vbyte *textureArray) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::TextureArray* texArray = (Kore::Graphics4::TextureArray*)textureArray;
+	Kore::Graphics4::setTextureArray(*u, texArray);
 }
 
 extern "C" void hl_kore_graphics_set_render_target(vbyte *unit, vbyte *renderTarget) {
@@ -70,6 +95,12 @@ extern "C" void hl_kore_graphics_set_cubemap_depth(vbyte *unit, vbyte *renderTar
 	rt->useDepthAsTexture(*u);
 }
 
+extern "C" void hl_kore_graphics_set_image_texture(vbyte *unit, vbyte *texture) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	Kore::Graphics4::setImageTexture(*u, tex);
+}
+
 extern "C" void hl_kore_graphics_set_cubemap_target(vbyte *unit, vbyte *renderTarget) {
 	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
 	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
@@ -86,22 +117,22 @@ extern "C" void hl_kore_graphics_set_int(vbyte *location, int value) {
 	Kore::Graphics4::setInt(*loc, value);
 }
 
-extern "C" void hl_kore_graphics_set_float(vbyte *location, double value) {
+extern "C" void hl_kore_graphics_set_float(vbyte *location, float value) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::Graphics4::setFloat(*loc, value);
 }
 
-extern "C" void hl_kore_graphics_set_float2(vbyte *location, double value1, double value2) {
+extern "C" void hl_kore_graphics_set_float2(vbyte *location, float value1, float value2) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::Graphics4::setFloat2(*loc, value1, value2);
 }
 
-extern "C" void hl_kore_graphics_set_float3(vbyte *location, double value1, double value2, double value3) {
+extern "C" void hl_kore_graphics_set_float3(vbyte *location, float value1, float value2, float value3) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::Graphics4::setFloat3(*loc, value1, value2, value3);
 }
 
-extern "C" void hl_kore_graphics_set_float4(vbyte *location, double value1, double value2, double value3, double value4) {
+extern "C" void hl_kore_graphics_set_float4(vbyte *location, float value1, float value2, float value3, float value4) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::Graphics4::setFloat4(*loc, value1, value2, value3, value4);
 }
@@ -112,10 +143,10 @@ extern "C" void hl_kore_graphics_set_floats(vbyte *location, vbyte *values, int 
 }
 
 extern "C" void hl_kore_graphics_set_matrix(vbyte *location,
-	double _00, double _10, double _20, double _30,
-	double _01, double _11, double _21, double _31,
-	double _02, double _12, double _22, double _32,
-	double _03, double _13, double _23, double _33) {
+	float _00, float _10, float _20, float _30,
+	float _01, float _11, float _21, float _31,
+	float _02, float _12, float _22, float _32,
+	float _03, float _13, float _23, float _33) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::mat4 value;
 	value.Set(0, 0, _00); value.Set(1, 0, _01); value.Set(2, 0, _02); value.Set(3, 0, _03);
@@ -126,9 +157,9 @@ extern "C" void hl_kore_graphics_set_matrix(vbyte *location,
 }
 
 extern "C" void hl_kore_graphics_set_matrix3(vbyte *location,
-	double _00, double _10, double _20,
-	double _01, double _11, double _21,
-	double _02, double _12, double _22) {
+	float _00, float _10, float _20,
+	float _01, float _11, float _21,
+	float _02, float _12, float _22) {
 	Kore::Graphics4::ConstantLocation* loc = (Kore::Graphics4::ConstantLocation*)location;
 	Kore::mat3 value;
 	value.Set(0, 0, _00); value.Set(1, 0, _01); value.Set(2, 0, _02);

--- a/Backends/KoreHL/KoreC/indexbuffer.cpp
+++ b/Backends/KoreHL/KoreC/indexbuffer.cpp
@@ -6,6 +6,11 @@ extern "C" vbyte *hl_kore_create_indexbuffer(int count) {
 	return (vbyte*)new Kore::Graphics4::IndexBuffer(count);
 }
 
+extern "C" void hl_kore_delete_indexbuffer(vbyte *buffer) {
+	Kore::Graphics4::IndexBuffer* buf = (Kore::Graphics4::IndexBuffer*)buffer;
+	delete buf;
+}
+
 extern "C" vbyte *hl_kore_indexbuffer_lock(vbyte *buffer) {
 	Kore::Graphics4::IndexBuffer* buf = (Kore::Graphics4::IndexBuffer*)buffer;
 	return (vbyte*)buf->lock();

--- a/Backends/KoreHL/KoreC/kore.cpp
+++ b/Backends/KoreHL/KoreC/kore.cpp
@@ -64,8 +64,8 @@ namespace {
 	}
 }
 
-extern "C" void hl_init_kore(vbyte *title, int width, int height) {
-	Kore::log(Kore::Info, "Starting Kore");
+extern "C" void hl_init_kore(vbyte *title, int width, int height, int antialiasing, bool vSync, int windowMode, bool resizable, bool maximizable, bool minimizable) {
+	Kore::log(Kore::Info, "Starting KoreHL");
 
 	Kore::Random::init(static_cast<int>(Kore::System::timestamp() % std::numeric_limits<int>::max()));
 	Kore::System::setName((char*)title);
@@ -81,11 +81,14 @@ extern "C" void hl_init_kore(vbyte *title, int width, int height) {
 	options.x = Kore::System::desktopWidth() / 2 - width / 2;
 	options.y = Kore::System::desktopHeight() / 2 - height / 2;
 	options.targetDisplay = -1;
-	options.mode = Kore::WindowModeWindow;
+	options.mode = (Kore::WindowMode)windowMode;
+	options.resizable = resizable;
+	options.maximizable = maximizable;
+	options.minimizable = minimizable;
 	options.rendererOptions.depthBufferBits = 16;
 	options.rendererOptions.stencilBufferBits = 8;
 	options.rendererOptions.textureFormat = 0;
-	options.rendererOptions.antialiasing = 1;
+	options.rendererOptions.antialiasing = antialiasing;
 
 	Kore::System::initWindow(options);
 

--- a/Backends/KoreHL/KoreC/kore.cpp
+++ b/Backends/KoreHL/KoreC/kore.cpp
@@ -1,17 +1,9 @@
 #include <Kore/pch.h>
-#include <Kore/Graphics4/Graphics.h>
-#include <Kore/Input/Gamepad.h>
-#include <Kore/Input/Keyboard.h>
-#include <Kore/Input/Mouse.h>
-#include <Kore/Input/Sensor.h>
-#include <Kore/Input/Surface.h>
-#include <Kore/Audio1/Audio.h>
-#include <Kore/IO/FileReader.h>
 #include <Kore/Log.h>
-#include <Kore/Threads/Mutex.h>
-#include <Kore/Math/Random.h>
 #include <Kore/System.h>
-#include <Kore/Math/Core.h>
+#include <Kore/Graphics4/Graphics.h>
+#include <Kore/Audio2/Audio.h>
+#include <Kore/Math/Random.h>
 
 #include <hl.h>
 #ifdef min
@@ -22,18 +14,18 @@
 #endif
 
 #include <limits>
-#include <stdio.h>
-#include <stdlib.h>
-
-#ifdef ANDROID
-#include <Kore/Vr/VrInterface.h>
-#endif
 
 extern "C" void frame();
 
 namespace {
 	bool visible = true;
 	bool paused = false;
+
+	typedef void(*FN_AUDIO_CALL_CALLBACK)(int);
+	typedef float(*FN_AUDIO_READ_SAMPLE)();
+
+	void (*audioCallCallback)(int);
+	float (*audioReadSample)();
 
 	void update() {
 		if (paused) return;
@@ -48,6 +40,26 @@ namespace {
 				Kore::Graphics4::end(windowIndex);
 				Kore::Graphics4::swapBuffers(windowIndex);
 			}
+		}
+	}
+
+	void mix(int samples) {
+		using namespace Kore;
+
+// #ifdef KORE_MULTITHREADED_AUDIO
+// 		if (!mixThreadregistered) {
+// 			__hxcpp_register_current_thread();
+// 			mixThreadregistered = true;
+// 		}
+// #endif
+
+		audioCallCallback(samples);
+
+		for (int i = 0; i < samples; ++i) {
+			float value = audioReadSample();
+			*(float*)&Audio2::buffer.data[Audio2::buffer.writeLocation] = value;
+			Audio2::buffer.writeLocation += 4;
+			if (Audio2::buffer.writeLocation >= Audio2::buffer.dataSize) Audio2::buffer.writeLocation = 0;
 		}
 	}
 }
@@ -78,6 +90,13 @@ extern "C" void hl_init_kore(vbyte *title, int width, int height) {
 	Kore::System::initWindow(options);
 
 	Kore::System::setCallback(update);
+}
+
+extern "C" void hl_kore_init_audio(vclosure *callCallback, vclosure *readSample) {
+	audioCallCallback = *((FN_AUDIO_CALL_CALLBACK*)(&callCallback->fun));
+	audioReadSample = *((FN_AUDIO_READ_SAMPLE*)(&readSample->fun));
+	Kore::Audio2::audioCallback = mix;
+	Kore::Audio2::init();
 }
 
 extern "C" void run_kore() {

--- a/Backends/KoreHL/KoreC/kore.cpp
+++ b/Backends/KoreHL/KoreC/kore.cpp
@@ -80,6 +80,7 @@ extern "C" void hl_init_kore(vbyte *title, int width, int height, int antialiasi
 	options.height = height;
 	options.x = Kore::System::desktopWidth() / 2 - width / 2;
 	options.y = Kore::System::desktopHeight() / 2 - height / 2;
+	options.vSync = vSync;
 	options.targetDisplay = -1;
 	options.mode = (Kore::WindowMode)windowMode;
 	options.resizable = resizable;

--- a/Backends/KoreHL/KoreC/shader.cpp
+++ b/Backends/KoreHL/KoreC/shader.cpp
@@ -106,11 +106,13 @@ extern "C" void hl_kore_pipeline_set_tesseval_shader(vbyte *pipeline, vbyte *sha
 	pipe->tessellationEvaluationShader = sh;
 }
 
-extern "C" void hl_kore_pipeline_compile(vbyte *pipeline, vbyte *structure) {
+extern "C" void hl_kore_pipeline_compile(vbyte *pipeline, vbyte *structure0, vbyte *structure1, vbyte *structure2, vbyte *structure3) {
 	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
-	Kore::Graphics4::VertexStructure* struc = (Kore::Graphics4::VertexStructure*)structure;
-	pipe->inputLayout[0] = struc;
-	pipe->inputLayout[1] = nullptr;
+	pipe->inputLayout[0] = (Kore::Graphics4::VertexStructure*)structure0;
+	pipe->inputLayout[1] = (Kore::Graphics4::VertexStructure*)structure1;
+	pipe->inputLayout[2] = (Kore::Graphics4::VertexStructure*)structure2;
+	pipe->inputLayout[3] = (Kore::Graphics4::VertexStructure*)structure3;
+	pipe->inputLayout[4] = nullptr;
 	pipe->compile();
 }
 

--- a/Backends/KoreHL/KoreC/shader.cpp
+++ b/Backends/KoreHL/KoreC/shader.cpp
@@ -67,6 +67,26 @@ extern "C" vbyte *hl_kore_create_tessevalshader(vbyte *data, int length) {
 	return (vbyte*)new Kore::Graphics4::Shader(data, length, Kore::Graphics4::TessellationEvaluationShader);
 }
 
+extern "C" vbyte *hl_kore_vertexshader_from_source(vbyte *source) {
+	return (vbyte*)new Kore::Graphics4::Shader((char*)source, Kore::Graphics4::VertexShader);
+}
+
+extern "C" vbyte *hl_kore_fragmentshader_from_source(vbyte *source) {
+	return (vbyte*)new Kore::Graphics4::Shader((char*)source, Kore::Graphics4::FragmentShader);
+}
+
+extern "C" vbyte *hl_kore_geometryshader_from_source(vbyte *source) {
+	return (vbyte*)new Kore::Graphics4::Shader((char*)source, Kore::Graphics4::GeometryShader);
+}
+
+extern "C" vbyte *hl_kore_tesscontrolshader_from_source(vbyte *source) {
+	return (vbyte*)new Kore::Graphics4::Shader((char*)source, Kore::Graphics4::TessellationControlShader);
+}
+
+extern "C" vbyte *hl_kore_tessevalshader_from_source(vbyte *source) {
+	return (vbyte*)new Kore::Graphics4::Shader((char*)source, Kore::Graphics4::TessellationEvaluationShader);
+}
+
 extern "C" vbyte *hl_kore_create_pipeline() {
 	return (vbyte*)new Kore::Graphics4::PipelineState();
 }

--- a/Backends/KoreHL/KoreC/shader.cpp
+++ b/Backends/KoreHL/KoreC/shader.cpp
@@ -55,6 +55,18 @@ extern "C" vbyte *hl_kore_create_fragmentshader(vbyte *data, int length) {
 	return (vbyte*)new Kore::Graphics4::Shader(data, length, Kore::Graphics4::FragmentShader);
 }
 
+extern "C" vbyte *hl_kore_create_geometryshader(vbyte *data, int length) {
+	return (vbyte*)new Kore::Graphics4::Shader(data, length, Kore::Graphics4::GeometryShader);
+}
+
+extern "C" vbyte *hl_kore_create_tesscontrolshader(vbyte *data, int length) {
+	return (vbyte*)new Kore::Graphics4::Shader(data, length, Kore::Graphics4::TessellationControlShader);
+}
+
+extern "C" vbyte *hl_kore_create_tessevalshader(vbyte *data, int length) {
+	return (vbyte*)new Kore::Graphics4::Shader(data, length, Kore::Graphics4::TessellationEvaluationShader);
+}
+
 extern "C" vbyte *hl_kore_create_pipeline() {
 	return (vbyte*)new Kore::Graphics4::PipelineState();
 }
@@ -69,6 +81,24 @@ extern "C" void hl_kore_pipeline_set_fragment_shader(vbyte *pipeline, vbyte *sha
 	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
 	Kore::Graphics4::Shader* sh = (Kore::Graphics4::Shader*)shader;
 	pipe->fragmentShader = sh;
+}
+
+extern "C" void hl_kore_pipeline_set_geometry_shader(vbyte *pipeline, vbyte *shader) {
+	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
+	Kore::Graphics4::Shader* sh = (Kore::Graphics4::Shader*)shader;
+	pipe->geometryShader = sh;
+}
+
+extern "C" void hl_kore_pipeline_set_tesscontrol_shader(vbyte *pipeline, vbyte *shader) {
+	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
+	Kore::Graphics4::Shader* sh = (Kore::Graphics4::Shader*)shader;
+	pipe->tessellationControlShader = sh;
+}
+
+extern "C" void hl_kore_pipeline_set_tesseval_shader(vbyte *pipeline, vbyte *shader) {
+	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
+	Kore::Graphics4::Shader* sh = (Kore::Graphics4::Shader*)shader;
+	pipe->tessellationEvaluationShader = sh;
 }
 
 extern "C" void hl_kore_pipeline_compile(vbyte *pipeline, vbyte *structure) {

--- a/Backends/KoreHL/KoreC/shader.cpp
+++ b/Backends/KoreHL/KoreC/shader.cpp
@@ -71,6 +71,11 @@ extern "C" vbyte *hl_kore_create_pipeline() {
 	return (vbyte*)new Kore::Graphics4::PipelineState();
 }
 
+extern "C" void hl_kore_delete_pipeline(vbyte *pipeline) {
+	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
+	delete pipe;
+}
+
 extern "C" void hl_kore_pipeline_set_vertex_shader(vbyte *pipeline, vbyte *shader) {
 	Kore::Graphics4::PipelineState* pipe = (Kore::Graphics4::PipelineState*)pipeline;
 	Kore::Graphics4::Shader* sh = (Kore::Graphics4::Shader*)shader;

--- a/Backends/KoreHL/KoreC/sound.cpp
+++ b/Backends/KoreHL/KoreC/sound.cpp
@@ -1,0 +1,50 @@
+#include <Kore/pch.h>
+#include <Kore/Audio1/Sound.h>
+#include <hl.h>
+
+#define STB_VORBIS_HEADER_ONLY
+#include <Kore/Audio1/stb_vorbis.c>
+
+extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize) {
+	Kore::Sound* sound = new Kore::Sound((char*)filename);
+	float* uncompressedData = new float[sound->size * 2];
+	reinterpret_cast<unsigned int*>(outSize)[0] = sound->size * 2; // Return array size to Kha
+	Kore::s16* left = (Kore::s16*)&sound->left[0];
+	Kore::s16* right = (Kore::s16*)&sound->right[0];
+	for (int i = 0; i < sound->size; i += 1) {
+		uncompressedData[i * 2 + 0] = (float)(left [i] / 32767.0);
+		uncompressedData[i * 2 + 1] = (float)(right[i] / 32767.0);
+	}
+	delete sound;
+	return (vbyte*)uncompressedData;
+}
+
+extern "C" vbyte *hl_kore_sound_init_vorbis(vbyte* data, int length) {
+	return (vbyte*)stb_vorbis_open_memory(data, length, NULL, NULL);
+}
+
+extern "C" bool hl_kore_sound_next_vorbis_samples(vbyte* vorbis, vbyte* samples, int length, bool loop, bool atend) {
+	int read = stb_vorbis_get_samples_float_interleaved((stb_vorbis*)vorbis, 2, (float*)samples, length);
+	if (read < length / 2) {
+		if (loop) {
+			stb_vorbis_seek_start((stb_vorbis*)vorbis);
+		}
+		else {
+			atend = true;
+		}
+		for (int i = read; i < length; ++i) {
+			samples[i] = 0;
+		}
+	}
+	return atend;
+}
+
+extern "C" int hl_kore_sound_vorbis_get_length(vbyte* vorbis) {
+	if (vorbis == NULL) return 0;
+	return (int)(stb_vorbis_stream_length_in_seconds((stb_vorbis*)vorbis) * 1000);
+}
+
+extern "C" int hl_kore_sound_vorbis_get_position(vbyte* vorbis) {
+	if (vorbis == NULL) return 0;
+	return stb_vorbis_get_sample_offset((stb_vorbis*)vorbis) / stb_vorbis_stream_length_in_samples((stb_vorbis*)vorbis) * 1000;
+}

--- a/Backends/KoreHL/KoreC/system.cpp
+++ b/Backends/KoreHL/KoreC/system.cpp
@@ -1,8 +1,13 @@
 #include <Kore/pch.h>
 #include <Kore/System.h>
+#include <Kore/Log.h>
 #include <Kore/Input/Keyboard.h>
 #include <Kore/Input/Mouse.h>
 #include <hl.h>
+
+extern "C" void hl_kore_log(vbyte *v) {
+	Kore::log(Kore::Info, (char*)v);
+}
 
 extern "C" double hl_kore_get_time() {
 	return Kore::System::time();

--- a/Backends/KoreHL/KoreC/system.cpp
+++ b/Backends/KoreHL/KoreC/system.cpp
@@ -3,6 +3,10 @@
 #include <Kore/Log.h>
 #include <Kore/Input/Keyboard.h>
 #include <Kore/Input/Mouse.h>
+#include <Kore/Input/Gamepad.h>
+#include <Kore/Input/Surface.h>
+#include <Kore/Input/Pen.h>
+#include <Kore/Input/Sensor.h>
 #include <hl.h>
 
 extern "C" void hl_kore_log(vbyte *v) {
@@ -21,6 +25,66 @@ extern "C" int hl_kore_get_window_height(int window) {
 	return Kore::System::windowHeight(window);
 }
 
+extern "C" int hl_kore_get_screen_dpi() {
+	return Kore::System::screenDpi();
+}
+
+extern "C" vbyte* hl_kore_get_system_id() {
+	return NULL;
+	// return (vbyte*)Kore::System::systemId();
+}
+
+extern "C" void hl_kore_request_shutdown() {
+	return Kore::System::stop();
+}
+
+extern "C" void hl_kore_mouse_lock(int windowId) {
+	Kore::Mouse::the()->lock(windowId);
+}
+
+extern "C" void hl_kore_mouse_unlock(int windowId) {
+	Kore::Mouse::the()->unlock(windowId);
+}
+
+extern "C" bool hl_kore_can_lock_mouse(int windowId) {
+	return Kore::Mouse::the()->canLock(windowId);
+}
+
+extern "C" bool hl_kore_is_mouse_locked(int windowId) {
+	return Kore::Mouse::the()->isLocked(windowId);
+}
+
+extern "C" bool hl_kore_system_is_fullscreen() {
+	return Kore::System::isFullscreen();
+}
+
+extern "C" void hl_kore_system_request_fullscreen() {
+	Kore::System::changeResolution(Kore::System::desktopWidth(), Kore::System::desktopHeight(), true);
+}
+
+extern "C" void hl_kore_system_exit_fullscreen(int previousWidth, int previousHeight) {
+	Kore::System::changeResolution(previousWidth, previousHeight, false);
+}
+
+extern "C" void hl_kore_system_change_resolution(int width, int height) {
+	Kore::System::changeResolution(width, height, false);
+}
+
+extern "C" void hl_kore_system_set_keepscreenon(bool on) {
+	Kore::System::setKeepScreenOn(on);
+}
+
+extern "C" void hl_kore_system_load_url(vbyte* url) {
+	Kore::System::loadURL((char*)url);
+}
+
+// const char* getGamepadId(int index);
+
+extern "C" vbyte* hl_kore_get_gamepad_id(int index) {
+	return NULL;
+	// return (vbyte*)getGamepadId(index);
+}
+
 typedef void(*FN_KEY_DOWN)(Kore::KeyCode);
 typedef void(*FN_KEY_UP)(Kore::KeyCode);
 typedef void(*FN_KEY_PRESS)(wchar_t);
@@ -34,9 +98,81 @@ extern "C" void hl_kore_register_keyboard(vclosure *keyDown, vclosure *keyUp, vc
 typedef void(*FN_MOUSE_DOWN)(int, int, int, int);
 typedef void(*FN_MOUSE_UP)(int, int, int, int);
 typedef void(*FN_MOUSE_MOVE)(int, int, int, int, int);
+typedef void(*FN_MOUSE_WHEEL)(int, int);
 
-extern "C" void hl_kore_register_mouse(vclosure *mouseDown, vclosure *mouseUp, vclosure *mouseMove) {
+extern "C" void hl_kore_register_mouse(vclosure *mouseDown, vclosure *mouseUp, vclosure *mouseMove, vclosure *mouseWheel) {
 	Kore::Mouse::the()->Press = *((FN_MOUSE_DOWN*)(&mouseDown->fun));
 	Kore::Mouse::the()->Release = *((FN_MOUSE_UP*)(&mouseUp->fun));
 	Kore::Mouse::the()->Move = *((FN_MOUSE_MOVE*)(&mouseMove->fun));
+	Kore::Mouse::the()->Scroll = *((FN_MOUSE_WHEEL*)(&mouseWheel->fun));
+}
+
+typedef void(*FN_PEN_DOWN)(int, int, int, float);
+typedef void(*FN_PEN_UP)(int, int, int, float);
+typedef void(*FN_PEN_MOVE)(int, int, int, float);
+
+extern "C" void hl_kore_register_pen(vclosure *penDown, vclosure *penUp, vclosure *penMove) {
+	Kore::Pen::the()->Press = *((FN_PEN_DOWN*)(&penDown->fun));
+	Kore::Pen::the()->Release = *((FN_PEN_UP*)(&penUp->fun));
+	Kore::Pen::the()->Move = *((FN_PEN_MOVE*)(&penMove->fun));
+}
+
+typedef void(*FN_GAMEPAD_AXIS)(int, float);
+typedef void(*FN_GAMEPAD_BUTTON)(int, float);
+
+extern "C" void hl_kore_register_gamepad(int index, vclosure *gamepadAxis, vclosure *gamepadButton) {
+	Kore::Gamepad::get(index)->Axis = *((FN_GAMEPAD_AXIS*)(&gamepadAxis->fun));
+	Kore::Gamepad::get(index)->Button = *((FN_GAMEPAD_BUTTON*)(&gamepadButton->fun));
+}
+
+typedef void(*FN_TOUCH_START)(int, int, int);
+typedef void(*FN_TOUCH_END)(int, int, int);
+typedef void(*FN_TOUCH_MOVE)(int, int, int);
+
+extern "C" void hl_kore_register_surface(vclosure *touchStart, vclosure *touchEnd, vclosure *touchMove) {
+	Kore::Surface::the()->TouchStart = *((FN_TOUCH_START*)(&touchStart->fun));
+	Kore::Surface::the()->TouchEnd = *((FN_TOUCH_END*)(&touchEnd->fun));
+	Kore::Surface::the()->Move = *((FN_TOUCH_MOVE*)(&touchMove->fun));
+}
+
+typedef void(*FN_SENSOR_ACCELEROMETER)(float, float, float);
+typedef void(*FN_SENSOR_GYROSCOPE)(float, float, float);
+
+extern "C" void hl_kore_register_sensor(vclosure *accelerometerChanged, vclosure *gyroscopeChanged) {
+	Kore::Sensor::the(Kore::SensorAccelerometer)->Changed = *((FN_SENSOR_ACCELEROMETER*)(&accelerometerChanged->fun));
+	Kore::Sensor::the(Kore::SensorGyroscope)->Changed = *((FN_SENSOR_GYROSCOPE*)(&gyroscopeChanged->fun));
+}
+
+// typedef void(*FN_CB_ORIENTATION)(int);
+typedef void(*FN_CB_FOREGROUND)();
+typedef void(*FN_CB_RESUME)();
+typedef void(*FN_CB_PAUSE)();
+typedef void(*FN_CB_BACKGROUND)();
+typedef void(*FN_CB_SHUTDOWN)();
+
+extern "C" void hl_kore_register_callbacks(vclosure *foreground, vclosure *resume, vclosure *pause, vclosure *background, vclosure *shutdown) {
+	// Kore::System::setOrientationCallback(orientation);
+	Kore::System::setForegroundCallback(*((FN_CB_FOREGROUND*)(&foreground->fun)));
+	Kore::System::setResumeCallback(*((FN_CB_RESUME*)(&resume->fun)));
+	Kore::System::setPauseCallback(*((FN_CB_PAUSE*)(&pause->fun)));
+	Kore::System::setBackgroundCallback(*((FN_CB_BACKGROUND*)(&background->fun)));
+	Kore::System::setShutdownCallback(*((FN_CB_SHUTDOWN*)(&shutdown->fun)));
+}
+
+typedef void(*FN_CB_DROPFILES)(wchar_t*);
+
+extern "C" void hl_kore_register_dropfiles(vclosure *dropFiles) {
+	// todo: string convert
+	// Kore::System::setDropFilesCallback(*((FN_CB_DROPFILES*)(&dropFiles->fun)));
+}
+
+typedef char*(*FN_CB_COPY)();
+typedef char*(*FN_CB_CUT)();
+typedef void(*FN_CB_PASTE)(char*);
+
+extern "C" void hl_kore_register_copycutpaste(vclosure *copy, vclosure *cut, vclosure *paste) {
+	// todo: string convert
+	// Kore::System::setCopyCallback(*((FN_CB_COPY*)(&copy->fun)));
+	// Kore::System::setCutCallback(*((FN_CB_CUT*)(&cut->fun)));
+	// Kore::System::setPasteCallback(*((FN_CB_PASTE*)(&paste->fun)));
 }

--- a/Backends/KoreHL/KoreC/texture.cpp
+++ b/Backends/KoreHL/KoreC/texture.cpp
@@ -10,6 +10,18 @@ extern "C" vbyte *hl_kore_texture_create_from_file(vbyte *filename, bool readabl
 	return (vbyte*)new Kore::Graphics4::Texture((char*)filename, readable);
 }
 
+extern "C" vbyte *hl_kore_texture_create3d(int width, int height, int depth, int format, bool readable) {
+	return (vbyte*)new Kore::Graphics4::Texture(width, height, depth, (Kore::Graphics4::Image::Format)format, readable);
+}
+
+extern "C" vbyte *hl_kore_texture_from_bytes(vbyte *bytes, int width, int height, int format, bool readable) {
+	return (vbyte*)new Kore::Graphics4::Texture(bytes, width, height, (Kore::Graphics4::Image::Format)format, readable);
+}
+
+extern "C" vbyte *hl_kore_texture_from_bytes3d(vbyte *bytes, int width, int height, int depth, int format, bool readable) {
+	return (vbyte*)new Kore::Graphics4::Texture(bytes, width, height, depth, (Kore::Graphics4::Image::Format)format, readable);
+}
+
 extern "C" bool hl_kore_non_pow2_textures_supported() {
 	return Kore::Graphics4::nonPow2TexturesSupported();
 }
@@ -32,6 +44,21 @@ extern "C" int hl_kore_texture_get_real_width(vbyte *texture) {
 extern "C" int hl_kore_texture_get_real_height(vbyte *texture) {
 	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
 	return tex->texHeight;
+}
+
+extern "C" int hl_kore_texture_at(vbyte *texture, int x, int y) {
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	return tex->at(x, y);
+}
+
+extern "C" void hl_kore_texture_unload(vbyte *texture) {
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	delete tex;
+}
+
+extern "C" void hl_kore_render_target_unload(vbyte *renderTarget) {
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	delete rt;
 }
 
 extern "C" vbyte *hl_kore_render_target_create(int width, int height, int depthBufferBits, int format, int stencilBufferBits, int contextId) {
@@ -58,8 +85,29 @@ extern "C" int hl_kore_render_target_get_real_height(vbyte *renderTarget) {
 	return rt->texHeight;
 }
 
+extern "C" void hl_kore_generate_mipmaps_texture(vbyte *texture, int levels) {
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	return tex->generateMipmaps(levels);
+}
+
+extern "C" void hl_kore_generate_mipmaps_target(vbyte *renderTarget, int levels) {
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	return rt->generateMipmaps(levels);
+}
+
+extern "C" void hl_kore_set_mipmap_texture(vbyte *texture, vbyte *mipmap, int level) {
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	Kore::Graphics4::Texture* miptex = (Kore::Graphics4::Texture*)mipmap;
+	return tex->setMipmap(miptex, level);
+}
+
 extern "C" void hl_kore_render_target_set_depth_stencil_from(vbyte *renderTarget, vbyte *from) {
 	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
 	Kore::Graphics4::RenderTarget* rt2 = (Kore::Graphics4::RenderTarget*)from;
 	rt->setDepthStencilFrom(rt2);
+}
+
+extern "C" void hl_kore_texture_clear(vbyte *texture, int x, int y, int z, int width, int height, int depth, int color) {
+	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
+	return tex->clear(x, y, z, width, height, depth, color);
 }

--- a/Backends/KoreHL/KoreC/texture.cpp
+++ b/Backends/KoreHL/KoreC/texture.cpp
@@ -85,6 +85,11 @@ extern "C" int hl_kore_render_target_get_real_height(vbyte *renderTarget) {
 	return rt->texHeight;
 }
 
+extern "C" void hl_kore_render_target_get_pixels(vbyte *renderTarget, vbyte *pixels) {
+	Kore::Graphics4::RenderTarget* rt = (Kore::Graphics4::RenderTarget*)renderTarget;
+	rt->getPixels(pixels);
+}
+
 extern "C" void hl_kore_generate_mipmaps_texture(vbyte *texture, int levels) {
 	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;
 	return tex->generateMipmaps(levels);

--- a/Backends/KoreHL/KoreC/vertexbuffer.cpp
+++ b/Backends/KoreHL/KoreC/vertexbuffer.cpp
@@ -16,6 +16,11 @@ extern "C" vbyte *hl_kore_create_vertexbuffer(int vertexCount, vbyte *structure,
 	return (vbyte*)new Kore::Graphics4::VertexBuffer(vertexCount, *struc, stepRate);
 }
 
+extern "C" void hl_kore_delete_vertexbuffer(vbyte *buffer) {
+	Kore::Graphics4::VertexBuffer* buf = (Kore::Graphics4::VertexBuffer*)buffer;
+	delete buf;
+}
+
 extern "C" vbyte *hl_kore_vertexbuffer_lock(vbyte *buffer) {
 	Kore::Graphics4::VertexBuffer* buf = (Kore::Graphics4::VertexBuffer*)buffer;
 	return (vbyte*)buf->lock();

--- a/Backends/KoreHL/KoreC/video.cpp
+++ b/Backends/KoreHL/KoreC/video.cpp
@@ -1,0 +1,57 @@
+#include <Kore/pch.h>
+#include <Kore/Video.h>
+#include <hl.h>
+
+extern "C" vbyte *hl_kore_video_create(vbyte* filename) {
+	return (vbyte*)new Kore::Video((char*)filename);
+}
+
+extern "C" void hl_kore_video_play(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->play();
+}
+
+extern "C" void hl_kore_video_pause(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->pause();
+}
+
+extern "C" void hl_kore_video_stop(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->stop();
+}
+
+extern "C" int hl_kore_video_get_duration(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return static_cast<int>(vid->duration * 1000.0);
+}
+
+extern "C" int hl_kore_video_get_position(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return static_cast<int>(vid->position * 1000.0);
+}
+
+extern "C" void hl_kore_video_set_position(vbyte* video, int value) {
+	Kore::Video* vid = (Kore::Video*)video;
+	vid->update(value / 1000.0);
+}
+
+extern "C" bool hl_kore_video_is_finished(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->finished;
+}
+
+extern "C" int hl_kore_video_width(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->width();
+}
+
+extern "C" int hl_kore_video_height(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	return vid->height();
+}
+
+extern "C" void hl_kore_video_unload(vbyte* video) {
+	Kore::Video* vid = (Kore::Video*)video;
+	delete vid;
+}

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -1,6 +1,7 @@
 package kha;
 
 import haxe.io.Bytes;
+import haxe.io.BytesData;
 import kha.korehl.graphics4.TextureUnit;
 import kha.graphics4.TextureFormat;
 import kha.graphics4.DepthStencilFormat;
@@ -9,6 +10,8 @@ import kha.graphics4.Usage;
 class Image implements Canvas implements Resource {
 	public var _texture: Pointer;
 	public var _renderTarget: Pointer;
+	public var _textureArray: Pointer;
+	public var _textureArrayTextures: Pointer;
 	
 	private var format: TextureFormat;
 	private var readable: Bool;
@@ -29,20 +32,51 @@ class Image implements Canvas implements Resource {
 	}
 
 	public static function create3D(width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
-		return null;
+		return create3(width, height, depth, format == null ? TextureFormat.RGBA32 : format, false, 0);
 	}
 
 	public static function createRenderTarget(width: Int, height: Int, format: TextureFormat = null, depthStencil: DepthStencilFormat = NoDepthAndStencil, antiAliasingSamples: Int = 1, contextId: Int = 0): Image {
 		return create2(width, height, format == null ? TextureFormat.RGBA32 : format, false, true, depthStencil, contextId);
 	}
+
+	// public static function createArray(images: Array<Image>, format: TextureFormat = null): Image {
+		// var image = new Image(false);
+		// image.format = (format == null) ? TextureFormat.RGBA32 : format;
+		// initArrayTexture(image, images);
+		// return image;
+	// }
 	
 	public static function fromBytes(bytes: Bytes, width: Int, height: Int, format: TextureFormat = null, usage: Usage = null): Image {
-		return null;
+		var readable = true;
+		var image = new Image(readable);
+		image.format = format;
+		image.initFromBytes(bytes.getData(), width, height, getTextureFormat(format));
+		return image;
+	}
+
+	private function initFromBytes(bytes: BytesData, width: Int, height: Int, format: Int): Void {
+		_texture = kore_texture_from_bytes(bytes.bytes, width, height, format, readable);
 	}
 
 	public static function fromBytes3D(bytes: Bytes, width: Int, height: Int, depth: Int, format: TextureFormat = null, usage: Usage = null): Image {
-		return null;
+		var readable = true;
+		var image = new Image(readable);
+		image.format = format;
+		image.initFromBytes3D(bytes.getData(), width, height, depth, getTextureFormat(format));
+		return image;
 	}
+
+	private function initFromBytes3D(bytes: BytesData, width: Int, height: Int, depth: Int, format: Int): Void {
+		_texture = kore_texture_from_bytes3d(bytes.bytes, width, height, depth, format, readable);
+	}
+
+	// public static function fromEncodedBytes(bytes: Bytes, format: String, doneCallback: Image -> Void, errorCallback: String->Void, readable: Bool = false): Void {
+		// var image = new Image(readable);
+		// var isFloat = format == "hdr" || format == "HDR";
+		// image.format = isFloat ? TextureFormat.RGBA128 : TextureFormat.RGBA32;
+		// image.initFromEncodedBytes(bytes.getData(), format);
+		// doneCallback(image);
+	// }
 
 	private function new(readable: Bool) {
 		this.readable = readable;
@@ -85,11 +119,35 @@ class Image implements Canvas implements Resource {
 		}
 	}
 
+	private static function getTextureFormat(format: TextureFormat): Int {
+		switch (format) {
+		case RGBA32:
+			return 0;
+		case RGBA128:
+			return 3;
+		case RGBA64:
+			return 4;
+		case A32:
+			return 5;
+		case A16:
+			return 7;
+		default:
+			return 1; // Grey8
+		}
+	}
+
 	public static function create2(width: Int, height: Int, format: TextureFormat, readable: Bool, renderTarget: Bool, depthStencil: DepthStencilFormat, contextId: Int): Image {
 		var image = new Image(readable);
 		image.format = format;
 		if (renderTarget) image.initRenderTarget(width, height, getDepthBufferBits(depthStencil), getRenderTargetFormat(format), getStencilBufferBits(depthStencil), contextId);
 		else image.init(width, height, format == TextureFormat.RGBA32 ? 0 : 1);
+		return image;
+	}
+
+	public static function create3(width: Int, height: Int, depth: Int, format: TextureFormat, readable: Bool, contextId: Int): Image {
+		var image = new Image(readable);
+		image.format = format;
+		image.init3D(width, height, depth, getTextureFormat(format));
 		return image;
 	}
 
@@ -100,6 +158,11 @@ class Image implements Canvas implements Resource {
 
 	private function init(width: Int, height: Int, format: Int): Void {
 		_texture = kore_texture_create(width, height, format, readable);
+		_renderTarget = null;
+	}
+
+	private function init3D(width: Int, height: Int, depth:Int, format: Int): Void {
+		_texture = kore_texture_create3d(width, height, depth, format, readable);
 		_renderTarget = null;
 	}
 
@@ -187,23 +250,20 @@ class Image implements Canvas implements Resource {
 		return _texture != null ? kore_texture_get_real_height(_texture) : kore_render_target_get_real_height(_renderTarget);
 	}
 
-	//@:functionCode("return (texture->at(x, y) & 0xff) != 0;")
 	public function isOpaque(x: Int, y: Int): Bool {
-		return true;
+		return atInternal(x, y) & 0xff != 0;
 	}
 
-	//@:functionCode('return texture->at(x, y);')
 	private function atInternal(x: Int, y: Int): Int {
-		return 0;
+		return kore_texture_at(_texture, x, y);
 	}
 
 	public inline function at(x: Int, y: Int): Color {
 		return Color.fromValue(atInternal(x, y));
 	}
 
-	//@:functionCode("delete texture; texture = nullptr; delete renderTarget; renderTarget = nullptr;")
 	public function unload(): Void {
-
+		_texture != null ? kore_texture_unload(_texture) : kore_render_target_unload(_renderTarget);
 	}
 
 	private var bytes: Bytes = null;
@@ -228,15 +288,15 @@ class Image implements Canvas implements Resource {
 	}
 
 	public function generateMipmaps(levels: Int): Void {
-		//untyped __cpp__("texture->generateMipmaps(levels)");
+		_texture != null ? kore_generate_mipmaps_texture(_texture, levels) : kore_generate_mipmaps_target(_renderTarget, levels);
 	}
 
 	public function setMipmaps(mipmaps: Array<Image>): Void {
-		/*for (i in 0...mipmaps.length) {
+		for (i in 0...mipmaps.length) {
 			var image = mipmaps[i];
 			var level = i + 1;
-			untyped __cpp__("texture->setMipmap(image->texture, level)");
-		}*/
+			kore_set_mipmap_texture(_texture, image._texture, level);
+		}
 	}
 
 	public function setDepthStencilFrom(image: Image): Void {
@@ -244,20 +304,30 @@ class Image implements Canvas implements Resource {
 	}
 
 	public function clear(x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void {
-		
+		kore_texture_clear(_texture, x, y, z, width, height, depth, color);
 	}
 	
 	@:hlNative("std", "kore_texture_create") static function kore_texture_create(width: Int, height: Int, format: Int, readable: Bool): Pointer { return null; }
 	@:hlNative("std", "kore_texture_create_from_file") static function kore_texture_create_from_file(filename: hl.Bytes, readable: Bool): Pointer { return null; }
+	@:hlNative("std", "kore_texture_create3d") static function kore_texture_create3d(width: Int, height: Int, depth: Int, format: Int, readable: Bool): Pointer { return null; }
+	@:hlNative("std", "kore_texture_from_bytes") static function kore_texture_from_bytes(bytes: Pointer, width: Int, height: Int, format: Int, readable: Bool): Pointer { return null; }
+	@:hlNative("std", "kore_texture_from_bytes3d") static function kore_texture_from_bytes3d(bytes: Pointer, width: Int, height: Int, depth: Int, format: Int, readable: Bool): Pointer { return null; }
 	@:hlNative("std", "kore_non_pow2_textures_supported") static function kore_non_pow2_textures_supported(): Bool { return false; }
 	@:hlNative("std", "kore_texture_get_width") static function kore_texture_get_width(texture: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_texture_get_height") static function kore_texture_get_height(texture: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_texture_get_real_width") static function kore_texture_get_real_width(texture: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_texture_get_real_height") static function kore_texture_get_real_height(texture: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_texture_at") static function kore_texture_at(texture: Pointer, x: Int, y: Int): Int { return 0; }
+	@:hlNative("std", "kore_texture_unload") static function kore_texture_unload(texture: Pointer): Void { }
+	@:hlNative("std", "kore_render_target_unload") static function kore_render_target_unload(renderTarget: Pointer): Void { }
 	@:hlNative("std", "kore_render_target_create") static function kore_render_target_create(width: Int, height: Int, depthBufferBits: Int, format: Int, stencilBufferBits: Int, contextId: Int): Pointer { return null; }
 	@:hlNative("std", "kore_render_target_get_width") static function kore_render_target_get_width(renderTarget: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_render_target_get_height") static function kore_render_target_get_height(renderTarget: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_render_target_get_real_width") static function kore_render_target_get_real_width(renderTarget: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_render_target_get_real_height") static function kore_render_target_get_real_height(renderTarget: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_generate_mipmaps_texture") static function kore_generate_mipmaps_texture(texture: Pointer, levels: Int): Void { }
+	@:hlNative("std", "kore_generate_mipmaps_target") static function kore_generate_mipmaps_target(renderTarget: Pointer, levels: Int): Void { }
+	@:hlNative("std", "kore_set_mipmap_texture") static function kore_set_mipmap_texture(texture: Pointer, mipmap: Pointer, level: Int): Void { }
 	@:hlNative("std", "kore_render_target_set_depth_stencil_from") static function kore_render_target_set_depth_stencil_from(renderTarget: Pointer, from: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_texture_clear") static function kore_texture_clear(texture: Pointer, x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Color): Void { }
 }

--- a/Backends/KoreHL/kha/Image.hx
+++ b/Backends/KoreHL/kha/Image.hx
@@ -283,8 +283,28 @@ class Image implements Canvas implements Resource {
 		bytes = null;
 	}
 
+	private var pixels: Bytes = null;
 	public function getPixels(): Bytes {
-		return null;
+		if (_renderTarget == null) return null;
+		if (pixels == null) {
+			var size = formatByteSize(format) * width * height;
+			pixels = Bytes.alloc(size);
+		}
+		kore_render_target_get_pixels(_renderTarget, pixels.getData().bytes);
+		return pixels;
+	}
+
+	private static function formatByteSize(format: TextureFormat): Int {
+		return switch(format) {
+			case RGBA32: 4;
+			case L8: 1;
+			case RGBA128: 16;
+			case DEPTH16: 2;
+			case RGBA64: 8;
+			case A32: 4;
+			case A16: 2;
+			default: 4;
+		}
 	}
 
 	public function generateMipmaps(levels: Int): Void {
@@ -325,6 +345,7 @@ class Image implements Canvas implements Resource {
 	@:hlNative("std", "kore_render_target_get_height") static function kore_render_target_get_height(renderTarget: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_render_target_get_real_width") static function kore_render_target_get_real_width(renderTarget: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_render_target_get_real_height") static function kore_render_target_get_real_height(renderTarget: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_render_target_get_pixels") static function kore_render_target_get_pixels(renderTarget: Pointer, pixels: Pointer): Void { }
 	@:hlNative("std", "kore_generate_mipmaps_texture") static function kore_generate_mipmaps_texture(texture: Pointer, levels: Int): Void { }
 	@:hlNative("std", "kore_generate_mipmaps_target") static function kore_generate_mipmaps_target(renderTarget: Pointer, levels: Int): Void { }
 	@:hlNative("std", "kore_set_mipmap_texture") static function kore_set_mipmap_texture(texture: Pointer, mipmap: Pointer, level: Int): Void { }

--- a/Backends/KoreHL/kha/SystemImpl.hx
+++ b/Backends/KoreHL/kha/SystemImpl.hx
@@ -22,6 +22,9 @@ class SystemImpl {
 	private static var surface: Surface;
 	
 	public static function init(options: SystemOptions, callback: Void -> Void): Void {
+		// haxe.Log.trace = function(v, ?infos) {
+			// kore_log(StringHelper.convert(v));
+		// };
 		init_kore(StringHelper.convert(options.title), options.width, options.height);
 		Shaders.init();
 		var g4 = new kha.korehl.graphics4.Graphics();
@@ -255,6 +258,7 @@ class SystemImpl {
 	}
 	
 	@:hlNative("std", "init_kore") static function init_kore(title: hl.Bytes, width: Int, height: Int): Void { }
+	@:hlNative("std", "kore_log") static function kore_log(v: hl.Bytes): Void { }
 	@:hlNative("std", "kore_get_time") static function kore_get_time(): Float { return 0; }
 	@:hlNative("std", "kore_get_window_width") static function kore_get_window_width(window: Int): Int { return 0; }
 	@:hlNative("std", "kore_get_window_height") static function kore_get_window_height(window: Int): Int { return 0; }

--- a/Backends/KoreHL/kha/SystemImpl.hx
+++ b/Backends/KoreHL/kha/SystemImpl.hx
@@ -72,6 +72,7 @@ class SystemImpl {
 		}
 	}
 	
+	@:keep
 	public static function frame(): Void {
 		Scheduler.executeFrame();
 		System.render(0, framebuffer);

--- a/Backends/KoreHL/kha/SystemImpl.hx
+++ b/Backends/KoreHL/kha/SystemImpl.hx
@@ -20,12 +20,13 @@ class SystemImpl {
 	private static var gamepad3: Gamepad;
 	private static var gamepad4: Gamepad;
 	private static var surface: Surface;
+	private static var mouseLockListeners: Array<Void->Void>;
 	
 	public static function init(options: SystemOptions, callback: Void -> Void): Void {
 		// haxe.Log.trace = function(v, ?infos) {
 			// kore_log(StringHelper.convert(v));
 		// };
-		init_kore(StringHelper.convert(options.title), options.width, options.height);
+		init_kore(StringHelper.convert(options.title), options.width, options.height, options.samplesPerPixel, options.vSync, translateWindowMode(options.windowMode), options.resizable, options.maximizable, options.minimizable);
 		Shaders.init();
 		var g4 = new kha.korehl.graphics4.Graphics();
 		framebuffer = new Framebuffer(0, null, null, g4);
@@ -42,7 +43,17 @@ class SystemImpl {
 		gamepad4 = new kha.input.Gamepad(3);
 		surface = new kha.input.Surface();
 		kore_register_keyboard(keyDown, keyUp, keyPress);
-		kore_register_mouse(mouseDown, mouseUp, mouseMove);
+		kore_register_mouse(mouseDown, mouseUp, mouseMove, mouseWheel);
+		kore_register_pen(penDown, penUp, penMove);
+		kore_register_gamepad(0, gamepad1Axis, gamepad1Button);
+		kore_register_gamepad(1, gamepad2Axis, gamepad2Button);
+		kore_register_gamepad(2, gamepad3Axis, gamepad3Button);
+		kore_register_gamepad(3, gamepad4Axis, gamepad4Button);
+		kore_register_surface(touchStart, touchEnd, touchMove);
+		kore_register_sensor(kha.input.Sensor._accelerometerChanged, kha.input.Sensor._gyroscopeChanged);
+		kore_register_callbacks(foreground, resume, pause, background, shutdown);
+		kore_register_dropfiles(dropFiles);
+		kore_register_copycutpaste(copy, cut, paste);
 		Scheduler.init();
 		Scheduler.start();
 		callback();
@@ -50,6 +61,15 @@ class SystemImpl {
 	
 	public static function initEx(title: String, options: Array<WindowOptions>, windowCallback: Int -> Void, callback: Void -> Void): Void {
 
+	}
+
+	static function translateWindowMode(value: Null<WindowMode>): Int {
+		if (value == null) return 0;
+		return switch (value) {
+			case Window: 0;
+			case BorderlessWindow: 1;
+			case Fullscreen: 2;
+		}
 	}
 	
 	public static function frame(): Void {
@@ -70,7 +90,7 @@ class SystemImpl {
 	}
 
 	public static function screenDpi(): Int {
-		return 96;
+		return kore_get_screen_dpi();
 	}
 	
 	public static function getVsync(): Bool {
@@ -85,13 +105,13 @@ class SystemImpl {
 		return ScreenRotation.RotationNone;
 	}
 
-	//@:functionCode('return ::String(Kore::System::systemId());')
 	public static function getSystemId(): String {
+		// return kore_get_system_id();
 		return 'HL';
 	}
 	
 	public static function requestShutdown(): Void {
-		
+		kore_request_shutdown();
 	}
 	
 	public static function getMouse(num: Int): Mouse {
@@ -109,28 +129,42 @@ class SystemImpl {
 		return keyboard;
 	}
 		
-	public static function lockMouse(): Void {
-		
+	public static function lockMouse(windowId: Int = 0): Void {
+		if (!isMouseLocked()) {
+			kore_mouse_lock(windowId);
+			for (listener in mouseLockListeners) {
+				listener();
+			}
+		}
 	}
 	
-	public static function unlockMouse(): Void {
-		
+	public static function unlockMouse(windowId: Int = 0): Void {
+		if (isMouseLocked()) {
+			kore_mouse_unlock(windowId);
+			for (listener in mouseLockListeners) {
+				listener();
+			}
+		}
 	}
 
-	public static function canLockMouse(): Bool {
-		return false;
+	public static function canLockMouse(windowId: Int = 0): Bool {
+		return kore_can_lock_mouse(windowId);
 	}
 
-	public static function isMouseLocked(): Bool {
-		return false;
+	public static function isMouseLocked(windowId: Int = 0): Bool {
+		return kore_is_mouse_locked(windowId);
 	}
 
 	public static function notifyOfMouseLockChange(func: Void -> Void, error: Void -> Void): Void{
-		
+		if (canLockMouse(0) && func != null) {
+			mouseLockListeners.push(func);
+		}
 	}
 
 	public static function removeFromMouseLockChange(func : Void -> Void, error  : Void -> Void) : Void{
-		
+		if (canLockMouse(0) && func != null) {
+			mouseLockListeners.remove(func);
+		}
 	}
 
 	public static function keyDown(code: KeyCode): Void {
@@ -155,6 +189,14 @@ class SystemImpl {
 
 	public static function mouseMove(windowId: Int, x: Int, y: Int, movementX: Int, movementY: Int): Void {
 		mouse.sendMoveEvent(windowId, x, y, movementX, movementY);
+	}
+
+	public static function mouseWheel(windowId: Int, delta: Int): Void {
+		mouse.sendWheelEvent(windowId, delta);
+	}
+
+	public static function mouseLeave(windowId: Int): Void {
+		mouse.sendLeaveEvent(windowId);
 	}
 
 	public static function penDown(windowId: Int, x: Int, y: Int, pressure: Float): Void {
@@ -213,57 +255,145 @@ class SystemImpl {
 		surface.sendMoveEvent(index, x, y);
 	}
 
-	static function unload(): Void {
-		
+	public static function foreground(): Void {
+		System.foreground();
+	}
+
+	public static function resume(): Void {
+		System.resume();
+	}
+
+	public static function pause(): Void {
+		System.pause();
+	}
+
+	public static function background(): Void {
+		System.background();
+	}
+
+	public static function shutdown(): Void {
+		System.shutdown();
+	}
+
+	public static function dropFiles(filePath: String): Void {
+		System.dropFiles(filePath);
 	}
 	
+	public static function copy(): String {
+		if (System.copyListener != null) {
+			return System.copyListener();
+		}
+		else {
+			return null;
+		}
+	}
+	
+	public static function cut(): String {
+		if (System.cutListener != null) {
+			return System.cutListener();
+		}
+		else {
+			return null;
+		}
+	}
+	
+	public static function paste(data: String): Void {
+		if (System.pasteListener != null) {
+			System.pasteListener(data);
+		}
+	}
+	
+	private static var fullscreenListeners: Array<Void->Void> = new Array();
+	private static var previousWidth: Int = 0;
+	private static var previousHeight: Int = 0;
+
 	public static function canSwitchFullscreen(): Bool {
-		return false;
+		return true;
 	}
 
 	public static function isFullscreen(): Bool {
-		return false;
+		return kore_system_is_fullscreen();
 	}
 
 	public static function requestFullscreen(): Void {
-		
+		if(!isFullscreen()){
+			previousWidth = kore_get_window_width(0);
+			previousHeight = kore_get_window_height(0);
+			kore_system_request_fullscreen();
+			for (listener in fullscreenListeners) {
+				listener();
+			}
+		}
 	}
 
 	public static function exitFullscreen(): Void {
-		
+		if (isFullscreen()) {
+			if (previousWidth == 0 || previousHeight == 0){
+				previousWidth = kore_get_window_width(0);
+				previousHeight = kore_get_window_height(0);
+			}
+			kore_system_exit_fullscreen(previousWidth, previousHeight);
+			for (listener in fullscreenListeners) {
+				listener();
+			}
+		}
 	}
 
 	public static function notifyOfFullscreenChange(func: Void -> Void, error: Void -> Void): Void {
-		
+		if (canSwitchFullscreen() && func != null) {
+			fullscreenListeners.push(func);
+		}
 	}
 
-
 	public static function removeFromFullscreenChange(func: Void -> Void, error: Void -> Void): Void {
-		
+		if (canSwitchFullscreen() && func != null) {
+			fullscreenListeners.remove(func);
+		}
 	}
 
 	public static function changeResolution(width: Int, height: Int): Void {
-		
+		kore_system_change_resolution(width, height);
 	}
 	
 	public static function setKeepScreenOn(on: Bool): Void {
-		
+		kore_system_set_keepscreenon(on);
 	}
 
 	public static function loadUrl(url: String): Void {
-		
+		kore_system_load_url(StringHelper.convert(url));
 	}
 
 	public static function getGamepadId(index: Int): String {
-		return "unknown";
+		return "";//kore_get_gamepad_id(index);
 	}
 	
-	@:hlNative("std", "init_kore") static function init_kore(title: hl.Bytes, width: Int, height: Int): Void { }
+	@:hlNative("std", "init_kore") static function init_kore(title: hl.Bytes, width: Int, height: Int, antialiasing: Int, vSync: Bool, windowMode: Int, resizable: Bool, maximizable: Bool, minimizable: Bool): Void { }
 	@:hlNative("std", "kore_init_audio") static function kore_init_audio(callCallback:Int->Void, readSample:Void->FastFloat): Void { }
 	@:hlNative("std", "kore_log") static function kore_log(v: hl.Bytes): Void { }
 	@:hlNative("std", "kore_get_time") static function kore_get_time(): Float { return 0; }
 	@:hlNative("std", "kore_get_window_width") static function kore_get_window_width(window: Int): Int { return 0; }
 	@:hlNative("std", "kore_get_window_height") static function kore_get_window_height(window: Int): Int { return 0; }
+	@:hlNative("std", "kore_get_screen_dpi") static function kore_get_screen_dpi(): Int { return 0; }
+	@:hlNative("std", "kore_get_system_id") static function kore_get_system_id(): hl.Bytes { return null; }
+	@:hlNative("std", "kore_request_shutdown") static function kore_request_shutdown(): Void { }
+	@:hlNative("std", "kore_mouse_lock") static function kore_mouse_lock(windowId: Int): Void { }
+	@:hlNative("std", "kore_mouse_unlock") static function kore_mouse_unlock(windowId: Int): Void { }
+	@:hlNative("std", "kore_can_lock_mouse") static function kore_can_lock_mouse(windowId: Int): Bool { return false; }
+	@:hlNative("std", "kore_is_mouse_locked") static function kore_is_mouse_locked(windowId: Int): Bool { return false; }
+	@:hlNative("std", "kore_system_is_fullscreen") static function kore_system_is_fullscreen(): Bool { return false; }
+	@:hlNative("std", "kore_system_request_fullscreen") static function kore_system_request_fullscreen(): Void { }
+	@:hlNative("std", "kore_system_exit_fullscreen") static function kore_system_exit_fullscreen(previousWidth: Int, previousHeight: Int): Void { }
 	@:hlNative("std", "kore_register_keyboard") static function kore_register_keyboard(keyDown: KeyCode->Void, keyUp: KeyCode->Void, keyPress: Int->Void): Void { }
-	@:hlNative("std", "kore_register_mouse") static function kore_register_mouse(mouseDown: Int->Int->Int->Int->Void, mouseUp: Int->Int->Int->Int->Void, mouseMove: Int->Int->Int->Int->Int->Void): Void { }
+	@:hlNative("std", "kore_register_mouse") static function kore_register_mouse(mouseDown: Int->Int->Int->Int->Void, mouseUp: Int->Int->Int->Int->Void, mouseMove: Int->Int->Int->Int->Int->Void, mouseWheel: Int->Int->Void): Void { }
+	@:hlNative("std", "kore_register_pen") static function kore_register_pen(penDown: Int->Int->Int->Float->Void, penUp: Int->Int->Int->Float->Void, penMove: Int->Int->Int->Float->Void): Void { }
+	@:hlNative("std", "kore_register_gamepad") static function kore_register_gamepad(index: Int, gamepadAxis: Int->Float->Void, gamepadButton: Int->Float->Void): Void { }
+	@:hlNative("std", "kore_register_surface") static function kore_register_surface(touchStart: Int->Int->Int->Void, touchEnd: Int->Int->Int->Void, touchMove: Int->Int->Int->Void): Void { }
+	@:hlNative("std", "kore_register_sensor") static function kore_register_sensor(accelerometerChanged: Float->Float->Float->Void, gyroscopeChanged: Float->Float->Float->Void): Void { }
+	@:hlNative("std", "kore_register_callbacks") static function kore_register_callbacks(foreground: Void->Void, resume: Void->Void, pause: Void->Void, background: Void->Void, shutdown: Void->Void): Void { }
+	@:hlNative("std", "kore_register_dropfiles") static function kore_register_dropfiles(dropFiles: String->Void): Void { }
+	@:hlNative("std", "kore_register_copycutpaste") static function kore_register_copycutpaste(copy: Void->String, cut: Void->String, paste: String->Void): Void { }
+	@:hlNative("std", "kore_system_change_resolution") static function kore_system_change_resolution(width: Int, height: Int): Void { }
+	@:hlNative("std", "kore_system_set_keepscreenon") static function kore_system_set_keepscreenon(on: Bool): Void { }
+	@:hlNative("std", "kore_system_load_url") static function kore_system_load_url(url: hl.Bytes): Void { }
+	@:hlNative("std", "kore_get_gamepad_id") static function kore_get_gamepad_id(index: Int): hl.Bytes { return null; }
 }

--- a/Backends/KoreHL/kha/SystemImpl.hx
+++ b/Backends/KoreHL/kha/SystemImpl.hx
@@ -30,8 +30,9 @@ class SystemImpl {
 		var g4 = new kha.korehl.graphics4.Graphics();
 		framebuffer = new Framebuffer(0, null, null, g4);
 		framebuffer.init(new kha.graphics2.Graphics1(framebuffer), new kha.korehl.graphics4.Graphics2(framebuffer), g4);
-		//kha.audio2.Audio._init();
-		//kha.audio1.Audio._init();
+		kha.audio2.Audio._init();
+		kha.audio1.Audio._init();
+		kore_init_audio(kha.audio2.Audio._callCallback, kha.audio2.Audio._readSample);
 		keyboard = new kha.input.Keyboard();
 		mouse = new kha.input.MouseImpl();
 		pen = new kha.input.Pen();
@@ -258,6 +259,7 @@ class SystemImpl {
 	}
 	
 	@:hlNative("std", "init_kore") static function init_kore(title: hl.Bytes, width: Int, height: Int): Void { }
+	@:hlNative("std", "kore_init_audio") static function kore_init_audio(callCallback:Int->Void, readSample:Void->FastFloat): Void { }
 	@:hlNative("std", "kore_log") static function kore_log(v: hl.Bytes): Void { }
 	@:hlNative("std", "kore_get_time") static function kore_get_time(): Float { return 0; }
 	@:hlNative("std", "kore_get_window_width") static function kore_get_window_width(window: Int): Int { return 0; }

--- a/Backends/KoreHL/kha/arrays/Float32Array.hx
+++ b/Backends/KoreHL/kha/arrays/Float32Array.hx
@@ -2,25 +2,47 @@ package kha.arrays;
 
 import kha.FastFloat;
 
-abstract Float32Array(haxe.io.Bytes) {
+class Float32ArrayPrivate {
+	// Has to be wrapped in class..
+	public var self: Pointer;
+	public var length: Int;
+	public inline function new() {}
+}
+
+abstract Float32Array(Float32ArrayPrivate) {
 	
-	public inline function new(elements: Int) {
-		this = haxe.io.Bytes.alloc(elements * 4);
+	public inline function new(elements: Int = 0) {
+		this = new Float32ArrayPrivate();
+		this.length = elements;
+		if (elements > 0) this.self = kore_float32array_alloc(elements);
+	}
+
+	public inline function free(): Void {
+		kore_float32array_free(this.self);
 	}
 	
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
-		return Std.int(this.length / 4);
+		return this.length;
+	}
+
+	public inline function getData():Pointer {
+		return this.self;
+	}
+
+	public inline function setData(ar:Pointer, elements: Int): Void {
+		this.self = ar;
+		this.length = elements;
 	}
 	
 	public inline function set(index: Int, value: FastFloat): FastFloat {
-		this.setFloat(index * 4, value);
+		kore_float32array_set(this.self, index, value);
 		return value;
 	}
 	
 	public inline function get(index: Int): FastFloat {
-		return this.getFloat(index * 4);
+		return kore_float32array_get(this.self, index);
 	}
 
 	@:arrayAccess
@@ -33,7 +55,8 @@ abstract Float32Array(haxe.io.Bytes) {
 		return set(index, value);
 	}
 
-	public function getData():haxe.io.BytesData {
-		return this.getData();
-	}
+	@:hlNative("std", "kore_float32array_alloc") static function kore_float32array_alloc(elements: Int): Pointer { return null; }
+	@:hlNative("std", "kore_float32array_free") static function kore_float32array_free(f32array: Pointer): Void { }
+	@:hlNative("std", "kore_float32array_set") static function kore_float32array_set(f32array: Pointer, index: Int, value: FastFloat): Void { }
+	@:hlNative("std", "kore_float32array_get") static function kore_float32array_get(f32array: Pointer, index: Int): FastFloat { return 0.0; }
 }

--- a/Backends/KoreHL/kha/arrays/Uint32Array.hx
+++ b/Backends/KoreHL/kha/arrays/Uint32Array.hx
@@ -1,24 +1,46 @@
 package kha.arrays;
 
-abstract Uint32Array(haxe.io.Bytes) {
+class Uint32ArrayPrivate {
+	// Has to be wrapped in class..
+	public var self: Pointer;
+	public var length: Int;
+	public inline function new() {}
+}
+
+abstract Uint32Array(Uint32ArrayPrivate) {
 	
-	public inline function new(elements: Int) {
-		this = haxe.io.Bytes.alloc(elements * 4);
+	public inline function new(elements: Int = 0) {
+		this = new Uint32ArrayPrivate();
+		this.length = elements;
+		if (elements > 0) this.self = kore_uint32array_alloc(elements);
+	}
+
+	public inline function free(): Void {
+		kore_uint32array_free(this.self);
 	}
 	
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
-		return Std.int(this.length / 4);
+		return this.length;
+	}
+
+	public inline function getData():Pointer {
+		return this.self;
+	}
+
+	public inline function setData(ar:Pointer, elements: Int): Void {
+		this.self = ar;
+		this.length = elements;
 	}
 	
 	public inline function set(index: Int, value: Int): Int {
-		this.setInt32(index * 4, value);
+		kore_uint32array_set(this.self, index, value);
 		return value;
 	}
 	
 	public inline function get(index: Int): Int {
-		return this.getInt32(index * 4);
+		return kore_uint32array_get(this.self, index);
 	}
 
 	@:arrayAccess
@@ -30,4 +52,9 @@ abstract Uint32Array(haxe.io.Bytes) {
 	public inline function arrayWrite(index: Int, value: Int): Int {
 		return set(index, value);
 	}
+
+	@:hlNative("std", "kore_uint32array_alloc") static function kore_uint32array_alloc(elements: Int): Pointer { return null; }
+	@:hlNative("std", "kore_uint32array_free") static function kore_uint32array_free(f32array: Pointer): Void { }
+	@:hlNative("std", "kore_uint32array_set") static function kore_uint32array_set(f32array: Pointer, index: Int, value: Int): Void { }
+	@:hlNative("std", "kore_uint32array_get") static function kore_uint32array_get(f32array: Pointer, index: Int): Int { return 0; }
 }

--- a/Backends/KoreHL/kha/audio2/Audio.hx
+++ b/Backends/KoreHL/kha/audio2/Audio.hx
@@ -3,12 +3,41 @@ package kha.audio2;
 import kha.Sound;
 
 class Audio {
-	public static var audioCallback: Int->Buffer->Void;
-	
-	public static function play(sound: Sound, loop: Bool = false): kha.audio1.AudioChannel {
-		return null;
+	private static var buffer: Buffer;
+
+	public static function _init() {
+		var bufferSize = 1024 * 2;
+		buffer = new Buffer(bufferSize * 4, 2, 44100);
 	}
-	
+
+	public static function _callCallback(samples: Int): Void {
+		if (buffer == null) return;
+		if (audioCallback != null) {
+			audioCallback(samples, buffer);
+		}
+		else {
+			for (i in 0...samples) {
+				buffer.data.set(buffer.writeLocation, 0);
+				buffer.writeLocation += 1;
+				if (buffer.writeLocation >= buffer.size) {
+					buffer.writeLocation = 0;
+				}
+			}
+		}
+	}
+
+	public static function _readSample(): FastFloat {
+		if (buffer == null) return 0;
+		var value: FastFloat = buffer.data.get(buffer.readLocation);
+		++buffer.readLocation;
+		if (buffer.readLocation >= buffer.size) {
+			buffer.readLocation = 0;
+		}
+		return value;
+	}
+
+	public static var audioCallback: Int->Buffer->Void;
+
 	public static function stream(sound: Sound, loop: Bool = false): kha.audio1.AudioChannel {
 		return null;
 	}

--- a/Backends/KoreHL/kha/audio2/StreamChannel.hx
+++ b/Backends/KoreHL/kha/audio2/StreamChannel.hx
@@ -1,0 +1,74 @@
+package kha.audio2;
+
+import haxe.ds.Vector;
+import haxe.io.Bytes;
+
+class StreamChannel implements kha.audio1.AudioChannel {
+	private var _vorbis:Pointer;
+	private var atend: Bool = false;
+	@:keep private var loop: Bool;
+	private var myVolume: Float;
+	private var paused: Bool = false;
+	
+	public function new(data: Bytes, loop: Bool) {
+		myVolume = 1;
+		this.loop = loop;
+		_vorbis = kore_sound_init_vorbis(data.getData().bytes, data.length);
+	}
+
+	public function nextSamples(samples: kha.arrays.Float32Array, length: Int, sampleRate: Int): Void {
+		if (paused) {
+			for (i in 0...length) {
+				samples[i] = 0;
+			}
+			return;
+		}
+		
+		atend = kore_sound_next_vorbis_samples(_vorbis, samples.getData(), length, loop, atend);
+	}
+	
+	public function play(): Void {
+		paused = false;
+	}
+
+	public function pause(): Void {
+		paused = true;
+	}
+
+	public function stop(): Void {
+		atend = true;
+	}
+
+	public var length(get, null): Int; // Miliseconds
+	
+	private function get_length(): Int {
+		return kore_sound_vorbis_get_length(_vorbis);
+	}
+
+	public var position(get, null): Int; // Miliseconds
+	
+	private function get_position(): Int {
+		return kore_sound_vorbis_get_position(_vorbis);
+	}
+	
+	public var volume(get, set): Float;
+	
+	private function get_volume(): Float {
+		return myVolume;
+	}
+
+	private function set_volume(value: Float): Float {
+		return myVolume = value;
+	}
+
+	public var finished(get, null): Bool;
+
+	private function get_finished(): Bool {
+		return atend;
+	}
+
+	@:hlNative("std", "kore_sound_init_vorbis") static function kore_sound_init_vorbis(data: Pointer, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_sound_next_vorbis_samples") static function kore_sound_next_vorbis_samples(vorbis: Pointer, samples: Pointer, length: Int, loop: Bool, atend: Bool): Bool { return false; }
+	@:hlNative("std", "kore_sound_vorbis_get_length") static function kore_sound_vorbis_get_length(vorbis: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_sound_vorbis_get_position") static function kore_sound_vorbis_get_position(vorbis: Pointer): Int { return 0; }
+}

--- a/Backends/KoreHL/kha/compute/Compute.hx
+++ b/Backends/KoreHL/kha/compute/Compute.hx
@@ -1,0 +1,187 @@
+package kha.compute;
+
+import kha.arrays.Float32Array;
+import kha.Image;
+import kha.FastFloat;
+import kha.math.FastMatrix3;
+import kha.math.FastMatrix4;
+import kha.math.FastVector2;
+import kha.math.FastVector3;
+import kha.math.FastVector4;
+import kha.graphics4.CubeMap;
+import kha.graphics4.TextureAddressing;
+import kha.graphics4.TextureFilter;
+import kha.graphics4.MipMapFilter;
+
+class Compute {
+	private static function getAccess(access: Access): Int {
+		switch (access) {
+		case Access.Read:
+			return 0;
+		case Access.Write:
+			return 1;
+		case Access.ReadWrite:
+			return 2;
+		}
+	}
+
+	public static function setBool(location: kha.compute.ConstantLocation, value: Bool): Void {
+		kore_compute_set_bool(location._location, value);
+	}
+	
+	public static function setInt(location: kha.compute.ConstantLocation, value: Int): Void {
+		kore_compute_set_int(location._location, value);
+	}
+
+	public static function setFloat(location: kha.compute.ConstantLocation, value: FastFloat): Void {
+		kore_compute_set_float(location._location, value);
+	}
+	
+	public static function setFloat2(location: kha.compute.ConstantLocation, value1: FastFloat, value2: FastFloat): Void {
+		kore_compute_set_float2(location._location, value1, value2);
+	}
+	
+	public static function setFloat3(location: kha.compute.ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void {
+		kore_compute_set_float3(location._location, value1, value2, value3);
+	}
+	
+	public static function setFloat4(location: kha.compute.ConstantLocation, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void {
+		kore_compute_set_float4(location._location, value1, value2, value3, value4);
+	}
+	
+	public static function setVector2(location: kha.compute.ConstantLocation, value: FastVector2): Void {
+		kore_compute_set_float2(location._location, value.x, value.y);
+	}
+	
+	public static function setVector3(location: kha.compute.ConstantLocation, value: FastVector3): Void {
+		kore_compute_set_float3(location._location, value.x, value.y, value.z);
+	}
+	
+	public static function setVector4(location: kha.compute.ConstantLocation, value: FastVector4): Void {
+		kore_compute_set_float4(location._location, value.x, value.y, value.z, value.w);
+	}
+	
+	public static function setFloats(location: kha.compute.ConstantLocation, values: Float32Array): Void {
+		kore_compute_set_floats(location._location, values.getData(), values.length);
+	}
+	
+	public static function setMatrix(location: kha.compute.ConstantLocation, matrix: FastMatrix4): Void {
+		kore_compute_set_matrix(location._location,
+			matrix._00, matrix._10, matrix._20, matrix._30,
+			matrix._01, matrix._11, matrix._21, matrix._31,
+			matrix._02, matrix._12, matrix._22, matrix._32,
+			matrix._03, matrix._13, matrix._23, matrix._33);
+	}
+
+	public static function setMatrix3(location: kha.compute.ConstantLocation, matrix: FastMatrix3): Void {
+		kore_compute_set_matrix3(location._location,
+			matrix._00, matrix._10, matrix._20,
+			matrix._01, matrix._11, matrix._21,
+			matrix._02, matrix._12, matrix._22);
+	}
+
+	public static function setBuffer(buffer: ShaderStorageBuffer, index: Int) {
+		// Kore::Compute::setBuffer(buffer->buffer, index);
+	}
+
+	public static function setTexture(unit: TextureUnit, texture: Image, access: Access) {
+		if (texture._texture != null) kore_compute_set_texture(unit._unit, texture._texture, getAccess(access));
+		else kore_compute_set_target(unit._unit, texture._renderTarget, getAccess(access));
+	}
+
+	public static function setSampledTexture(unit: TextureUnit, texture: Image) {
+		if (texture._texture != null) kore_compute_set_sampled_texture(unit._unit, texture._texture);
+		else kore_compute_set_sampled_target(unit._unit, texture._renderTarget);
+	}
+
+	public static function setSampledDepthTexture(unit: TextureUnit, texture: Image) {
+		kore_compute_set_sampled_depth_target(unit._unit, texture._renderTarget);
+	}
+
+	public static function setSampledCubeMap(unit: TextureUnit, cubeMap: CubeMap) {
+		if (cubeMap._texture != null) kore_compute_set_sampled_cubemap_texture(unit._unit, cubeMap._texture);
+		else kore_compute_set_sampled_cubemap_target(unit._unit, cubeMap._renderTarget);
+	}
+
+	public static function setSampledDepthCubeMap(unit: TextureUnit, cubeMap: CubeMap) {
+		kore_compute_set_sampled_cubemap_depth_target(unit._unit, cubeMap._renderTarget);
+	}
+	
+	private static function getTextureAddressing(addressing: TextureAddressing): Int {
+		switch (addressing) {
+		case TextureAddressing.Repeat:
+			return 0;
+		case TextureAddressing.Mirror:
+			return 1;
+		case TextureAddressing.Clamp:
+			return 2;
+		}
+	}
+	
+	private static function getTextureFilter(filter: TextureFilter): Int {
+		switch (filter) {
+		case PointFilter:
+			return 0;
+		case LinearFilter:
+			return 1;
+		case AnisotropicFilter:
+			return 2;
+		}
+	}
+	
+	private static function getTextureMipMapFilter(filter: MipMapFilter): Int {
+		switch (filter) {
+		case NoMipFilter:
+			return 0;
+		case PointMipFilter:
+			return 1;
+		case LinearMipFilter:
+			return 2;
+		}
+	}
+	
+	public static function setTextureParameters(unit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
+		kore_compute_set_texture_parameters(unit._unit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
+	}
+
+	public static function setTexture3DParameters(unit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
+		kore_compute_set_texture3d_parameters(unit._unit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureAddressing(wAddressing), getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
+	}
+
+	public static function setShader(shader: Shader) {
+		kore_compute_set_shader(shader._shader);
+	}
+
+	public static function compute(x: Int, y: Int, z: Int) {
+		kore_compute_compute(x, y, z);
+	}
+
+	@:hlNative("std", "kore_compute_set_bool") static function kore_compute_set_bool(location: Pointer, value: Bool): Void { }
+	@:hlNative("std", "kore_compute_set_int") static function kore_compute_set_int(location: Pointer, value: Int): Void { }
+	@:hlNative("std", "kore_compute_set_float") static function kore_compute_set_float(location: Pointer, value: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_float2") static function kore_compute_set_float2(location: Pointer, value1: FastFloat, value2: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_float3") static function kore_compute_set_float3(location: Pointer, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_float4") static function kore_compute_set_float4(location: Pointer, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_floats") static function kore_compute_set_floats(location: Pointer, values: Pointer, count: Int): Void { }
+	@:hlNative("std", "kore_compute_set_matrix") static function kore_compute_set_matrix(location: Pointer,
+		_00: FastFloat, _10: FastFloat, _20: FastFloat, _30: FastFloat,
+		_01: FastFloat, _11: FastFloat, _21: FastFloat, _31: FastFloat,
+		_02: FastFloat, _12: FastFloat, _22: FastFloat, _32: FastFloat,
+		_03: FastFloat, _13: FastFloat, _23: FastFloat, _33: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_matrix3") static function kore_compute_set_matrix3(location: Pointer,
+		_00: FastFloat, _10: FastFloat, _20: FastFloat,
+		_01: FastFloat, _11: FastFloat, _21: FastFloat,
+		_02: FastFloat, _12: FastFloat, _22: FastFloat): Void { }
+	@:hlNative("std", "kore_compute_set_texture") static function kore_compute_set_texture(unit: Pointer, texture: Pointer, access: Int): Void { }
+	@:hlNative("std", "kore_compute_set_target") static function kore_compute_set_target(unit: Pointer, renderTarget: Pointer, access: Int): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_texture") static function kore_compute_set_sampled_texture(unit: Pointer, texture: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_target") static function kore_compute_set_sampled_target(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_depth_target") static function kore_compute_set_sampled_depth_target(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_cubemap_texture") static function kore_compute_set_sampled_cubemap_texture(unit: Pointer, texture: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_cubemap_target") static function kore_compute_set_sampled_cubemap_target(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_sampled_cubemap_depth_target") static function kore_compute_set_sampled_cubemap_depth_target(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_compute_set_texture_parameters") static function kore_compute_set_texture_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
+	@:hlNative("std", "kore_compute_set_texture3d_parameters") static function kore_compute_set_texture3d_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, wAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
+	@:hlNative("std", "kore_compute_set_shader") static function kore_compute_set_shader(shader: Pointer): Void { }
+	@:hlNative("std", "kore_compute_compute") static function kore_compute_compute(x: Int, y: Int, z: Int): Void { }
+}

--- a/Backends/KoreHL/kha/compute/ConstantLocation.hx
+++ b/Backends/KoreHL/kha/compute/ConstantLocation.hx
@@ -1,0 +1,9 @@
+package kha.compute;
+
+class ConstantLocation {
+	public var _location: Pointer;
+
+	public function new(location: Pointer) {
+		_location = location;
+	}
+}

--- a/Backends/KoreHL/kha/compute/Shader.hx
+++ b/Backends/KoreHL/kha/compute/Shader.hx
@@ -1,29 +1,28 @@
 package kha.compute;
 
-import haxe.io.Bytes;
 import kha.Blob;
 
 class Shader {
-	public var shader_: Dynamic;
+	public var _shader: Pointer;
 
 	public function new(sources: Array<Blob>, files: Array<String>) {
-		// shader_ = Krom.createShaderCompute(sources[0].toBytes().getData());
+		_shader = kore_compute_create_shader(sources[0].bytes.getData(), sources[0].bytes.getData().length);
 	}
 	
 	public function delete(): Void {
-		// Krom.deleteShaderCompute(shader_);
-		shader_ = null;
+		kore_compute_delete_shader(_shader);
 	}
 	
-	// public function getConstantLocation(name: String): ConstantLocation {
-	public function getConstantLocation(name: String): Dynamic {
-		// return Krom.getConstantLocationCompute(shader_, name);
-		return null;
+	public function getConstantLocation(name: String): ConstantLocation {
+		return new ConstantLocation(kore_compute_get_constantlocation(_shader, StringHelper.convert(name)));
 	}
 	
-	// public function getTextureUnit(name: String): TextureUnit {
-	public function getTextureUnit(name: String): Dynamic {
-		// return Krom.getTextureUnitCompute(shader_, name);
-		return null;
+	public function getTextureUnit(name: String): TextureUnit {
+		return new TextureUnit(kore_compute_get_textureunit(_shader, StringHelper.convert(name)));
 	}
+
+	@:hlNative("std", "kore_compute_create_shader") static function kore_compute_create_shader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_compute_delete_shader") static function kore_compute_delete_shader(shader: Pointer): Void { }
+	@:hlNative("std", "kore_compute_get_constantlocation") static function kore_compute_get_constantlocation(shader: Pointer, name: hl.Bytes): Pointer { return null; }
+	@:hlNative("std", "kore_compute_get_textureunit") static function kore_compute_get_textureunit(shader: Pointer, name: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/compute/ShaderStorageBuffer.hx
+++ b/Backends/KoreHL/kha/compute/ShaderStorageBuffer.hx
@@ -1,0 +1,33 @@
+package kha.compute;
+
+import kha.graphics4.VertexData;
+
+class ShaderStorageBuffer {
+	public var _buffer: Pointer;
+	private var data: Array<Int>;
+	private var myCount: Int;
+	
+	public function new(indexCount: Int, type: VertexData) {
+		
+	}
+  
+	private function init(indexCount: Int, type: VertexData) {
+		
+	}
+	
+	public function delete(): Void {
+		
+	}
+	
+	public function lock(): Array<Int> {
+		return data;
+	}
+	
+	public function unlock(): Void {
+		
+	}
+	
+	public function count(): Int {
+		return myCount;
+	}
+}

--- a/Backends/KoreHL/kha/compute/TextureUnit.hx
+++ b/Backends/KoreHL/kha/compute/TextureUnit.hx
@@ -1,0 +1,9 @@
+package kha.compute;
+
+class TextureUnit {
+	public var _unit:Pointer;
+
+	public function new(unit: Pointer) {
+		_unit = unit;
+	}
+}

--- a/Backends/KoreHL/kha/graphics4/FragmentShader.hx
+++ b/Backends/KoreHL/kha/graphics4/FragmentShader.hx
@@ -7,10 +7,10 @@ class FragmentShader {
 	public var _shader: Pointer;
 	
 	public function new(sources: Array<Blob>, files: Array<String>) {
-		initFragmentShader(sources[0]);
+		initShader(sources[0]);
 	}
 	
-	private function initFragmentShader(source: Blob): Void {
+	private function initShader(source: Blob): Void {
 		_shader = kore_create_fragmentshader(source.bytes.getData(), source.bytes.getData().length); 
 	}
 

--- a/Backends/KoreHL/kha/graphics4/FragmentShader.hx
+++ b/Backends/KoreHL/kha/graphics4/FragmentShader.hx
@@ -1,6 +1,5 @@
 package kha.graphics4;
 
-import haxe.io.Bytes;
 import kha.Blob;
 
 class FragmentShader {
@@ -15,12 +14,11 @@ class FragmentShader {
 	}
 
 	public static function fromSource(source: String): FragmentShader {
-		return null;
-	}
-	
-	public function unused(): Void {
-		var include: Bytes = Bytes.ofString("");
+		var sh = new FragmentShader(null, null);
+		sh._shader = kore_fragmentshader_from_source(StringHelper.convert(source));
+		return sh;
 	}
 	
 	@:hlNative("std", "kore_create_fragmentshader") static function kore_create_fragmentshader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_fragmentshader_from_source") static function kore_fragmentshader_from_source(source: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/GeometryShader.hx
+++ b/Backends/KoreHL/kha/graphics4/GeometryShader.hx
@@ -1,6 +1,5 @@
 package kha.graphics4;
 
-import haxe.io.Bytes;
 import kha.Blob;
 
 class GeometryShader {
@@ -14,13 +13,12 @@ class GeometryShader {
 		_shader = kore_create_geometryshader(source.bytes.getData(), source.bytes.getData().length); 
 	}
 
-	public static function fromSource(source: String): FragmentShader {
-		return null;
-	}
-	
-	public function unused(): Void {
-		var include: Bytes = Bytes.ofString("");
+	public static function fromSource(source: String): GeometryShader {
+		var sh = new GeometryShader(null, null);
+		sh._shader = kore_geometryshader_from_source(StringHelper.convert(source));
+		return sh;
 	}
 	
 	@:hlNative("std", "kore_create_geometryshader") static function kore_create_geometryshader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_geometryshader_from_source") static function kore_geometryshader_from_source(source: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/GeometryShader.hx
+++ b/Backends/KoreHL/kha/graphics4/GeometryShader.hx
@@ -1,0 +1,26 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+import kha.Blob;
+
+class GeometryShader {
+	public var _shader: Pointer;
+	
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		initShader(sources[0]);
+	}
+	
+	private function initShader(source: Blob): Void {
+		_shader = kore_create_geometryshader(source.bytes.getData(), source.bytes.getData().length); 
+	}
+
+	public static function fromSource(source: String): FragmentShader {
+		return null;
+	}
+	
+	public function unused(): Void {
+		var include: Bytes = Bytes.ofString("");
+	}
+	
+	@:hlNative("std", "kore_create_geometryshader") static function kore_create_geometryshader(data: hl.Bytes, length: Int): Pointer { return null; }
+}

--- a/Backends/KoreHL/kha/graphics4/IndexBuffer.hx
+++ b/Backends/KoreHL/kha/graphics4/IndexBuffer.hx
@@ -5,32 +5,24 @@ import haxe.io.BytesData;
 
 class IndexBuffer {
 	public var _buffer: Pointer;
-	public var _data: kha.arrays.Uint32Array;
 	private var myCount: Int;
 	
 	public function new(indexCount: Int, usage: Usage, canRead: Bool = false) {
 		myCount = indexCount;
-		_data = new kha.arrays.Uint32Array(myCount);
-		init(indexCount);
-	}
-	
-	private function init(count: Int) {
-		_buffer = kore_create_indexbuffer(count);
+		_buffer = kore_create_indexbuffer(indexCount);
 	}
 
 	public function delete() {
-		
+		kore_delete_indexbuffer(_buffer);
 	}
 	
 	public function lock(): kha.arrays.Uint32Array {
-		return _data;
+		var u32array = new kha.arrays.Uint32Array();
+		u32array.setData(kore_indexbuffer_lock(_buffer), myCount);
+		return u32array;
 	}
 	
 	public function unlock(): Void {
-		var bytes = Bytes.ofData(new BytesData(kore_indexbuffer_lock(_buffer), myCount * 4));
-		for (i in 0...myCount) {
-			bytes.setInt32(i * 4, _data[i]);
-		}
 		kore_indexbuffer_unlock(_buffer);
 	}
 	
@@ -39,6 +31,7 @@ class IndexBuffer {
 	}
 	
 	@:hlNative("std", "kore_create_indexbuffer") static function kore_create_indexbuffer(count: Int): Pointer { return null; }
+	@:hlNative("std", "kore_delete_indexbuffer") static function kore_delete_indexbuffer(buffer: Pointer): Void { }
 	@:hlNative("std", "kore_indexbuffer_lock") static function kore_indexbuffer_lock(buffer: Pointer): hl.Bytes { return null; }
 	@:hlNative("std", "kore_indexbuffer_unlock") static function kore_indexbuffer_unlock(buffer: Pointer): Void { }
 }

--- a/Backends/KoreHL/kha/graphics4/PipelineState.hx
+++ b/Backends/KoreHL/kha/graphics4/PipelineState.hx
@@ -7,7 +7,7 @@ import kha.graphics4.VertexShader;
 import kha.graphics4.VertexStructure;
 
 class PipelineState extends PipelineStateBase {
-	private var pipeline: Pointer;
+	private var _pipeline: Pointer;
 	
 	public function new() {
 		super();
@@ -15,19 +15,19 @@ class PipelineState extends PipelineStateBase {
 	}
 	
 	private function init(): Void {
-		pipeline = kore_create_pipeline();
+		_pipeline = kore_create_pipeline();
 	}
 
 	public function delete() {
-		
+		kore_delete_pipeline(_pipeline);
 	}
 	
 	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, size: Int): Void {
-		kore_pipeline_set_vertex_shader(pipeline, vertexShader._shader);
-		kore_pipeline_set_fragment_shader(pipeline, fragmentShader._shader);		
-		if (geometryShader != null) kore_pipeline_set_geometry_shader(pipeline, geometryShader._shader);
-		if (tessellationControlShader != null) kore_pipeline_set_tesscontrol_shader(pipeline, tessellationControlShader._shader);
-		if (tessellationEvaluationShader != null) kore_pipeline_set_tesseval_shader(pipeline, tessellationEvaluationShader._shader);
+		kore_pipeline_set_vertex_shader(_pipeline, vertexShader._shader);
+		kore_pipeline_set_fragment_shader(_pipeline, fragmentShader._shader);		
+		if (geometryShader != null) kore_pipeline_set_geometry_shader(_pipeline, geometryShader._shader);
+		if (tessellationControlShader != null) kore_pipeline_set_tesscontrol_shader(_pipeline, tessellationControlShader._shader);
+		if (tessellationEvaluationShader != null) kore_pipeline_set_tesseval_shader(_pipeline, tessellationEvaluationShader._shader);
 
 		var kore_structure = VertexBuffer.kore_create_vertexstructure();
 		for (i in 0...structure0.size()) {
@@ -47,11 +47,11 @@ class PipelineState extends PipelineStateBase {
 			VertexBuffer.kore_vertexstructure_add(kore_structure, StringHelper.convert(structure0.get(i).name), data);
 		}
 		
-		kore_pipeline_compile(pipeline, kore_structure);
+		kore_pipeline_compile(_pipeline, kore_structure);
 	}
 	
 	public function compile(): Void {
-		kore_pipeline_set_states(pipeline,
+		kore_pipeline_set_states(_pipeline,
 			cullMode.getIndex(), depthMode.getIndex(), stencilMode.getIndex(), stencilBothPass.getIndex(), stencilDepthFail.getIndex(), stencilFail.getIndex(),
 			getBlendFunc(blendSource), getBlendFunc(blendDestination), getBlendFunc(alphaBlendSource), getBlendFunc(alphaBlendDestination),
 			depthWrite, stencilReferenceValue, stencilReadMask, stencilWriteMask,
@@ -66,12 +66,12 @@ class PipelineState extends PipelineStateBase {
 	}
 	
 	public function getConstantLocation(name: String): kha.graphics4.ConstantLocation {
-		return new kha.korehl.graphics4.ConstantLocation(kore_pipeline_get_constantlocation(pipeline, StringHelper.convert(name)));
+		return new kha.korehl.graphics4.ConstantLocation(kore_pipeline_get_constantlocation(_pipeline, StringHelper.convert(name)));
 	}
 	
 	
 	public function getTextureUnit(name: String): kha.graphics4.TextureUnit {
-		return new kha.korehl.graphics4.TextureUnit(kore_pipeline_get_textureunit(pipeline, StringHelper.convert(name)));
+		return new kha.korehl.graphics4.TextureUnit(kore_pipeline_get_textureunit(_pipeline, StringHelper.convert(name)));
 	}
 
 	private static function getBlendFunc(factor: BlendingFactor): Int {
@@ -102,19 +102,11 @@ class PipelineState extends PipelineStateBase {
 	}
 	
 	public function set(): Void {
-		kore_pipeline_set(pipeline);
-	}
-	
-	public function unused(): Void {
-		var include1 = new VertexElement("include", VertexData.Float2);
-		var include2 = new VertexShader(null, null);
-		var include3 = new FragmentShader(null, null);
-		// var include4 = new GeometryShader(null);
-		// var include5 = new TessellationControlShader(null);
-		// var include6 = new TessellationEvaluationShader(null);
+		kore_pipeline_set(_pipeline);
 	}
 	
 	@:hlNative("std", "kore_create_pipeline") static function kore_create_pipeline(): Pointer { return null; }
+	@:hlNative("std", "kore_delete_pipeline") static function kore_delete_pipeline(pipeline: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_fragment_shader") static function kore_pipeline_set_fragment_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_vertex_shader") static function kore_pipeline_set_vertex_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_geometry_shader") static function kore_pipeline_set_geometry_shader(pipeline: Pointer, shader: Pointer): Void { }

--- a/Backends/KoreHL/kha/graphics4/PipelineState.hx
+++ b/Backends/KoreHL/kha/graphics4/PipelineState.hx
@@ -24,8 +24,11 @@ class PipelineState extends PipelineStateBase {
 	
 	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, size: Int): Void {
 		kore_pipeline_set_vertex_shader(pipeline, vertexShader._shader);
-		kore_pipeline_set_fragment_shader(pipeline, fragmentShader._shader);
-		
+		kore_pipeline_set_fragment_shader(pipeline, fragmentShader._shader);		
+		if (geometryShader != null) kore_pipeline_set_geometry_shader(pipeline, geometryShader._shader);
+		if (tessellationControlShader != null) kore_pipeline_set_tesscontrol_shader(pipeline, tessellationControlShader._shader);
+		if (tessellationEvaluationShader != null) kore_pipeline_set_tesseval_shader(pipeline, tessellationEvaluationShader._shader);
+
 		var kore_structure = VertexBuffer.kore_create_vertexstructure();
 		for (i in 0...structure0.size()) {
 			var data: Int = 0;
@@ -114,6 +117,9 @@ class PipelineState extends PipelineStateBase {
 	@:hlNative("std", "kore_create_pipeline") static function kore_create_pipeline(): Pointer { return null; }
 	@:hlNative("std", "kore_pipeline_set_fragment_shader") static function kore_pipeline_set_fragment_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_vertex_shader") static function kore_pipeline_set_vertex_shader(pipeline: Pointer, shader: Pointer): Void { }
+	@:hlNative("std", "kore_pipeline_set_geometry_shader") static function kore_pipeline_set_geometry_shader(pipeline: Pointer, shader: Pointer): Void { }
+	@:hlNative("std", "kore_pipeline_set_tesscontrol_shader") static function kore_pipeline_set_tesscontrol_shader(pipeline: Pointer, shader: Pointer): Void { }
+	@:hlNative("std", "kore_pipeline_set_tesseval_shader") static function kore_pipeline_set_tesseval_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_compile") static function kore_pipeline_compile(pipeline: Pointer, structure: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_get_constantlocation") static function kore_pipeline_get_constantlocation(pipeline: Pointer, name: hl.Bytes): Pointer { return null; }
 	@:hlNative("std", "kore_pipeline_get_textureunit") static function kore_pipeline_get_textureunit(pipeline: Pointer, name: hl.Bytes): Pointer { return null; }

--- a/Backends/KoreHL/kha/graphics4/PipelineState.hx
+++ b/Backends/KoreHL/kha/graphics4/PipelineState.hx
@@ -22,32 +22,38 @@ class PipelineState extends PipelineStateBase {
 		kore_delete_pipeline(_pipeline);
 	}
 	
-	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, size: Int): Void {
+	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, count: Int): Void {
 		kore_pipeline_set_vertex_shader(_pipeline, vertexShader._shader);
 		kore_pipeline_set_fragment_shader(_pipeline, fragmentShader._shader);		
 		if (geometryShader != null) kore_pipeline_set_geometry_shader(_pipeline, geometryShader._shader);
 		if (tessellationControlShader != null) kore_pipeline_set_tesscontrol_shader(_pipeline, tessellationControlShader._shader);
 		if (tessellationEvaluationShader != null) kore_pipeline_set_tesseval_shader(_pipeline, tessellationEvaluationShader._shader);
 
-		var kore_structure = VertexBuffer.kore_create_vertexstructure();
-		for (i in 0...structure0.size()) {
-			var data: Int = 0;
-			switch (structure0.get(i).data.getIndex()) {
-			case 0:
-				data = 1;
-			case 1:
-				data = 2;
-			case 2:
-				data = 3;
-			case 3:
-				data = 4;
-			case 4:
-				data = 5;
+		var structures = [structure0, structure1, structure2, structure3];
+		var kore_structures:Array<Pointer> = [];
+
+		for (i in 0...count) {
+			var kore_structure = VertexBuffer.kore_create_vertexstructure();
+			kore_structures.push(kore_structure);
+			for (j in 0...structures[i].size()) {
+				var data: Int = 0;
+				switch (structures[i].get(j).data.getIndex()) {
+				case 0:
+					data = 1; // Kore::Graphics4::Float1VertexData;
+				case 1:
+					data = 2;
+				case 2:
+					data = 3;
+				case 3:
+					data = 4;
+				case 4:
+					data = 5; // Kore::Graphics4::Float4x4VertexData;
+				}
+				VertexBuffer.kore_vertexstructure_add(kore_structure, StringHelper.convert(structures[i].get(j).name), data);
 			}
-			VertexBuffer.kore_vertexstructure_add(kore_structure, StringHelper.convert(structure0.get(i).name), data);
 		}
 		
-		kore_pipeline_compile(_pipeline, kore_structure);
+		kore_pipeline_compile(_pipeline, kore_structures[0], count > 1 ? kore_structures[1] : null, count > 2 ? kore_structures[2] : null, count > 3 ? kore_structures[3] : null);
 	}
 	
 	public function compile(): Void {
@@ -112,7 +118,7 @@ class PipelineState extends PipelineStateBase {
 	@:hlNative("std", "kore_pipeline_set_geometry_shader") static function kore_pipeline_set_geometry_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_tesscontrol_shader") static function kore_pipeline_set_tesscontrol_shader(pipeline: Pointer, shader: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_set_tesseval_shader") static function kore_pipeline_set_tesseval_shader(pipeline: Pointer, shader: Pointer): Void { }
-	@:hlNative("std", "kore_pipeline_compile") static function kore_pipeline_compile(pipeline: Pointer, structure: Pointer): Void { }
+	@:hlNative("std", "kore_pipeline_compile") static function kore_pipeline_compile(pipeline: Pointer, structure0: Pointer, structure1: Pointer, structure2: Pointer, structure3: Pointer): Void { }
 	@:hlNative("std", "kore_pipeline_get_constantlocation") static function kore_pipeline_get_constantlocation(pipeline: Pointer, name: hl.Bytes): Pointer { return null; }
 	@:hlNative("std", "kore_pipeline_get_textureunit") static function kore_pipeline_get_textureunit(pipeline: Pointer, name: hl.Bytes): Pointer { return null; }
 	@:hlNative("std", "kore_pipeline_set_states") static function kore_pipeline_set_states(pipeline: Pointer,

--- a/Backends/KoreHL/kha/graphics4/TessellationControlShader.hx
+++ b/Backends/KoreHL/kha/graphics4/TessellationControlShader.hx
@@ -1,0 +1,26 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+import kha.Blob;
+
+class TessellationControlShader {
+	public var _shader: Pointer;
+	
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		initShader(sources[0]);
+	}
+	
+	private function initShader(source: Blob): Void {
+		_shader = kore_create_tesscontrolshader(source.bytes.getData(), source.bytes.getData().length); 
+	}
+
+	public static function fromSource(source: String): FragmentShader {
+		return null;
+	}
+	
+	public function unused(): Void {
+		var include: Bytes = Bytes.ofString("");
+	}
+	
+	@:hlNative("std", "kore_create_tesscontrolshader") static function kore_create_tesscontrolshader(data: hl.Bytes, length: Int): Pointer { return null; }
+}

--- a/Backends/KoreHL/kha/graphics4/TessellationControlShader.hx
+++ b/Backends/KoreHL/kha/graphics4/TessellationControlShader.hx
@@ -14,13 +14,12 @@ class TessellationControlShader {
 		_shader = kore_create_tesscontrolshader(source.bytes.getData(), source.bytes.getData().length); 
 	}
 
-	public static function fromSource(source: String): FragmentShader {
-		return null;
-	}
-	
-	public function unused(): Void {
-		var include: Bytes = Bytes.ofString("");
+	public static function fromSource(source: String): TessellationControlShader {
+		var sh = new TessellationControlShader(null, null);
+		sh._shader = kore_tesscontrolshader_from_source(StringHelper.convert(source));
+		return sh;
 	}
 	
 	@:hlNative("std", "kore_create_tesscontrolshader") static function kore_create_tesscontrolshader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_tesscontrolshader_from_source") static function kore_tesscontrolshader_from_source(source: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/TessellationEvaluationShader.hx
+++ b/Backends/KoreHL/kha/graphics4/TessellationEvaluationShader.hx
@@ -1,0 +1,26 @@
+package kha.graphics4;
+
+import haxe.io.Bytes;
+import kha.Blob;
+
+class TessellationEvaluationShader {
+	public var _shader: Pointer;
+	
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		initShader(sources[0]);
+	}
+	
+	private function initShader(source: Blob): Void {
+		_shader = kore_create_tessevalshader(source.bytes.getData(), source.bytes.getData().length); 
+	}
+
+	public static function fromSource(source: String): FragmentShader {
+		return null;
+	}
+	
+	public function unused(): Void {
+		var include: Bytes = Bytes.ofString("");
+	}
+	
+	@:hlNative("std", "kore_create_tessevalshader") static function kore_create_tessevalshader(data: hl.Bytes, length: Int): Pointer { return null; }
+}

--- a/Backends/KoreHL/kha/graphics4/TessellationEvaluationShader.hx
+++ b/Backends/KoreHL/kha/graphics4/TessellationEvaluationShader.hx
@@ -1,6 +1,5 @@
 package kha.graphics4;
 
-import haxe.io.Bytes;
 import kha.Blob;
 
 class TessellationEvaluationShader {
@@ -14,13 +13,12 @@ class TessellationEvaluationShader {
 		_shader = kore_create_tessevalshader(source.bytes.getData(), source.bytes.getData().length); 
 	}
 
-	public static function fromSource(source: String): FragmentShader {
-		return null;
-	}
-	
-	public function unused(): Void {
-		var include: Bytes = Bytes.ofString("");
+	public static function fromSource(source: String): TessellationEvaluationShader {
+		var sh = new TessellationEvaluationShader(null, null);
+		sh._shader = kore_tessevalshader_from_source(StringHelper.convert(source));
+		return sh;
 	}
 	
 	@:hlNative("std", "kore_create_tessevalshader") static function kore_create_tessevalshader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_tessevalshader_from_source") static function kore_tessevalshader_from_source(source: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
@@ -7,15 +7,8 @@ import kha.graphics4.VertexStructure;
 
 class VertexBuffer {
 	public var _buffer: Pointer;
-	private var data: Float32Array;
 	
 	public function new(vertexCount: Int, structure: VertexStructure, usage: Usage, instanceDataStepRate: Int = 0, canRead: Bool = false) {
-		init(vertexCount, structure, instanceDataStepRate);
-		data = new Float32Array(vertexCount * Std.int(structure.byteSize() / 4));
-		var a: VertexElement = new VertexElement("a", VertexData.Float2); //to generate include
-	}
-	
-	private function init(vertexCount: Int, structure: VertexStructure, instanceDataStepRate: Int) {
 		var structure2 = kore_create_vertexstructure();
 		for (i in 0...structure.size()) {
 			var data: Int = 0;
@@ -37,20 +30,16 @@ class VertexBuffer {
 	}
 
 	public function delete() {
-		
+		kore_delete_vertexbuffer(_buffer);
 	}
 	
 	public function lock(?start: Int, ?count: Int): Float32Array {
-		//data._data.getData().b = kore_vertexbuffer_lock(_buffer);
-		//data._data.getData().length = this.count() * Std.int(stride() / 4);
-		return data;
+		var f32array = new Float32Array();
+		f32array.setData(kore_vertexbuffer_lock(_buffer), this.count() * Std.int(stride() / 4));
+		return f32array;
 	}
 	
 	public function unlock(): Void {
-		var locked = kore_vertexbuffer_lock(_buffer);
-		for (i in 0...(count() * Std.int(stride() / 4))) {
-			locked.setF32(i * 4, data.get(i));
-		}
 		kore_vertexbuffer_unlock(_buffer);
 	}
 	
@@ -65,7 +54,8 @@ class VertexBuffer {
 	@:hlNative("std", "kore_create_vertexstructure") public static function kore_create_vertexstructure(): Pointer { return null; }
 	@:hlNative("std", "kore_vertexstructure_add") public static function kore_vertexstructure_add(structure: Pointer, name: hl.Bytes, data: Int): Void { }
 	@:hlNative("std", "kore_create_vertexbuffer") static function kore_create_vertexbuffer(vertexCount: Int, structure: Pointer, stepRate: Int): Pointer { return null; }
-	@:hlNative("std", "kore_vertexbuffer_lock") static function kore_vertexbuffer_lock(buffer: Pointer): hl.Bytes { return null; }
+	@:hlNative("std", "kore_delete_vertexbuffer") static function kore_delete_vertexbuffer(buffer: Pointer): Void { }
+	@:hlNative("std", "kore_vertexbuffer_lock") static function kore_vertexbuffer_lock(buffer: Pointer): Pointer { return null; }
 	@:hlNative("std", "kore_vertexbuffer_unlock") static function kore_vertexbuffer_unlock(buffer: Pointer): Void { }
 	@:hlNative("std", "kore_vertexbuffer_stride") static function kore_vertexbuffer_stride(buffer: Pointer): Int { return 0; }
 	@:hlNative("std", "kore_vertexbuffer_count") static function kore_vertexbuffer_count(buffer: Pointer): Int { return 0; }

--- a/Backends/KoreHL/kha/graphics4/VertexShader.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexShader.hx
@@ -1,6 +1,5 @@
 package kha.graphics4;
 
-import haxe.io.Bytes;
 import kha.Blob;
 
 class VertexShader {
@@ -15,12 +14,11 @@ class VertexShader {
 	}
 
 	public static function fromSource(source: String): VertexShader {
-		return null;
-	}
-	
-	public function unused(): Void {
-		var include: Bytes = Bytes.ofString("");
+		var sh = new VertexShader(null, null);
+		sh._shader = kore_vertexshader_from_source(StringHelper.convert(source));
+		return sh;
 	}
 	
 	@:hlNative("std", "kore_create_vertexshader") static function kore_create_vertexshader(data: hl.Bytes, length: Int): Pointer { return null; }
+	@:hlNative("std", "kore_vertexshader_from_source") static function kore_vertexshader_from_source(source: hl.Bytes): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/graphics4/VertexShader.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexShader.hx
@@ -7,10 +7,10 @@ class VertexShader {
 	public var _shader: Pointer;
 	
 	public function new(sources: Array<Blob>, files: Array<String>) {
-		initVertexShader(sources[0]);
+		initShader(sources[0]);
 	}
 	
-	private function initVertexShader(source: Blob): Void {
+	private function initShader(source: Blob): Void {
 		_shader = kore_create_vertexshader(source.bytes.getData(), source.bytes.getData().length);
 	}
 

--- a/Backends/KoreHL/kha/input/Sensor.hx
+++ b/Backends/KoreHL/kha/input/Sensor.hx
@@ -1,0 +1,39 @@
+package kha.input;
+
+@:keep
+class Sensor {
+	private static var accelerometer: Sensor = new Sensor();
+	private static var gyroscope: Sensor = new Sensor();
+	private var listeners: Array<Float -> Float -> Float -> Void> = new Array();
+
+	public static function get(type: SensorType): Sensor {
+		switch (type) {
+		case Accelerometer:
+			return accelerometer;
+		case Gyroscope:
+			return gyroscope;
+		}
+	}
+
+	public function notify(listener: Float -> Float -> Float -> Void): Void {
+		listeners.push(listener);
+	}
+
+	private function new() {
+
+	}
+
+	public static function _accelerometerChanged(x: Float, y: Float, z: Float): Void {
+		var sensor = get(SensorType.Accelerometer);
+		for (listener in sensor.listeners) {
+			listener(x, y, z);
+		}
+	}
+
+	public static function _gyroscopeChanged(x: Float, y: Float, z: Float): Void {
+		var sensor = get(SensorType.Gyroscope);
+		for (listener in sensor.listeners) {
+			listener(x, y, z);
+		}
+	}
+}

--- a/Backends/KoreHL/kha/korehl/Sound.hx
+++ b/Backends/KoreHL/kha/korehl/Sound.hx
@@ -1,78 +1,37 @@
 package kha.korehl;
 
 import haxe.ds.Vector;
+import sys.io.File;
 
+using StringTools;
+
+@:keep
 class Sound extends kha.Sound {
-	public var _sound: Pointer;
-	private var filename: String;
+
+	function initWav(filename: String) {
+		uncompressedData = new kha.arrays.Float32Array();
+		var dataSize = new kha.arrays.Uint32Array(1);
+		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData());
+		uncompressedData.setData(data, dataSize[0]);
+		dataSize.free();
+	}
+
+	function initOgg(filename: String) {
+		compressedData = File.getBytes(filename);
+	}
 	
 	public function new(filename: String) {
 		super();
-		this.filename = filename;
-	}
-	
-	/*@:functionCode('
-		sound = new Kore::Sound(filename.c_str());
-		if (sound->format.channels == 1) {
-			if (sound->format.bitsPerSample == 8) {
-				this->_createData(sound->size * 2);
-				for (int i = 0; i < sound->size; ++i) {
-					uncompressedData[i * 2 + 0] = sound->data[i] / 255.0 * 2.0 - 1.0;
-					uncompressedData[i * 2 + 1] = sound->data[i] / 255.0 * 2.0 - 1.0;
-				}
-			}
-			else if (sound->format.bitsPerSample == 16) {
-				this->_createData(sound->size);
-				Kore::s16* sdata = (Kore::s16*)&sound->data[0];
-				for (int i = 0; i < sound->size / 2; ++i) {
-					uncompressedData[i * 2 + 0] = sdata[i] / 32767.0;
-					uncompressedData[i * 2 + 1] = sdata[i] / 32767.0;
-				}
-			}
-			else {
-				this->_createData(2);
-			}
+		if (filename.endsWith(".wav")) {
+			initWav(filename);
+		}
+		else if (filename.endsWith(".ogg")) {
+			initOgg(filename);
 		}
 		else {
-			if (sound->format.bitsPerSample == 8) {
-				this->_createData(sound->size);
-				for (int i = 0; i < sound->size; ++i) {
-					uncompressedData[i] = sound->data[i] / 255.0 * 2.0 - 1.0;
-				}
-			}
-			else if (sound->format.bitsPerSample == 16) {
-				this->_createData(sound->size / 2);
-				Kore::s16* sdata = (Kore::s16*)&sound->data[0];
-				for (int i = 0; i < sound->size / 2; ++i) {
-					uncompressedData[i] = sdata[i] / 32767.0;
-				}
-			}
-			else {
-				this->_createData(2);
-			}
+			trace("Unknown sound format: " + filename);
 		}
-	')*/
-	private function uncompress2(): Void {
-		
 	}
 
-	override public function uncompress(done: Void->Void): Void {
-		uncompress2();
-		compressedData = null;
-		done();
-	}
-	
-	//@:functionCode("delete sound; sound = nullptr;")
-	private function unload2(): Void {
-		
-	}
-		
-	override public function unload(): Void {
-		super.unload();
-		unload2();
-	}
-	
-	private function _createData(size: Int): Void {
-		uncompressedData = new Vector<Float>(size);
-	}
+	@:hlNative("std", "kore_sound_init_wav") static function kore_sound_init_wav(filename: hl.Bytes, outSize: Pointer): Pointer { return null; }
 }

--- a/Backends/KoreHL/kha/korehl/Video.hx
+++ b/Backends/KoreHL/kha/korehl/Video.hx
@@ -1,0 +1,72 @@
+package kha.korehl;
+
+class Video extends kha.Video {
+
+	public var _video: Pointer;
+
+	public function new(filename: String) {
+		super();
+		init(filename);
+	}
+	
+	private function init(filename: String) {
+		_video = kore_video_create(StringHelper.convert(filename));
+	}
+	
+	override public function play(loop: Bool = false): Void {
+		kore_video_play(_video);
+	}
+
+	override public function pause(): Void {
+		kore_video_pause(_video);
+	}
+
+	override public function stop(): Void {
+		kore_video_stop(_video);
+	}
+	
+	override public function getLength(): Int { // Miliseconds
+		return kore_video_get_duration(_video);
+	}
+	
+	override public function getCurrentPos(): Int { // Miliseconds
+		return kore_video_get_position(_video);
+	}
+	
+	override function get_position(): Int {
+		return getCurrentPos();
+	}
+	
+	override function set_position(value: Int): Int {
+		kore_video_set_position(_video, value);
+		return value;
+	}
+	
+	override public function isFinished(): Bool {
+		return kore_video_is_finished(_video);
+	}
+
+	override public function width(): Int {
+		return kore_video_width(_video);
+	}
+
+	override public function height(): Int {
+		return kore_video_height(_video);
+	}
+
+	override public function unload(): Void {
+		kore_video_unload(_video);
+	}
+
+	@:hlNative("std", "kore_video_create") static function kore_video_create(filename: hl.Bytes): Pointer { return null; }
+	@:hlNative("std", "kore_video_play") static function kore_video_play(video: Pointer): Void { }
+	@:hlNative("std", "kore_video_pause") static function kore_video_pause(video: Pointer): Void { }
+	@:hlNative("std", "kore_video_stop") static function kore_video_stop(video: Pointer): Void { }
+	@:hlNative("std", "kore_video_get_duration") static function kore_video_get_duration(video: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_video_get_position") static function kore_video_get_position(video: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_video_set_position") static function kore_video_set_position(video: Pointer, value: Int): Int { return 0; }
+	@:hlNative("std", "kore_video_is_finished") static function kore_video_is_finished(video: Pointer): Bool { return false; }
+	@:hlNative("std", "kore_video_width") static function kore_video_width(video: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_video_height") static function kore_video_height(video: Pointer): Int { return 0; }
+	@:hlNative("std", "kore_video_unload") static function kore_video_unload(video: Pointer): Void { }
+}

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -33,7 +33,7 @@ class Graphics implements kha.graphics4.Graphics {
 		return kore_graphics_refreshrate();
 	}
 	
-	public function clear(?color: Color, ?z: Float, ?stencil: Int): Void {
+	public function clear(?color: Color, ?z: FastFloat, ?stencil: Int): Void {
 		var flags: Int = 0;
 		if (color != null) flags |= 1;
 		if (z != null) flags |= 2;
@@ -110,23 +110,6 @@ class Graphics implements kha.graphics4.Graphics {
 		return true;
 	}
 	
-	/*@:functionCode('
-		Kore::Graphics::setTextureAddressing(unit->unit, Kore::U, (Kore::TextureAddressing)uWrap);
-		Kore::Graphics::setTextureAddressing(unit->unit, Kore::V, (Kore::TextureAddressing)vWrap);
-	')*/
-	private function setTextureWrapNative(unit: TextureUnit, uWrap: Int, vWrap: Int): Void {
-		
-	}
-	
-	/*@:functionCode('
-		Kore::Graphics::setTextureMinificationFilter(unit->unit, (Kore::TextureFilter)minificationFilter);
-		Kore::Graphics::setTextureMagnificationFilter(unit->unit, (Kore::TextureFilter)magnificationFilter);
-		Kore::Graphics::setTextureMipmapFilter(unit->unit, (Kore::MipmapFilter)mipMapFilter);
-	')*/
-	private function setTextureFiltersNative(unit: TextureUnit, minificationFilter: Int, magnificationFilter: Int, mipMapFilter: Int): Void {
-		
-	}
-	
 	private function getTextureAddressing(addressing: TextureAddressing): Int {
 		switch (addressing) {
 		case TextureAddressing.Repeat:
@@ -160,13 +143,12 @@ class Graphics implements kha.graphics4.Graphics {
 		}
 	}
 	
-	public function setTextureParameters(texunit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-		setTextureWrapNative(cast texunit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing));
-		setTextureFiltersNative(cast texunit, getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
+	public function setTextureParameters(unit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {	
+		kore_graphics_set_texture_parameters(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
 	}
 
-	public function setTexture3DParameters(texunit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-	
+	public function setTexture3DParameters(unit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
+		kore_graphics_set_texture3d_parameters(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureAddressing(wAddressing), getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
 	}
 	
 	public function setTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
@@ -176,7 +158,8 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function setTextureArray(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
-	
+		if (texture == null) return;
+		kore_graphics_set_texture_array(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, texture._textureArray);
 	}
 	
 	public function setTextureDepth(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
@@ -186,11 +169,11 @@ class Graphics implements kha.graphics4.Graphics {
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
 		if (texture == null) return;
-		//setTextureInternal(cast unit, Image.createFromVideo(texture));
+		kore_graphics_set_texture(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, Image.createFromVideo(texture)._texture);
 	}
 
 	public function setImageTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
-
+		kore_graphics_set_image_texture(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, texture._texture);
 	}
 		
 	public function setPipeline(pipe: PipelineState): Void {
@@ -301,7 +284,7 @@ class Graphics implements kha.graphics4.Graphics {
 		kore_graphics_flush();
 	}
 	
-	@:hlNative("std", "kore_graphics_clear") static function kore_graphics_clear(flags: Int, color: Int, z: Float, stencil: Int): Void { }
+	@:hlNative("std", "kore_graphics_clear") static function kore_graphics_clear(flags: Int, color: Int, z: FastFloat, stencil: Int): Void { }
 	@:hlNative("std", "kore_graphics_vsynced") static function kore_graphics_vsynced(): Bool { return false; }
 	@:hlNative("std", "kore_graphics_refreshrate") static function kore_graphics_refreshrate(): Int { return 0; }
 	@:hlNative("std", "kore_graphics_viewport") static function kore_graphics_viewport(x: Int, y: Int, width: Int, height: Int): Void { }
@@ -310,28 +293,32 @@ class Graphics implements kha.graphics4.Graphics {
 	@:hlNative("std", "kore_graphics_scissor") static function kore_graphics_scissor(x: Int, y: Int, width: Int, height: Int): Void { }
 	@:hlNative("std", "kore_graphics_disable_scissor") static function kore_graphics_disable_scissor(): Void { }
 	@:hlNative("std", "kore_graphics_render_targets_inverted_y") static function kore_graphics_render_targets_inverted_y(): Bool { return false; }
+	@:hlNative("std", "kore_graphics_set_texture_parameters") static function kore_graphics_set_texture_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
+	@:hlNative("std", "kore_graphics_set_texture3d_parameters") static function kore_graphics_set_texture3d_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, wAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
 	@:hlNative("std", "kore_graphics_set_texture") static function kore_graphics_set_texture(unit: Pointer, texture: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_texture_depth") static function kore_graphics_set_texture_depth(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_graphics_set_texture_array") static function kore_graphics_set_texture_array(unit: Pointer, textureArray: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_render_target") static function kore_graphics_set_render_target(unit: Pointer, renderTarget: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_cubemap_texture") static function kore_graphics_set_cubemap_texture(unit: Pointer, texture: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_cubemap_target") static function kore_graphics_set_cubemap_target(unit: Pointer, renderTarget: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_cubemap_depth") static function kore_graphics_set_cubemap_depth(unit: Pointer, renderTarget: Pointer): Void { }
+	@:hlNative("std", "kore_graphics_set_image_texture") static function kore_graphics_set_image_texture(unit: Pointer, texture: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_bool") static function kore_graphics_set_bool(location: Pointer, value: Bool): Void { }
 	@:hlNative("std", "kore_graphics_set_int") static function kore_graphics_set_int(location: Pointer, value: Int): Void { }
-	@:hlNative("std", "kore_graphics_set_float") static function kore_graphics_set_float(location: Pointer, value: Float): Void { }
-	@:hlNative("std", "kore_graphics_set_float2") static function kore_graphics_set_float2(location: Pointer, value1: Float, value2: Float): Void { }
-	@:hlNative("std", "kore_graphics_set_float3") static function kore_graphics_set_float3(location: Pointer, value1: Float, value2: Float, value3: Float): Void { }
-	@:hlNative("std", "kore_graphics_set_float4") static function kore_graphics_set_float4(location: Pointer, value1: Float, value2: Float, value3: Float, value4: Float): Void { }
+	@:hlNative("std", "kore_graphics_set_float") static function kore_graphics_set_float(location: Pointer, value: FastFloat): Void { }
+	@:hlNative("std", "kore_graphics_set_float2") static function kore_graphics_set_float2(location: Pointer, value1: FastFloat, value2: FastFloat): Void { }
+	@:hlNative("std", "kore_graphics_set_float3") static function kore_graphics_set_float3(location: Pointer, value1: FastFloat, value2: FastFloat, value3: FastFloat): Void { }
+	@:hlNative("std", "kore_graphics_set_float4") static function kore_graphics_set_float4(location: Pointer, value1: FastFloat, value2: FastFloat, value3: FastFloat, value4: FastFloat): Void { }
 	@:hlNative("std", "kore_graphics_set_floats") static function kore_graphics_set_floats(location: Pointer, values: Pointer, count: Int): Void { }
 	@:hlNative("std", "kore_graphics_set_matrix") static function kore_graphics_set_matrix(location: Pointer,
-		_00: Float, _10: Float, _20: Float, _30: Float,
-		_01: Float, _11: Float, _21: Float, _31: Float,
-		_02: Float, _12: Float, _22: Float, _32: Float,
-		_03: Float, _13: Float, _23: Float, _33: Float): Void { }
+		_00: FastFloat, _10: FastFloat, _20: FastFloat, _30: FastFloat,
+		_01: FastFloat, _11: FastFloat, _21: FastFloat, _31: FastFloat,
+		_02: FastFloat, _12: FastFloat, _22: FastFloat, _32: FastFloat,
+		_03: FastFloat, _13: FastFloat, _23: FastFloat, _33: FastFloat): Void { }
 	@:hlNative("std", "kore_graphics_set_matrix3") static function kore_graphics_set_matrix3(location: Pointer,
-		_00: Float, _10: Float, _20: Float,
-		_01: Float, _11: Float, _21: Float,
-		_02: Float, _12: Float, _22: Float): Void { }
+		_00: FastFloat, _10: FastFloat, _20: FastFloat,
+		_01: FastFloat, _11: FastFloat, _21: FastFloat,
+		_02: FastFloat, _12: FastFloat, _22: FastFloat): Void { }
 	@:hlNative("std", "kore_graphics_draw_all_indexed_vertices") static function kore_graphics_draw_all_indexed_vertices(): Void { }
 	@:hlNative("std", "kore_graphics_draw_indexed_vertices") static function kore_graphics_draw_indexed_vertices(start: Int, count: Int): Void { }
 	@:hlNative("std", "kore_graphics_draw_all_indexed_vertices_instanced") static function kore_graphics_draw_all_indexed_vertices_instanced(instanceCount: Int): Void { }

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -49,25 +49,12 @@ class Graphics implements kha.graphics4.Graphics {
 		kore_graphics_set_vertexbuffer(vertexBuffer._buffer);
 	}
 	
-	/*@:functionCode('
-		Kore::VertexBuffer* vertexBuffers[4] = {
-			vb0 == null() ? nullptr : vb0->buffer,
-			vb1 == null() ? nullptr : vb1->buffer,
-			vb2 == null() ? nullptr : vb2->buffer,
-			vb3 == null() ? nullptr : vb3->buffer
-		};
-		Kore::Graphics::setVertexBuffers(vertexBuffers, count);
-	')*/
-	private function setVertexBuffersInternal(vb0: VertexBuffer, vb1: VertexBuffer, vb2: VertexBuffer, vb3: VertexBuffer, count: Int): Void {
-		
-	}
-	
 	public function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void {
-		setVertexBuffersInternal(
-			vertexBuffers.length > 0 ? vertexBuffers[0] : null,
-			vertexBuffers.length > 1 ? vertexBuffers[1] : null,
-			vertexBuffers.length > 2 ? vertexBuffers[2] : null,
-			vertexBuffers.length > 3 ? vertexBuffers[3] : null,
+		kore_graphics_set_vertexbuffers(
+			vertexBuffers.length > 0 ? vertexBuffers[0]._buffer : null,
+			vertexBuffers.length > 1 ? vertexBuffers[1]._buffer : null,
+			vertexBuffers.length > 2 ? vertexBuffers[2]._buffer : null,
+			vertexBuffers.length > 3 ? vertexBuffers[3]._buffer : null,
 			vertexBuffers.length);
 	}
 	
@@ -289,6 +276,7 @@ class Graphics implements kha.graphics4.Graphics {
 	@:hlNative("std", "kore_graphics_refreshrate") static function kore_graphics_refreshrate(): Int { return 0; }
 	@:hlNative("std", "kore_graphics_viewport") static function kore_graphics_viewport(x: Int, y: Int, width: Int, height: Int): Void { }
 	@:hlNative("std", "kore_graphics_set_vertexbuffer") static function kore_graphics_set_vertexbuffer(buffer: Pointer): Void { }
+	@:hlNative("std", "kore_graphics_set_vertexbuffers") static function kore_graphics_set_vertexbuffers(b0: Pointer, b1: Pointer, b2: Pointer, b3: Pointer, count: Int): Void { }
 	@:hlNative("std", "kore_graphics_set_indexbuffer") static function kore_graphics_set_indexbuffer(buffer: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_scissor") static function kore_graphics_scissor(x: Int, y: Int, width: Int, height: Int): Void { }
 	@:hlNative("std", "kore_graphics_disable_scissor") static function kore_graphics_disable_scissor(): Void { }

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -217,7 +217,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	public function setFloats(location: kha.graphics4.ConstantLocation, values: Float32Array): Void {
-		kore_graphics_set_floats(cast (location, kha.korehl.graphics4.ConstantLocation)._location, values.getData().bytes, values.getData().length);
+		kore_graphics_set_floats(cast (location, kha.korehl.graphics4.ConstantLocation)._location, values.getData(), values.length);
 	}
 	
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -208,7 +208,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 	
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
-		kore_graphics_set_matrix(cast(location, ConstantLocation)._location,
+		kore_graphics_set_matrix(cast (location, kha.korehl.graphics4.ConstantLocation)._location,
 			matrix._00, matrix._10, matrix._20, matrix._30,
 			matrix._01, matrix._11, matrix._21, matrix._31,
 			matrix._02, matrix._12, matrix._22, matrix._32,
@@ -216,7 +216,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
-		kore_graphics_set_matrix3(cast(location, ConstantLocation)._location,
+		kore_graphics_set_matrix3(cast (location, kha.korehl.graphics4.ConstantLocation)._location,
 			matrix._00, matrix._10, matrix._20,
 			matrix._01, matrix._11, matrix._21,
 			matrix._02, matrix._12, matrix._22);

--- a/Backends/KoreHL/kha/korehl/graphics4/ShaderType.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/ShaderType.hx
@@ -1,6 +1,0 @@
-package kha.korehl.graphics4;
-
-enum ShaderType {
-	FragmentShader;
-	VertexShader;
-}

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -78,11 +78,11 @@ class SystemImpl {
 		gamepads[gamepad].sendButtonEvent(button, value);
 	}
 
-	private static var audioOutputData: Vector<Float>;
+	private static var audioOutputData: kha.arrays.Float32Array;
 	private static function audioCallback(samples: Int) : Void {
 		//Krom.log("Samples " + samples);
 		
-		audioOutputData = new Vector<Float>(samples);
+		audioOutputData = new kha.arrays.Float32Array(samples);
 		
 		// lock mutex
 		//Krom.audioThread(true);

--- a/Backends/Krom/kha/krom/Sound.hx
+++ b/Backends/Krom/kha/krom/Sound.hx
@@ -1,6 +1,5 @@
 package kha.krom;
 
-import haxe.ds.Vector;
 import haxe.io.Bytes;
 
 class Sound extends kha.Sound {
@@ -19,7 +18,7 @@ class Sound extends kha.Sound {
 
 		var soundBytes = compressedData;
 		var count = Std.int(soundBytes.length / 4);
-		uncompressedData = new Vector<Float>(count);
+		uncompressedData = new kha.arrays.Float32Array(count);
 		for (i in 0...count) {
 			uncompressedData[i] = soundBytes.getFloat(i * 4);
 			//if (i < 10) Krom.log(" " + uncompressedData[i]);

--- a/Sources/kha/FastFloat.hx
+++ b/Sources/kha/FastFloat.hx
@@ -2,6 +2,8 @@ package kha;
 
 #if cpp
 typedef FastFloat = cpp.Float32;
+#elseif hl
+typedef FastFloat = hl.F32;
 #else
 typedef FastFloat = Float;
 #end

--- a/Sources/kha/Sound.hx
+++ b/Sources/kha/Sound.hx
@@ -1,6 +1,5 @@
 package kha;
 
-import haxe.ds.Vector;
 import haxe.io.Bytes;
 import haxe.io.BytesOutput;
 import kha.audio2.ogg.vorbis.Reader;
@@ -10,7 +9,7 @@ import kha.audio2.ogg.vorbis.Reader;
  */
 class Sound implements Resource {
 	public var compressedData: Bytes;
-	public var uncompressedData: Vector<Float>;
+	public var uncompressedData: kha.arrays.Float32Array;
 	
 	public function new() {
 		
@@ -27,14 +26,14 @@ class Sound implements Resource {
 		var soundBytes = output.getBytes();
 		var count = Std.int(soundBytes.length / 4);
 		if (header.channel == 1) {
-			uncompressedData = new Vector<Float>(count * 2);
+			uncompressedData = new kha.arrays.Float32Array(count * 2);
 			for (i in 0...count) {
 				uncompressedData[i * 2 + 0] = soundBytes.getFloat(i * 4);
 				uncompressedData[i * 2 + 1] = soundBytes.getFloat(i * 4);
 			}
 		}
 		else {
-			uncompressedData = new Vector<Float>(count);
+			uncompressedData = new kha.arrays.Float32Array(count);
 			for (i in 0...count) {
 				uncompressedData[i] = soundBytes.getFloat(i * 4);
 			}

--- a/Sources/kha/audio2/Audio1.hx
+++ b/Sources/kha/audio2/Audio1.hx
@@ -12,8 +12,8 @@ class Audio1 {
 	
 	private static var internalSoundChannels: Vector<AudioChannel>;
 	private static var internalStreamChannels: Vector<StreamChannel>;
-	private static var sampleCache1: Vector<FastFloat>;
-	private static var sampleCache2: Vector<FastFloat>;
+	private static var sampleCache1: kha.arrays.Float32Array;
+	private static var sampleCache2: kha.arrays.Float32Array;
 	#if cpp
 	private static var mutex: Mutex;
 	#end
@@ -27,8 +27,8 @@ class Audio1 {
 		streamChannels = new Vector<StreamChannel>(channelCount);
 		internalSoundChannels = new Vector<AudioChannel>(channelCount);
 		internalStreamChannels = new Vector<StreamChannel>(channelCount);
-		sampleCache1 = new Vector<FastFloat>(512);
-		sampleCache2 = new Vector<FastFloat>(512);
+		sampleCache1 = new kha.arrays.Float32Array(512);
+		sampleCache2 = new kha.arrays.Float32Array(512);
 		Audio.audioCallback = mix;
 	}
 	
@@ -42,8 +42,8 @@ class Audio1 {
 	
 	public static function mix(samples: Int, buffer: Buffer): Void {
 		if (sampleCache1.length < samples) {
-			sampleCache1 = new Vector<FastFloat>(samples);
-			sampleCache2 = new Vector<FastFloat>(samples);
+			sampleCache1 = new kha.arrays.Float32Array(samples);
+			sampleCache2 = new kha.arrays.Float32Array(samples);
 		}
 		for (i in 0...samples) {
 			sampleCache2[i] = 0;

--- a/Sources/kha/audio2/AudioChannel.hx
+++ b/Sources/kha/audio2/AudioChannel.hx
@@ -1,9 +1,7 @@
 package kha.audio2;
 
-import haxe.ds.Vector;
-
 class AudioChannel implements kha.audio1.AudioChannel {
-	public var data: Vector<Float>;
+	public var data: kha.arrays.Float32Array;
 	private var myVolume: Float;
 	private var myPosition: Int;
 	private var paused: Bool = false;
@@ -15,7 +13,7 @@ class AudioChannel implements kha.audio1.AudioChannel {
 		myPosition = 0;
 	}
 	
-	public function nextSamples(samples: Vector<FastFloat>, length: Int, sampleRate: Int): Void {
+	public function nextSamples(samples: kha.arrays.Float32Array, length: Int, sampleRate: Int): Void {
 		if (paused) {
 			for (i in 0...length) {
 				samples[i] = 0;

--- a/Sources/kha/audio2/Buffer.hx
+++ b/Sources/kha/audio2/Buffer.hx
@@ -1,19 +1,17 @@
 package kha.audio2;
 
-import haxe.ds.Vector;
-
 class Buffer {
 	public var channels: Int;
 	public var samplesPerSecond: Int;
 	
-	public var data: Vector<Float>;
+	public var data: kha.arrays.Float32Array;
 	public var size: Int;
 	public var readLocation: Int;
 	public var writeLocation: Int;
 	
 	public function new(size: Int, channels: Int, samplesPerSecond: Int) {
 		this.size = size;
-		this.data = new Vector<Float>(size);
+		this.data = new kha.arrays.Float32Array(size);
 		this.channels = channels;
 		this.samplesPerSecond = samplesPerSecond;
 		readLocation = 0;

--- a/Sources/kha/audio2/StreamChannel.hx
+++ b/Sources/kha/audio2/StreamChannel.hx
@@ -1,11 +1,10 @@
 package kha.audio2;
 
-import haxe.ds.Vector;
 import haxe.io.Bytes;
 import haxe.io.BytesOutput;
 import kha.audio2.ogg.vorbis.Reader;
 
-#if !cpp
+#if (!cpp && !hl)
 class StreamChannel implements kha.audio1.AudioChannel {
 	private var reader: Reader;
 	private var atend: Bool = false;
@@ -19,7 +18,7 @@ class StreamChannel implements kha.audio1.AudioChannel {
 		reader = Reader.openFromBytes(data);
 	}
 
-	public function nextSamples(samples: Vector<FastFloat>, length: Int, sampleRate: Int): Void {
+	public function nextSamples(samples: kha.arrays.Float32Array, length: Int, sampleRate: Int): Void {
 		if (paused) {
 			for (i in 0...length) {
 				samples[i] = 0;

--- a/Sources/kha/audio2/ogg/vorbis/Reader.hx
+++ b/Sources/kha/audio2/ogg/vorbis/Reader.hx
@@ -106,7 +106,7 @@ class Reader {
         var header = decoder.header;
         var count = 0;
 		var bufferSize = 4096;
-		var buffer = new Vector<FastFloat>(bufferSize * header.channel);
+		var buffer = new kha.arrays.Float32Array(bufferSize * header.channel);
         while (true) {
             var n = decoder.read(buffer, bufferSize, header.channel, header.sampleRate, useFloat);
 			for (i in 0...n * header.channel) {
@@ -118,7 +118,7 @@ class Reader {
         return decoder.header;
     }
 
-    public function read(output:Vector<FastFloat>, ?samples:Int, ?channels:Int, ?sampleRate:Int, useFloat:Bool = false) {
+    public function read(output:kha.arrays.Float32Array, ?samples:Int, ?channels:Int, ?sampleRate:Int, useFloat:Bool = false) {
         decoder.ensurePosition(seekFunc);
 
         if (samples == null) {

--- a/Sources/kha/audio2/ogg/vorbis/Reader.hx
+++ b/Sources/kha/audio2/ogg/vorbis/Reader.hx
@@ -106,7 +106,7 @@ class Reader {
         var header = decoder.header;
         var count = 0;
 		var bufferSize = 4096;
-		var buffer = new Vector<Float>(bufferSize * header.channel);
+		var buffer = new Vector<FastFloat>(bufferSize * header.channel);
         while (true) {
             var n = decoder.read(buffer, bufferSize, header.channel, header.sampleRate, useFloat);
 			for (i in 0...n * header.channel) {
@@ -118,7 +118,7 @@ class Reader {
         return decoder.header;
     }
 
-    public function read(output:Vector<Float>, ?samples:Int, ?channels:Int, ?sampleRate:Int, useFloat:Bool = false) {
+    public function read(output:Vector<FastFloat>, ?samples:Int, ?channels:Int, ?sampleRate:Int, useFloat:Bool = false) {
         decoder.ensurePosition(seekFunc);
 
         if (samples == null) {

--- a/Sources/kha/audio2/ogg/vorbis/VorbisDecoder.hx
+++ b/Sources/kha/audio2/ogg/vorbis/VorbisDecoder.hx
@@ -79,7 +79,7 @@ class VorbisDecoder
         return decoder;
     }
 
-    public function read(output:Vector<Float>, samples:Int, channels:Int, sampleRate:Int, useFloat:Bool) {
+    public function read(output:Vector<FastFloat>, samples:Int, channels:Int, sampleRate:Int, useFloat:Bool) {
         if (sampleRate % header.sampleRate != 0) {
             throw 'Unsupported sampleRate : can\'t convert ${header.sampleRate} to $sampleRate';
         }

--- a/Sources/kha/audio2/ogg/vorbis/VorbisDecoder.hx
+++ b/Sources/kha/audio2/ogg/vorbis/VorbisDecoder.hx
@@ -79,7 +79,7 @@ class VorbisDecoder
         return decoder;
     }
 
-    public function read(output:Vector<FastFloat>, samples:Int, channels:Int, sampleRate:Int, useFloat:Bool) {
+    public function read(output:kha.arrays.Float32Array, samples:Int, channels:Int, sampleRate:Int, useFloat:Bool) {
         if (sampleRate % header.sampleRate != 0) {
             throw 'Unsupported sampleRate : can\'t convert ${header.sampleRate} to $sampleRate';
         }

--- a/Sources/kha/input/Sensor.hx
+++ b/Sources/kha/input/Sensor.hx
@@ -1,6 +1,6 @@
 package kha.input;
 
-#if cpp
+#if (cpp || hl)
 
 extern class Sensor {
 	public static function get(type: SensorType): Sensor;


### PR DESCRIPTION
It works! 🔋 
- Has proper FastFloat, Float32/Uint32Array
- Audio now uses Float32Array as well
- Requires Haxe 4.0 (https://haxe.org/download/version/4.0.0-preview.3/)
- Compiles with `node Kha\make windows-hl`
- Needs more testing/profiling now

I have tested the first-person template from armory, it already runs surprisingly well. Some first observations below.

windows (hxcpp) / windows-hl (hashlink/c):
- khamake(from scratch): 10.02sec / 7.16sec
- win32-debug build-time: 125.1sec / 31.7sec
- win32-release mem usage: 96.2MB / 89.2MB
- win32-release frame time: 5.3ms / 5.5ms
- win32-release binary size: 3.9MB / 2.8MB

(Previous PRs: https://github.com/Kode/Kha/pull/795 https://github.com/Kode/Kha/pull/770)