### PR TITLE
fix missed Key -> KeyCode changes

### DIFF
--- a/Sources/kha/network/ControllerBuilder.hx
+++ b/Sources/kha/network/ControllerBuilder.hx
@@ -38,7 +38,7 @@ class ControllerBuilder {
 								size += 8;
 							case "Bool":
 								size += 1;
-							case "Key":
+							case "KeyCode":
 								size += 1;
 							}
 						default:
@@ -82,11 +82,11 @@ class ControllerBuilder {
 									bytes.set($v { index } , $i { argname } ? 1 : 0);
 								};
 								index += 1;
-							case "Key":
+							case "KeyCode":
 								var argname = arg.name;
 								expr = macro @:mergeBlock {
 									$expr;
-									bytes.set($v { index } , Type.enumIndex($i { argname } ));
+									bytes.set($v { index } , $i { argname });
 								};
 								index += 1;
 							}


### PR DESCRIPTION
I think this wasn't changed when kha.Key was removed in favor of kha.input.KeyCode?
