### PR TITLE
Faster Krom

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -27,8 +27,8 @@ extern class Krom {
 	static function setFloat3(location: kha.graphics4.ConstantLocation, value1: Float, value2: Float, value3: Float): Void;
 	static function setFloat4(location: kha.graphics4.ConstantLocation, value1: Float, value2: Float, value3: Float, value4: Float): Void;
 	static function setFloats(location: kha.graphics4.ConstantLocation, values: kha.arrays.Float32Array): Void;
-	static function setMatrix(location: kha.graphics4.ConstantLocation, matrix: kha.math.FastMatrix4): Void;
-	static function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: kha.math.FastMatrix3): Void;
+	static function setMatrix(location: kha.graphics4.ConstantLocation, matrix: kha.arrays.Float32Array): Void;
+	static function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: kha.arrays.Float32Array): Void;
 	
 	static function begin(renderTarget: kha.Canvas, additionalRenderTargets: Array<kha.Canvas>): Void;
 	static function beginFace(renderTarget: kha.Canvas, face: Int): Void;
@@ -52,11 +52,13 @@ extern class Krom {
 	static function clearTexture(target: Dynamic, x: Int, y: Int, z: Int, width: Int, height: Int, depth: Int, color: Int): Void;
 	static function createIndexBuffer(count: Int): Dynamic;
 	static function deleteIndexBuffer(buffer: Dynamic): Dynamic;
-	static function setIndices(buffer: Dynamic, indices: kha.arrays.Uint32Array): Void;
+	static function lockIndexBuffer(buffer: Dynamic): kha.arrays.Uint32Array;
+	static function unlockIndexBuffer(buffer: Dynamic): Void;
 	static function setIndexBuffer(buffer: Dynamic): Void;
 	static function createVertexBuffer(count: Int, structure: Array<kha.graphics4.VertexElement>, instanceDataStepRate: Int): Dynamic;
 	static function deleteVertexBuffer(buffer: Dynamic): Dynamic;
-	static function setVertices(buffer: Dynamic, vertices: kha.arrays.Float32Array): Void;
+	static function lockVertexBuffer(buffer: Dynamic): kha.arrays.Float32Array;
+	static function unlockVertexBuffer(buffer: Dynamic): Void;
 	static function setVertexBuffer(buffer: Dynamic): Void;
 	static function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void;
 	static function drawIndexedVertices(start: Int, count: Int): Void;
@@ -118,8 +120,8 @@ extern class Krom {
 	static function setFloat3Compute(location: kha.compute.ConstantLocation, value1: Float, value2: Float, value3: Float): Void;
 	static function setFloat4Compute(location: kha.compute.ConstantLocation, value1: Float, value2: Float, value3: Float, value4: Float): Void;
 	static function setFloatsCompute(location: kha.compute.ConstantLocation, values: kha.arrays.Float32Array): Void;
-	static function setMatrixCompute(location: kha.compute.ConstantLocation, matrix: kha.math.FastMatrix4): Void;
-	static function setMatrix3Compute(location: kha.compute.ConstantLocation, matrix: kha.math.FastMatrix3): Void;
+	static function setMatrixCompute(location: kha.compute.ConstantLocation, matrix: kha.arrays.Float32Array): Void;
+	static function setMatrix3Compute(location: kha.compute.ConstantLocation, matrix: kha.arrays.Float32Array): Void;
 	static function setTextureCompute(unit: kha.compute.TextureUnit, texture: kha.Canvas, access: Int): Void;
 	static function setSampledTextureCompute(unit: kha.compute.TextureUnit, texture: kha.Canvas): Void;
 	static function setSampledDepthTextureCompute(unit: kha.compute.TextureUnit, texture: kha.Canvas): Void;

--- a/Backends/Krom/kha/compute/Compute.hx
+++ b/Backends/Krom/kha/compute/Compute.hx
@@ -55,12 +55,20 @@ class Compute {
 		Compute.setFloat4(location, value.x, value.y, value.z, value.w);
 	}
 
-	public static function setMatrix(location: ConstantLocation, value: FastMatrix4): Void {
-		Krom.setMatrixCompute(location, value);
+	static var mat = new kha.arrays.Float32Array(16);
+	public static function setMatrix(location: ConstantLocation, matrix: FastMatrix4): Void {
+		mat[0] = matrix._00; mat[1] = matrix._01; mat[2] = matrix._02; mat[3] = matrix._03;
+		mat[4] = matrix._10; mat[5] = matrix._11; mat[6] = matrix._12; mat[7] = matrix._13;
+		mat[8] = matrix._20; mat[9] = matrix._21; mat[10] = matrix._22; mat[11] = matrix._23;
+		mat[12] = matrix._30; mat[13] = matrix._31; mat[14] = matrix._32; mat[15] = matrix._33;
+		Krom.setMatrixCompute(location, mat);
 	}
 
-	public static function setMatrix3(location: ConstantLocation, value: FastMatrix3): Void {
-		Krom.setMatrix3Compute(location, value);
+	public static function setMatrix3(location: ConstantLocation, matrix: FastMatrix3): Void {
+		mat[0] = matrix._00; mat[1] = matrix._01; mat[2] = matrix._02;
+		mat[3] = matrix._10; mat[4] = matrix._11; mat[5] = matrix._12;
+		mat[6] = matrix._20; mat[7] = matrix._21; mat[8] = matrix._22;
+		Krom.setMatrix3Compute(location, mat);
 	}
 
 	public static function setBuffer(buffer: ShaderStorageBuffer, index: Int) {

--- a/Backends/Krom/kha/graphics4/IndexBuffer.hx
+++ b/Backends/Krom/kha/graphics4/IndexBuffer.hx
@@ -10,7 +10,6 @@ class IndexBuffer {
 	
 	public function new(indexCount: Int, usage: Usage, canRead: Bool = false) {
 		this.indexCount = indexCount;
-		_data = new Uint32Array(indexCount);
 		buffer = Krom.createIndexBuffer(indexCount);
 	}
 
@@ -20,13 +19,14 @@ class IndexBuffer {
 	}
 	
 	public function lock(?start: Int, ?count: Int): Uint32Array {
+		_data = Krom.lockIndexBuffer(buffer);
 		if (start == null) start = 0;
 		if (count == null) count = indexCount;
 		return _data.subarray(start, start + count);
 	}
 	
 	public function unlock(): Void {
-		Krom.setIndices(buffer, _data);
+		Krom.unlockIndexBuffer(buffer);
 	}
 	
 	public function set(): Void {

--- a/Backends/Krom/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Krom/kha/graphics4/VertexBuffer.hx
@@ -15,7 +15,6 @@ class VertexBuffer {
 		this.vertexCount = vertexCount;
 		this.structure = structure;
 		buffer = Krom.createVertexBuffer(vertexCount, structure.elements, instanceDataStepRate);
-		_data = new Float32Array(vertexCount * Std.int(structure.byteSize() / 4));
 	}
 
 	public function delete() {
@@ -24,11 +23,12 @@ class VertexBuffer {
 	}
 	
 	public function lock(?start: Int, ?count: Int): Float32Array {
+		_data = Krom.lockVertexBuffer(buffer);
 		return _data;
 	}
 	
 	public function unlock(): Void {
-		Krom.setVertices(buffer, _data);
+		Krom.unlockVertexBuffer(buffer);
 	}
 	
 	public function stride(): Int {

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -170,12 +170,20 @@ class Graphics implements kha.graphics4.Graphics {
 		Krom.setFloat4(location, value.x, value.y, value.z, value.w);
 	}
 
+	static var mat = new kha.arrays.Float32Array(16);
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
-		Krom.setMatrix(location, matrix);
+		mat[0] = matrix._00; mat[1] = matrix._01; mat[2] = matrix._02; mat[3] = matrix._03;
+		mat[4] = matrix._10; mat[5] = matrix._11; mat[6] = matrix._12; mat[7] = matrix._13;
+		mat[8] = matrix._20; mat[9] = matrix._21; mat[10] = matrix._22; mat[11] = matrix._23;
+		mat[12] = matrix._30; mat[13] = matrix._31; mat[14] = matrix._32; mat[15] = matrix._33;
+		Krom.setMatrix(location, mat);
 	}
 
 	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
-		Krom.setMatrix3(location, matrix);
+		mat[0] = matrix._00; mat[1] = matrix._01; mat[2] = matrix._02;
+		mat[3] = matrix._10; mat[4] = matrix._11; mat[5] = matrix._12;
+		mat[6] = matrix._20; mat[7] = matrix._21; mat[8] = matrix._22;
+		Krom.setMatrix3(location, mat);
 	}
 
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {


### PR DESCRIPTION
I continued my profiling session, results from the matrix-math heavy demo:
`hxcpp`/`hlc` - 6ms
`krom` before - 11.2ms :(
`krom` now - 5.1ms :) 

These should be all non-breaking changes, passing matrices is much faster now and I even got V8 to share the vertex/index buffers directly with Krom, so less memory usage & no copy.

And this is still without the 32bit float math. Back to the wasm experiments!

To go with https://github.com/Kode/Krom/pull/68.