### PR TITLE
fix compilation on static targets

### DIFF
--- a/Sources/kha/System.hx
+++ b/Sources/kha/System.hx
@@ -8,7 +8,7 @@ class SystemOptions {
 	@:optional public var window: WindowOptions = null;
 	@:optional public var framebuffer: FramebufferOptions = null;
 
-	public function new(title: String = "Kha", width: Int = 800, height: Int = 600, window: WindowOptions = null, framebuffer: FramebufferOptions = null) {
+	public function new(title: String = "Kha", ?width: Int = 800, ?height: Int = 600, window: WindowOptions = null, framebuffer: FramebufferOptions = null) {
 		this.title = title;
 		this.width = width;
 		this.height = height;


### PR DESCRIPTION
Wouldn't compile as `width` and `height` weren't optional in the parameter list

```haxe
kha.System.start({ title: "foo" }, ...)
```
