### PR TITLE
Graphics5 for Kore

### DIFF
--- a/Backends/Kore/kha/SystemImpl.hx
+++ b/Backends/Kore/kha/SystemImpl.hx
@@ -128,8 +128,9 @@ class SystemImpl {
 
 #if (!VR_GEAR_VR && !VR_RIFT)
 		var g4 = new kha.kore.graphics4.Graphics();
-		var framebuffer = new Framebuffer(0, null, null, g4);
-		framebuffer.init(new kha.graphics2.Graphics1(framebuffer), new kha.kore.graphics4.Graphics2(framebuffer), g4);
+		var g5 = new kha.kore.graphics5.Graphics();
+		var framebuffer = new Framebuffer(0, null, null, g4, g5);
+		framebuffer.init(new kha.graphics2.Graphics1(framebuffer), new kha.kore.graphics4.Graphics2(framebuffer), g4, g5);
 		framebuffers.push(framebuffer);
 #end
 

--- a/Backends/Kore/kha/graphics5/AccelerationStructure.hx
+++ b/Backends/Kore/kha/graphics5/AccelerationStructure.hx
@@ -1,0 +1,22 @@
+package kha.graphics5;
+
+#if kha_dxr
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/RayTrace.h>
+')
+
+@:headerClassCode("Kore::Graphics5::AccelerationStructure* accel;")
+class AccelerationStructure {
+
+	public function new(commandList: CommandList, vb: VertexBuffer, ib: IndexBuffer) {
+		init(commandList, vb, ib);
+	}
+
+	function init(commandList: CommandList, vb: VertexBuffer, ib: IndexBuffer) {
+		untyped __cpp__("accel = new Kore::Graphics5::AccelerationStructure(commandList->commandList, vb->buffer, ib->buffer);");
+	}
+}
+
+#end

--- a/Backends/Kore/kha/graphics5/CommandList.hx
+++ b/Backends/Kore/kha/graphics5/CommandList.hx
@@ -1,0 +1,52 @@
+package kha.graphics5;
+
+class CommandList {
+
+	public function new() {
+		
+	}
+
+	public function begin(): Void {
+
+	}
+
+	public function end(): Void {
+
+	}
+
+	public function renderTargetToFramebufferBarrier(renderTarget: RenderTarget): Void {
+
+	}
+
+	public function framebufferToRenderTargetBarrier(renderTarget: RenderTarget): Void {
+
+	}
+
+	public function setRenderTargets(targets:Array<RenderTarget>): Void {
+
+	}
+
+	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {
+
+	}
+
+	public function setIndexBuffer(indexBuffer: IndexBuffer): Void {
+
+	}
+
+	public function setVertexBuffers(vertexBuffers: Array<VertexBuffer>, offsets: Array<Int>): Void {
+
+	}
+
+	public function setPipelineLayout(): Void {
+
+	}
+
+	public function setPipeline(pipeline: PipelineState): Void {
+
+	}
+
+	public function clear(target:RenderTarget, ?color: Color, ?depth: Float, ?stencil: Int): Void {
+
+	}
+}

--- a/Backends/Kore/kha/graphics5/CommandList.hx
+++ b/Backends/Kore/kha/graphics5/CommandList.hx
@@ -1,52 +1,76 @@
 package kha.graphics5;
 
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/CommandList.h>
+')
+
+@:headerClassCode("Kore::Graphics5::CommandList* commandList;")
 class CommandList {
 
 	public function new() {
-		
+		init();
+	}
+
+	@:functionCode('commandList = new Kore::Graphics5::CommandList();')
+	private function init(): Void {
+
 	}
 
 	public function begin(): Void {
-
+		untyped __cpp__("commandList->begin();");
 	}
 
 	public function end(): Void {
-
+		untyped __cpp__("commandList->end();");
 	}
 
 	public function renderTargetToFramebufferBarrier(renderTarget: RenderTarget): Void {
-
+		untyped __cpp__("commandList->renderTargetToFramebufferBarrier(renderTarget->renderTarget);");
 	}
 
 	public function framebufferToRenderTargetBarrier(renderTarget: RenderTarget): Void {
-
+		untyped __cpp__("commandList->framebufferToRenderTargetBarrier(renderTarget->renderTarget);");
 	}
 
 	public function setRenderTargets(targets:Array<RenderTarget>): Void {
-
+		var len = targets.length;
+		var image1 = targets[0];
+		var image2 = targets[1];
+		var image3 = targets[2];
+		var image4 = targets[3];
+		var image5 = targets[4];
+		var image6 = targets[5];
+		var image7 = targets[6];
+		untyped __cpp__("Kore::Graphics5::RenderTarget* renderTargets[8] = { image1 == null() ? nullptr : image1->renderTarget, image2 == null() ? nullptr : image2->renderTarget, image3 == null() ? nullptr : image3->renderTarget, image4 == null() ? nullptr : image4->renderTarget, image5 == null() ? nullptr : image5->renderTarget, image6 == null() ? nullptr : image6->renderTarget, image7 == null() ? nullptr : image7->renderTarget }; commandList->setRenderTargets(renderTargets, len);");
 	}
 
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {
-
+		untyped __cpp__("commandList->drawIndexedVertices();");
 	}
 
 	public function setIndexBuffer(indexBuffer: IndexBuffer): Void {
-
+		untyped __cpp__("commandList->setIndexBuffer(*indexBuffer->buffer);");
 	}
 
 	public function setVertexBuffers(vertexBuffers: Array<VertexBuffer>, offsets: Array<Int>): Void {
-
+		var vb = vertexBuffers[0];
+		untyped __cpp__("int offs[1] = { 0 }; Kore::Graphics5::VertexBuffer* buffers[1] = { vb->buffer }; commandList->setVertexBuffers(buffers, offs, 1);");
 	}
 
 	public function setPipelineLayout(): Void {
-
+		untyped __cpp__("commandList->setPipelineLayout();");
 	}
 
 	public function setPipeline(pipeline: PipelineState): Void {
-
+		untyped __cpp__("commandList->setPipeline(pipeline->pipeline);");
 	}
 
 	public function clear(target:RenderTarget, ?color: Color, ?depth: Float, ?stencil: Int): Void {
+		untyped __cpp__("commandList->clear(target->renderTarget, Kore::Graphics5::ClearColorFlag);");
+	}
 
+	public function upload(indexBuffer: IndexBuffer): Void {
+		untyped __cpp__("commandList->upload(indexBuffer->buffer);");
 	}
 }

--- a/Backends/Kore/kha/graphics5/ConstantBuffer.hx
+++ b/Backends/Kore/kha/graphics5/ConstantBuffer.hx
@@ -1,0 +1,30 @@
+package kha.graphics5;
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/ConstantBuffer.h>
+')
+
+@:headerClassCode("Kore::Graphics5::ConstantBuffer* buffer;")
+class ConstantBuffer {
+	
+	public function new(size: Int) {
+		init(size);
+	}
+
+	function init(size: Int) {
+		untyped __cpp__("buffer = new Kore::Graphics5::ConstantBuffer(size)");
+	}
+
+	public function lock(): Void {
+		untyped __cpp__("buffer->lock()");
+	}
+
+	public function unlock(): Void {
+		untyped __cpp__("buffer->unlock()");
+	}
+
+	public function setFloat(offset: Int, value: FastFloat): Void {
+		untyped __cpp__("buffer->setFloat(offset, value)");
+	}
+}

--- a/Backends/Kore/kha/graphics5/FragmentShader.hx
+++ b/Backends/Kore/kha/graphics5/FragmentShader.hx
@@ -1,0 +1,38 @@
+package kha.graphics5;
+
+import haxe.io.Bytes;
+import kha.Blob;
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
+@:cppFileCode('
+#ifndef INCLUDED_haxe_io_Bytes
+#include <haxe/io/Bytes.h>
+#endif
+')
+
+@:headerClassCode("Kore::Graphics5::Shader* shader;")
+class FragmentShader {
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		if (sources != null) {
+			init(sources[0], files[0]);
+		}
+	}
+	
+	private function init(source: Blob, file: String): Void {
+		untyped __cpp__('shader = new Kore::Graphics5::Shader(source->bytes->b->Pointer(), source->get_length(), Kore::Graphics5::FragmentShader);');
+	}
+
+	// public static function fromSource(source: String): FragmentShader {
+		// var fragmentShader = new FragmentShader(null, null);
+		// untyped __cpp__('fragmentShader->shader = new Kore::Graphics5::Shader(source, Kore::Graphics5::FragmentShader);');
+		// return fragmentShader;
+	// }
+	
+	public function delete(): Void {
+		untyped __cpp__('delete shader; shader = nullptr;');
+	}
+}

--- a/Backends/Kore/kha/graphics5/IndexBuffer.hx
+++ b/Backends/Kore/kha/graphics5/IndexBuffer.hx
@@ -1,0 +1,35 @@
+package kha.graphics5;
+
+import kha.arrays.Uint32Array;
+
+class IndexBuffer {
+	private var data: Uint32Array;
+	private var myCount: Int;
+	
+	public function new(indexCount: Int, usage: Usage, canRead: Bool = false) {
+		myCount = indexCount;
+		data = new Uint32Array();
+	}
+	
+	public function delete(): Void {
+		
+	}
+	
+	private function lock2(start: Int, count: Int): Uint32Array {
+		return data;
+	}
+
+	public function lock(?start: Int, ?count: Int): Uint32Array {
+		if (start == null) start = 0;
+		if (count == null) count = this.count();
+		return lock2(start, count);
+	}
+	
+	public function unlock(): Void {
+		
+	}
+	
+	public function count(): Int {
+		return myCount;
+	}
+}

--- a/Backends/Kore/kha/graphics5/IndexBuffer.hx
+++ b/Backends/Kore/kha/graphics5/IndexBuffer.hx
@@ -2,6 +2,12 @@ package kha.graphics5;
 
 import kha.arrays.Uint32Array;
 
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
+@:headerClassCode("Kore::Graphics5::IndexBuffer* buffer;")
 class IndexBuffer {
 	private var data: Uint32Array;
 	private var myCount: Int;
@@ -9,12 +15,18 @@ class IndexBuffer {
 	public function new(indexCount: Int, usage: Usage, canRead: Bool = false) {
 		myCount = indexCount;
 		data = new Uint32Array();
+		untyped __cpp__('buffer = new Kore::Graphics5::IndexBuffer(indexCount, true);');
 	}
 	
 	public function delete(): Void {
-		
+		untyped __cpp__('delete buffer; buffer = nullptr;');
 	}
 	
+	@:functionCode('
+		data->self.data = (unsigned int*)buffer->lock() + start;
+		data->self.myLength = count;
+		return data;
+	')
 	private function lock2(start: Int, count: Int): Uint32Array {
 		return data;
 	}
@@ -25,6 +37,7 @@ class IndexBuffer {
 		return lock2(start, count);
 	}
 	
+	@:functionCode('buffer->unlock();')
 	public function unlock(): Void {
 		
 	}

--- a/Backends/Kore/kha/graphics5/PipelineState.hx
+++ b/Backends/Kore/kha/graphics5/PipelineState.hx
@@ -1,14 +1,114 @@
 package kha.graphics5;
 
+import kha.graphics5.FragmentShader;
+import kha.graphics5.VertexData;
+import kha.graphics5.VertexElement;
+import kha.graphics5.VertexShader;
+import kha.graphics5.VertexStructure;
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+#include <Kore/Graphics5/PipelineState.h>
+')
+
+@:cppFileCode('
+Kore::Graphics5::ZCompareMode convertCompareMode(int mode) {
+	switch (mode) {
+	case 0:
+		return Kore::Graphics5::ZCompareAlways;
+	case 1:
+		return Kore::Graphics5::ZCompareNever;
+	case 2:
+		return Kore::Graphics5::ZCompareEqual;
+	case 3:
+		return Kore::Graphics5::ZCompareNotEqual;
+	case 4:
+		return Kore::Graphics5::ZCompareLess;
+	case 5:
+		return Kore::Graphics5::ZCompareLessEqual;
+	case 6:
+		return Kore::Graphics5::ZCompareGreater;
+	case 7:
+	default:
+		return Kore::Graphics5::ZCompareGreaterEqual;
+	}
+}
+
+Kore::Graphics5::StencilAction convertStencilAction(int action) {
+	switch (action) {
+	case 0:
+		return Kore::Graphics5::Keep;
+	case 1:
+		return Kore::Graphics5::Zero;
+	case 2:
+		return Kore::Graphics5::Replace;
+	case 3:
+		return Kore::Graphics5::Increment;
+	case 4:
+		return Kore::Graphics5::IncrementWrap;
+	case 5:
+		return Kore::Graphics5::Decrement;
+	case 6:
+		return Kore::Graphics5::DecrementWrap;
+	case 7:
+	default:
+		return Kore::Graphics5::Invert;	
+	}
+}
+')
+
+@:headerClassCode("Kore::Graphics5::PipelineState* pipeline;")
+@:keep
 class PipelineState extends PipelineStateBase {
 	public function new() {
 		super();
+		untyped __cpp__('pipeline = new Kore::Graphics5::PipelineState;');
 	}
 	
 	public function delete(): Void {
-
+		untyped __cpp__('delete pipeline; pipeline = nullptr;');
 	}
 	
+	@:functionCode('
+		pipeline->vertexShader = vertexShader->shader;
+		pipeline->fragmentShader = fragmentShader->shader;
+		// if (geometryShader != null()) pipeline->geometryShader = geometryShader->shader;
+		// if (tessellationControlShader != null()) pipeline->tessellationControlShader = tessellationControlShader->shader;
+		// if (tessellationEvaluationShader != null()) pipeline->tessellationEvaluationShader = tessellationEvaluationShader->shader;
+		Kore::Graphics4::VertexStructure s0, s1, s2, s3;
+		Kore::Graphics4::VertexStructure* structures2[4] = { &s0, &s1, &s2, &s3 };
+		::kha::graphics4::VertexStructure* structures[4] = { &structure0, &structure1, &structure2, &structure3 };
+		for (int i1 = 0; i1 < size; ++i1) {
+			structures2[i1]->instanced = (*structures[i1])->instanced;
+			for (int i2 = 0; i2 < (*structures[i1])->size(); ++i2) {
+				Kore::Graphics4::VertexData data;
+				switch ((*structures[i1])->get(i2)->data->index) {
+				case 0:
+					data = Kore::Graphics4::Float1VertexData;
+					break;
+				case 1:
+					data = Kore::Graphics4::Float2VertexData;
+					break;
+				case 2:
+					data = Kore::Graphics4::Float3VertexData;
+					break;
+				case 3:
+					data = Kore::Graphics4::Float4VertexData;
+					break;
+				case 4:
+					data = Kore::Graphics4::Float4x4VertexData;
+					break;
+				}
+				pipeline->inputLayout[i1] = structures2[i1];
+				pipeline->inputLayout[i1]->add((*structures[i1])->get(i2)->name, data);
+			}
+		}
+		for (int i = size; i < 16; ++i) {
+			pipeline->inputLayout[i] = nullptr;
+		}
+		pipeline->compile();
+	')
 	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, size: Int): Void {
 		
 	}
@@ -30,6 +130,7 @@ class PipelineState extends PipelineStateBase {
 		return location;
 	}
 	
+	// @:functionCode('location->location = pipeline->getConstantLocation(name.c_str());')
 	private function initConstantLocation(location: kha.kore.graphics4.ConstantLocation, name: String): Void {
 		
 	}
@@ -40,6 +141,7 @@ class PipelineState extends PipelineStateBase {
 		return unit;
 	}
 	
+	// @:functionCode('unit->unit = pipeline->getTextureUnit(name.c_str());')
 	private function initTextureUnit(unit: kha.kore.graphics4.TextureUnit, name: String): Void {
 		
 	}
@@ -71,16 +173,113 @@ class PipelineState extends PipelineStateBase {
 		}
 	}
 	
+	@:functionCode('
+		switch (cullMode) {
+		case 0:
+			pipeline->cullMode = Kore::Graphics5::Clockwise;
+			break;
+		case 1:
+			pipeline->cullMode = Kore::Graphics5::CounterClockwise;
+			break;
+		case 2:
+			pipeline->cullMode = Kore::Graphics5::NoCulling;
+			break;
+		}
+
+		switch (depthMode) {
+		case 0:
+			pipeline->depthMode = Kore::Graphics5::ZCompareAlways;
+			break;
+		case 1:
+			pipeline->depthMode = Kore::Graphics5::ZCompareNever;
+			break;
+		case 2:
+			pipeline->depthMode = Kore::Graphics5::ZCompareEqual;
+			break;
+		case 3:
+			pipeline->depthMode = Kore::Graphics5::ZCompareNotEqual;
+			break;
+		case 4:
+			pipeline->depthMode = Kore::Graphics5::ZCompareLess;
+			break;
+		case 5:
+			pipeline->depthMode = Kore::Graphics5::ZCompareLessEqual;
+			break;
+		case 6:
+			pipeline->depthMode = Kore::Graphics5::ZCompareGreater;
+			break;
+		case 7:
+			pipeline->depthMode = Kore::Graphics5::ZCompareGreaterEqual;
+			break;
+		}
+		pipeline->depthWrite = depthWrite;
+		
+		pipeline->stencilMode = convertCompareMode(stencilMode);
+		pipeline->stencilBothPass = convertStencilAction(stencilBothPass);
+		pipeline->stencilDepthFail = convertStencilAction(stencilDepthFail);
+		pipeline->stencilFail = convertStencilAction(stencilFail);
+		pipeline->stencilReferenceValue = stencilReferenceValue;
+		pipeline->stencilReadMask = stencilReadMask;
+		pipeline->stencilWriteMask = stencilWriteMask;
+		
+		pipeline->blendSource = (Kore::Graphics5::BlendingOperation)blendSource;
+		pipeline->blendDestination = (Kore::Graphics5::BlendingOperation)blendDestination;
+		pipeline->alphaBlendSource = (Kore::Graphics5::BlendingOperation)alphaBlendSource;
+		pipeline->alphaBlendDestination = (Kore::Graphics5::BlendingOperation)alphaBlendDestination;
+		
+		pipeline->colorWriteMaskRed = colorWriteMaskRed;
+		pipeline->colorWriteMaskGreen = colorWriteMaskGreen;
+		pipeline->colorWriteMaskBlue = colorWriteMaskBlue;
+		pipeline->colorWriteMaskAlpha = colorWriteMaskAlpha;
+		
+		pipeline->conservativeRasterization = conservativeRasterization;
+	')
 	private function setStates(cullMode: Int, depthMode: Int, stencilMode: Int, stencilBothPass: Int, stencilDepthFail: Int, stencilFail: Int,
 	blendSource: Int, blendDestination: Int, alphaBlendSource: Int, alphaBlendDestination: Int): Void {
 		
 	}
 	
-	private function set2(): Void {
+	// @:functionCode('Kore::Graphics4::setPipeline(pipeline);')
+	// private function set2(): Void {
 		
+	// }
+	
+	// public function set(): Void {
+	// 	set2();
+	// }
+	
+	@:noCompletion
+	public static function _unused1(): VertexElement {
+		return null;
 	}
 	
-	public function set(): Void {
-		set2();
+	@:noCompletion
+	public static function _unused2(): VertexData {
+		return null;
+	}
+	
+	@:noCompletion
+	public static function _unused3(): VertexShader {
+		return null;
+	}
+	
+	@:noCompletion
+	public static function _unused4(): FragmentShader {
+		return null;
+	}
+	
+	@:noCompletion
+	public static function _unused5(): GeometryShader {
+		return null;
+	}
+	
+	@:noCompletion
+	public static function _unused6(): TessellationControlShader {
+		return null;
+	}
+	
+	@:noCompletion
+	public static function _unused7(): TessellationEvaluationShader {
+		return null;
 	}
 }

--- a/Backends/Kore/kha/graphics5/PipelineState.hx
+++ b/Backends/Kore/kha/graphics5/PipelineState.hx
@@ -1,0 +1,86 @@
+package kha.graphics5;
+
+class PipelineState extends PipelineStateBase {
+	public function new() {
+		super();
+	}
+	
+	public function delete(): Void {
+
+	}
+	
+	private function linkWithStructures2(structure0: VertexStructure, structure1: VertexStructure, structure2: VertexStructure, structure3: VertexStructure, size: Int): Void {
+		
+	}
+	
+	public function compile(): Void {
+		setStates(cullMode.getIndex(), depthMode.getIndex(), stencilMode.getIndex(), stencilBothPass.getIndex(), stencilDepthFail.getIndex(), stencilFail.getIndex(),
+		getBlendFunc(blendSource), getBlendFunc(blendDestination), getBlendFunc(alphaBlendSource), getBlendFunc(alphaBlendDestination));
+		linkWithStructures2(
+			inputLayout.length > 0 ? inputLayout[0] : null,
+			inputLayout.length > 1 ? inputLayout[1] : null,
+			inputLayout.length > 2 ? inputLayout[2] : null,
+			inputLayout.length > 3 ? inputLayout[3] : null,
+			inputLayout.length);
+	}
+	
+	public function getConstantLocation(name: String): kha.graphics4.ConstantLocation {
+		var location = new kha.kore.graphics4.ConstantLocation();
+		initConstantLocation(location, name);
+		return location;
+	}
+	
+	private function initConstantLocation(location: kha.kore.graphics4.ConstantLocation, name: String): Void {
+		
+	}
+		
+	public function getTextureUnit(name: String): kha.graphics4.TextureUnit {
+		var unit = new kha.kore.graphics4.TextureUnit();
+		initTextureUnit(unit, name);
+		return unit;
+	}
+	
+	private function initTextureUnit(unit: kha.kore.graphics4.TextureUnit, name: String): Void {
+		
+	}
+	
+	private static function getBlendFunc(factor: BlendingFactor): Int {
+		switch (factor) {
+		case BlendOne, Undefined:
+			return 0;
+		case BlendZero:
+			return 1;
+		case SourceAlpha:
+			return 2;
+		case DestinationAlpha:
+			return 3;
+		case InverseSourceAlpha:
+			return 4;
+		case InverseDestinationAlpha:
+			return 5;
+		case SourceColor:
+			return 6;
+		case DestinationColor:
+			return 7;
+		case InverseSourceColor:
+			return 8;
+		case InverseDestinationColor:
+			return 9;
+		default:
+			return 0;
+		}
+	}
+	
+	private function setStates(cullMode: Int, depthMode: Int, stencilMode: Int, stencilBothPass: Int, stencilDepthFail: Int, stencilFail: Int,
+	blendSource: Int, blendDestination: Int, alphaBlendSource: Int, alphaBlendDestination: Int): Void {
+		
+	}
+	
+	private function set2(): Void {
+		
+	}
+	
+	public function set(): Void {
+		set2();
+	}
+}

--- a/Backends/Kore/kha/graphics5/RayTracePipeline.hx
+++ b/Backends/Kore/kha/graphics5/RayTracePipeline.hx
@@ -1,0 +1,24 @@
+package kha.graphics5;
+
+#if kha_dxr
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/RayTrace.h>
+')
+
+@:cppFileCode('
+#ifndef INCLUDED_haxe_io_Bytes
+#include <haxe/io/Bytes.h>
+#endif
+')
+
+@:headerClassCode("Kore::Graphics5::RayTracePipeline* pipeline;")
+class RayTracePipeline {
+
+	public function new(commandList: CommandList, rayShader: kha.Blob, hitShader: kha.Blob, missShader: kha.Blob, constantBuffer: ConstantBuffer) {
+		untyped __cpp__("pipeline = new Kore::Graphics5::RayTracePipeline(commandList->commandList, rayShader->bytes->b->Pointer(), rayShader->get_length(), hitShader->bytes->b->Pointer(), hitShader->get_length(), missShader->bytes->b->Pointer(), missShader->get_length(), constantBuffer->buffer);");
+	}
+}
+
+#end

--- a/Backends/Kore/kha/graphics5/RayTraceTarget.hx
+++ b/Backends/Kore/kha/graphics5/RayTraceTarget.hx
@@ -1,0 +1,22 @@
+package kha.graphics5;
+
+#if kha_dxr
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/RayTrace.h>
+')
+
+@:headerClassCode("Kore::Graphics5::RayTraceTarget* target;")
+class RayTraceTarget {
+
+	public function new(width: Int, height: Int) {
+		init(width, height);
+	}
+
+	function init(width: Int, height: Int) {
+		untyped __cpp__("target = new Kore::Graphics5::RayTraceTarget(width, height);");
+	}
+}
+
+#end

--- a/Backends/Kore/kha/graphics5/RenderTarget.hx
+++ b/Backends/Kore/kha/graphics5/RenderTarget.hx
@@ -1,0 +1,8 @@
+package kha.graphics5;
+
+class RenderTarget {
+	
+	public function new(width: Int, height: Int, depthBufferBits: Int, antialiasing: Bool, format: TextureFormat, stencilBufferBits: Int, contextId: Int) {
+
+	}
+}

--- a/Backends/Kore/kha/graphics5/RenderTarget.hx
+++ b/Backends/Kore/kha/graphics5/RenderTarget.hx
@@ -1,8 +1,40 @@
 package kha.graphics5;
 
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
+@:headerClassCode("Kore::Graphics5::RenderTarget* renderTarget;")
 class RenderTarget {
 	
 	public function new(width: Int, height: Int, depthBufferBits: Int, antialiasing: Bool, format: TextureFormat, stencilBufferBits: Int, contextId: Int) {
+		init(width, height, depthBufferBits, antialiasing, getRenderTargetFormat(format), stencilBufferBits, contextId);
+	}
 
+	@:functionCode('renderTarget = new Kore::Graphics5::RenderTarget(width, height, depthBufferBits, antialiasing, (Kore::Graphics5::RenderTargetFormat)format, stencilBufferBits, contextId);')
+	private function init(width: Int, height: Int, depthBufferBits: Int, antialiasing: Bool, format: Int, stencilBufferBits: Int, contextId: Int): Void {
+
+	}
+
+	private static function getRenderTargetFormat(format: TextureFormat): Int {
+		switch (format) {
+		case RGBA32:	// Target32Bit
+			return 0;
+		case RGBA64:	// Target64BitFloat
+			return 1;
+		case A32:		// Target32BitRedFloat
+			return 2;
+		case RGBA128:	// Target128BitFloat
+			return 3;
+		case DEPTH16:	// Target16BitDepth
+			return 4;
+		case L8:
+			return 5;	// Target8BitRed
+		case A16:
+			return 6;	// Target16BitRedFloat
+		default:
+			return 0;
+		}
 	}
 }

--- a/Backends/Kore/kha/graphics5/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics5/VertexBuffer.hx
@@ -1,0 +1,42 @@
+package kha.graphics5;
+
+import kha.arrays.Float32Array;
+
+class VertexBuffer {
+	private var data: Float32Array;
+	
+	public function new(vertexCount: Int, structure: VertexStructure, usage: Usage, instanceDataStepRate: Int = 0, canRead: Bool = false) {
+		init(vertexCount, structure, usage.getIndex(), instanceDataStepRate);
+		data = new Float32Array();
+	}
+	
+	public function delete(): Void {
+		
+	}
+	
+	private function init(vertexCount: Int, structure: VertexStructure, usage: Int, instanceDataStepRate: Int) {
+		
+	}
+
+	private function lock2(start: Int, count: Int): Float32Array {
+		return data;
+	}
+
+	public function lock(?start: Int, ?count: Int): Float32Array {
+		if (start == null) start = 0;
+		if (count == null) count = this.count();
+		return lock2(start, count);
+	}
+	
+	public function unlock(): Void {
+		
+	}
+	
+	public function stride(): Int {
+		return 0;
+	}
+	
+	public function count(): Int {
+		return 0;
+	}
+}

--- a/Backends/Kore/kha/graphics5/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics5/VertexBuffer.hx
@@ -1,7 +1,16 @@
 package kha.graphics5;
 
 import kha.arrays.Float32Array;
+import kha.graphics5.VertexData;
+import kha.graphics5.VertexElement;
+import kha.graphics5.VertexStructure;
 
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
+@:headerClassCode("Kore::Graphics5::VertexBuffer* buffer;")
 class VertexBuffer {
 	private var data: Float32Array;
 	
@@ -11,13 +20,43 @@ class VertexBuffer {
 	}
 	
 	public function delete(): Void {
-		
+		untyped __cpp__('delete buffer; buffer = nullptr;');
 	}
 	
+	@:functionCode("
+		Kore::Graphics4::VertexStructure structure2;
+		for (int i = 0; i < structure->size(); ++i) {
+			Kore::Graphics4::VertexData data;
+			switch (structure->get(i)->data->index) {
+			case 0:
+				data = Kore::Graphics4::Float1VertexData;
+				break;
+			case 1:
+				data = Kore::Graphics4::Float2VertexData;
+				break;
+			case 2:
+				data = Kore::Graphics4::Float3VertexData;
+				break;
+			case 3:
+				data = Kore::Graphics4::Float4VertexData;
+				break;
+			case 4:
+				data = Kore::Graphics4::Float4x4VertexData;
+				break;
+			}
+			structure2.add(structure->get(i)->name, data);
+		}
+		buffer = new Kore::Graphics5::VertexBuffer(vertexCount, structure2, false);
+	")
 	private function init(vertexCount: Int, structure: VertexStructure, usage: Int, instanceDataStepRate: Int) {
 		
 	}
 
+	@:functionCode('
+		data->self.data = buffer->lock() + start * buffer->stride() / 4;
+		data->self.myLength = count * buffer->stride() / 4;
+		return data;
+	')
 	private function lock2(start: Int, count: Int): Float32Array {
 		return data;
 	}
@@ -28,15 +67,30 @@ class VertexBuffer {
 		return lock2(start, count);
 	}
 	
+	@:functionCode('buffer->unlock();')
 	public function unlock(): Void {
 		
 	}
 	
+	@:functionCode("return buffer->stride();")
 	public function stride(): Int {
 		return 0;
 	}
 	
+	@:functionCode("return buffer->count();")
 	public function count(): Int {
 		return 0;
+	}
+
+	@:noCompletion
+	@:keep
+	public static function _unused1(): VertexElement {
+		return null;
+	}
+	
+	@:noCompletion
+	@:keep
+	public static function _unused2(): VertexData {
+		return null;
 	}
 }

--- a/Backends/Kore/kha/graphics5/VertexShader.hx
+++ b/Backends/Kore/kha/graphics5/VertexShader.hx
@@ -1,0 +1,38 @@
+package kha.graphics5;
+
+import haxe.io.Bytes;
+import kha.Blob;
+
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
+@:cppFileCode('
+#ifndef INCLUDED_haxe_io_Bytes
+#include <haxe/io/Bytes.h>
+#endif
+')
+
+@:headerClassCode("Kore::Graphics5::Shader* shader;")
+class VertexShader {
+	public function new(sources: Array<Blob>, files: Array<String>) {
+		if (sources != null) {
+			init(sources[0], files[0]);
+		}
+	}
+	
+	private function init(source: Blob, file: String): Void {
+		untyped __cpp__('shader = new Kore::Graphics5::Shader(source->bytes->b->Pointer(), source->get_length(), Kore::Graphics5::VertexShader);');
+	}
+
+	// public static function fromSource(source: String): VertexShader {
+		// var vertexShader = new VertexShader(null, null);
+		// untyped __cpp__('vertexShader->shader = new Kore::Graphics5::Shader(source, Kore::Graphics5::VertexShader);');
+		// return vertexShader;
+	// }
+	
+	public function delete(): Void {
+		untyped __cpp__('delete shader; shader = nullptr;');
+	}
+}

--- a/Backends/Kore/kha/kore/graphics5/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics5/Graphics.hx
@@ -1,0 +1,29 @@
+package kha.kore.graphics5;
+
+import kha.graphics5.RenderTarget;
+
+class Graphics implements kha.graphics5.Graphics {
+
+	private var target: Canvas;
+	
+	public function new(target: Canvas = null) {
+		this.target = target;
+	}
+
+	@:functionCode('return Kore::Graphics5::renderTargetsInvertedY();')
+	public function renderTargetsInvertedY(): Bool {
+		return false;
+	}
+
+	public function begin(target:RenderTarget): Void {
+		
+	}
+	
+	public function end(): Void {
+		
+	}
+
+	public function swapBuffers(): Void {
+		
+	}
+}

--- a/Backends/Kore/kha/kore/graphics5/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics5/Graphics.hx
@@ -1,10 +1,17 @@
 package kha.kore.graphics5;
 
 import kha.graphics5.RenderTarget;
+import kha.graphics5.CommandList;
+#if kha_dxr
+import kha.graphics5.AccelerationStructure;
+import kha.graphics5.RayTraceTarget;
+import kha.graphics5.RayTracePipeline;
+#end
 
 @:headerCode('
 #include <Kore/pch.h>
 #include <Kore/Graphics5/Graphics.h>
+#include <Kore/Graphics5/RayTrace.h>
 ')
 
 class Graphics implements kha.graphics5.Graphics {
@@ -19,7 +26,7 @@ class Graphics implements kha.graphics5.Graphics {
 		return untyped __cpp__("Kore::Graphics5::renderTargetsInvertedY();");
 	}
 
-	public function begin(target:RenderTarget): Void {
+	public function begin(target: RenderTarget): Void {
 		untyped __cpp__("Kore::Graphics5::begin(target->renderTarget);");
 	}
 	
@@ -30,4 +37,26 @@ class Graphics implements kha.graphics5.Graphics {
 	public function swapBuffers(): Void {
 		untyped __cpp__("Kore::Graphics5::swapBuffers();");
 	}
+
+	#if kha_dxr
+	public function setAccelerationStructure(accel: AccelerationStructure): Void {
+		untyped __cpp__("Kore::Graphics5::setAccelerationStructure(accel->accel);");
+	}
+
+	public function setRayTracePipeline(pipe: RayTracePipeline): Void {
+		untyped __cpp__("Kore::Graphics5::setRayTracePipeline(pipe->pipeline);");
+	}
+
+	public function setRayTraceTarget(target: RayTraceTarget): Void {
+		untyped __cpp__("Kore::Graphics5::setRayTraceTarget(target->target);");
+	}
+
+	public function dispatchRays(commandList: CommandList): Void {
+		untyped __cpp__("Kore::Graphics5::dispatchRays(commandList->commandList);");
+	}
+
+	public function copyRayTraceTarget(commandList: CommandList, renderTarget: RenderTarget, output: RayTraceTarget): Void {
+		untyped __cpp__("Kore::Graphics5::copyRayTraceTarget(commandList->commandList, renderTarget->renderTarget, output->target);");
+	}
+	#end
 }

--- a/Backends/Kore/kha/kore/graphics5/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics5/Graphics.hx
@@ -2,6 +2,11 @@ package kha.kore.graphics5;
 
 import kha.graphics5.RenderTarget;
 
+@:headerCode('
+#include <Kore/pch.h>
+#include <Kore/Graphics5/Graphics.h>
+')
+
 class Graphics implements kha.graphics5.Graphics {
 
 	private var target: Canvas;
@@ -10,20 +15,19 @@ class Graphics implements kha.graphics5.Graphics {
 		this.target = target;
 	}
 
-	@:functionCode('return Kore::Graphics5::renderTargetsInvertedY();')
 	public function renderTargetsInvertedY(): Bool {
-		return false;
+		return untyped __cpp__("Kore::Graphics5::renderTargetsInvertedY();");
 	}
 
 	public function begin(target:RenderTarget): Void {
-		
+		untyped __cpp__("Kore::Graphics5::begin(target->renderTarget);");
 	}
 	
 	public function end(): Void {
-		
+		untyped __cpp__("Kore::Graphics5::end();");
 	}
 
 	public function swapBuffers(): Void {
-		
+		untyped __cpp__("Kore::Graphics5::swapBuffers();");
 	}
 }

--- a/Backends/Kore/main.cpp
+++ b/Backends/Kore/main.cpp
@@ -1,6 +1,10 @@
 #include <Kore/pch.h>
 //#include <Kore/Application.h>
+// #ifdef KORE_G4ONG5
+// #include <Kore/Graphics5/Graphics.h>
+// #else
 #include <Kore/Graphics4/Graphics.h>
+// #endif
 #include <Kore/Input/Gamepad.h>
 #include <Kore/Input/Keyboard.h>
 #include <Kore/Input/Mouse.h>

--- a/Backends/Kore/main.cpp
+++ b/Backends/Kore/main.cpp
@@ -1,10 +1,6 @@
 #include <Kore/pch.h>
 //#include <Kore/Application.h>
-// #ifdef KORE_G4ONG5
-// #include <Kore/Graphics5/Graphics.h>
-// #else
 #include <Kore/Graphics4/Graphics.h>
-// #endif
 #include <Kore/Input/Gamepad.h>
 #include <Kore/Input/Keyboard.h>
 #include <Kore/Input/Mouse.h>

--- a/Sources/kha/Framebuffer.hx
+++ b/Sources/kha/Framebuffer.hx
@@ -10,22 +10,25 @@ class Framebuffer implements Canvas {
 	var graphics1: kha.graphics1.Graphics;
 	var graphics2: kha.graphics2.Graphics;
 	var graphics4: kha.graphics4.Graphics;
+	var graphics5: kha.graphics5.Graphics;
 
 	@:noCompletion
 	@:noDoc
-	public function new(window: Int, g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics) {
+	public function new(window: Int, g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, g5: kha.graphics5.Graphics) {
 		this.window = window;
 		this.graphics1 = g1;
 		this.graphics2 = g2;
 		this.graphics4 = g4;
+		this.graphics5 = g5;
 	}
 
 	@:noCompletion
 	@:noDoc
-	public function init(g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics): Void {
+	public function init(g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, g5: kha.graphics5.Graphics): Void {
 		this.graphics1 = g1;
 		this.graphics2 = g2;
 		this.graphics4 = g4;
+		this.graphics5 = g5;
 	}
 
 	/**
@@ -53,6 +56,15 @@ class Framebuffer implements Canvas {
 
 	private function get_g4(): kha.graphics4.Graphics {
 		return graphics4;
+	}
+
+	/**
+	 * Returns a kha.graphics5.Graphics interface for the framebuffer.
+	 */
+	public var g5(get, never): kha.graphics5.Graphics;
+
+	private function get_g5(): kha.graphics5.Graphics {
+		return graphics5;
 	}
 
 	/**

--- a/Sources/kha/Framebuffer.hx
+++ b/Sources/kha/Framebuffer.hx
@@ -14,7 +14,7 @@ class Framebuffer implements Canvas {
 
 	@:noCompletion
 	@:noDoc
-	public function new(window: Int, g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, g5: kha.graphics5.Graphics) {
+	public function new(window: Int, g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, ?g5: kha.graphics5.Graphics) {
 		this.window = window;
 		this.graphics1 = g1;
 		this.graphics2 = g2;
@@ -24,7 +24,7 @@ class Framebuffer implements Canvas {
 
 	@:noCompletion
 	@:noDoc
-	public function init(g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, g5: kha.graphics5.Graphics): Void {
+	public function init(g1: kha.graphics1.Graphics, g2: kha.graphics2.Graphics, g4: kha.graphics4.Graphics, ?g5: kha.graphics5.Graphics): Void {
 		this.graphics1 = g1;
 		this.graphics2 = g2;
 		this.graphics4 = g4;

--- a/Sources/kha/graphics5/AccelerationStructure.hx
+++ b/Sources/kha/graphics5/AccelerationStructure.hx
@@ -1,0 +1,5 @@
+package kha.graphics5;
+
+interface AccelerationStructure {
+	
+}

--- a/Sources/kha/graphics5/BlendingFactor.hx
+++ b/Sources/kha/graphics5/BlendingFactor.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef BlendingFactor = kha.graphics4.BlendingFactor;

--- a/Sources/kha/graphics5/BlendingOperation.hx
+++ b/Sources/kha/graphics5/BlendingOperation.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef BlendingOperation = kha.graphics4.BlendingOperation;

--- a/Sources/kha/graphics5/CommandList.hx
+++ b/Sources/kha/graphics5/CommandList.hx
@@ -3,9 +3,9 @@ package kha.graphics5;
 interface CommandList {
 	function begin(): Void;
 	function end(): Void;
-	function setRenderTargets(targets:Array<RenderTarget>): Void;
+	function setRenderTargets(targets: Array<RenderTarget>): Void;
 	function setPipelineLayout(): Void;
-	function clear(target:RenderTarget, ?color: Color, ?depth: Float, ?stencil: Int): Void;
+	function clear(target: RenderTarget, ?color: Color, ?depth: Float, ?stencil: Int): Void;
 
 	function setVertexBuffer(vertexBuffer: VertexBuffer): Void;
 	function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void;

--- a/Sources/kha/graphics5/CommandList.hx
+++ b/Sources/kha/graphics5/CommandList.hx
@@ -1,6 +1,12 @@
 package kha.graphics5;
 
 interface CommandList {
+	function begin(): Void;
+	function end(): Void;
+	function setRenderTargets(targets:Array<RenderTarget>): Void;
+	function setPipelineLayout(): Void;
+	function clear(target:RenderTarget, ?color: Color, ?depth: Float, ?stencil: Int): Void;
+
 	function setVertexBuffer(vertexBuffer: VertexBuffer): Void;
 	function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void;
 	function setIndexBuffer(indexBuffer: IndexBuffer): Void;

--- a/Sources/kha/graphics5/CompareMode.hx
+++ b/Sources/kha/graphics5/CompareMode.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef CompareMode = kha.graphics4.CompareMode;

--- a/Sources/kha/graphics5/CullMode.hx
+++ b/Sources/kha/graphics5/CullMode.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef CullMode = kha.graphics4.CullMode;

--- a/Sources/kha/graphics5/FragmentShader.hx
+++ b/Sources/kha/graphics5/FragmentShader.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef FragmentShader = kha.graphics4.FragmentShader;

--- a/Sources/kha/graphics5/GeometryShader.hx
+++ b/Sources/kha/graphics5/GeometryShader.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef GeometryShader = kha.graphics4.GeometryShader;

--- a/Sources/kha/graphics5/Graphics.hx
+++ b/Sources/kha/graphics5/Graphics.hx
@@ -5,4 +5,11 @@ interface Graphics {
 	function begin(target:RenderTarget): Void;
 	function end(): Void;
 	function swapBuffers(): Void;
+	#if kha_dxr
+	function setAccelerationStructure(accel: AccelerationStructure): Void;
+	function setRayTracePipeline(pipe: RayTracePipeline): Void;
+	function setRayTraceTarget(target: RayTraceTarget): Void;
+	function dispatchRays(commandList: CommandList): Void;
+	function copyRayTraceTarget(commandList: CommandList, renderTarget: RenderTarget, output: RayTraceTarget): Void;
+	#end
 }

--- a/Sources/kha/graphics5/Graphics.hx
+++ b/Sources/kha/graphics5/Graphics.hx
@@ -2,7 +2,7 @@ package kha.graphics5;
 
 interface Graphics {
 	function renderTargetsInvertedY(): Bool;
-	function begin(target:RenderTarget): Void;
+	function begin(target: RenderTarget): Void;
 	function end(): Void;
 	function swapBuffers(): Void;
 	#if kha_dxr

--- a/Sources/kha/graphics5/Graphics.hx
+++ b/Sources/kha/graphics5/Graphics.hx
@@ -2,4 +2,7 @@ package kha.graphics5;
 
 interface Graphics {
 	function renderTargetsInvertedY(): Bool;
+	function begin(target:RenderTarget): Void;
+	function end(): Void;
+	function swapBuffers(): Void;
 }

--- a/Sources/kha/graphics5/PipelineStateBase.hx
+++ b/Sources/kha/graphics5/PipelineStateBase.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef PipelineStateBase = kha.graphics4.PipelineStateBase;

--- a/Sources/kha/graphics5/PipelineStateBase.hx
+++ b/Sources/kha/graphics5/PipelineStateBase.hx
@@ -1,3 +1,76 @@
 package kha.graphics5;
 
-typedef PipelineStateBase = kha.graphics4.PipelineStateBase;
+class PipelineStateBase {
+	public function new() {
+		inputLayout = null;
+		vertexShader = null;
+		fragmentShader = null;
+		// geometryShader = null;
+		// tessellationControlShader = null;
+		// tessellationEvaluationShader = null;
+
+		cullMode = CullMode.None;
+
+		depthWrite = false;
+		depthMode = CompareMode.Always;
+
+		stencilMode = CompareMode.Always;
+		stencilBothPass = StencilAction.Keep;
+		stencilDepthFail = StencilAction.Keep;
+		stencilFail = StencilAction.Keep;
+		stencilReferenceValue = 0;
+		stencilReadMask = 0xff;
+		stencilWriteMask = 0xff;
+
+		blendSource = BlendingFactor.BlendOne;
+		blendDestination = BlendingFactor.BlendZero;
+		blendOperation = BlendingOperation.Add;
+		alphaBlendSource = BlendingFactor.BlendOne;
+		alphaBlendDestination = BlendingFactor.BlendZero;
+		alphaBlendOperation = BlendingOperation.Add;
+		
+		colorWriteMask = true;
+
+		conservativeRasterization = false;
+	}
+
+	public var inputLayout: Array<VertexStructure>;
+	public var vertexShader: VertexShader;
+	public var fragmentShader: FragmentShader;
+	// public var geometryShader: GeometryShader;
+	// public var tessellationControlShader: TessellationControlShader;
+	// public var tessellationEvaluationShader: TessellationEvaluationShader;
+
+	public var cullMode: CullMode;
+
+	public var depthWrite: Bool;
+	public var depthMode: CompareMode;
+
+	public var stencilMode: CompareMode;
+	public var stencilBothPass: StencilAction;
+	public var stencilDepthFail: StencilAction;
+	public var stencilFail: StencilAction;
+	public var stencilReferenceValue: Int;
+	public var stencilReadMask: Int;
+	public var stencilWriteMask: Int;
+
+	// One, Zero deactivates blending
+	public var blendSource: BlendingFactor;
+	public var blendDestination: BlendingFactor;
+	public var blendOperation: BlendingOperation;
+	public var alphaBlendSource: BlendingFactor;
+	public var alphaBlendDestination: BlendingFactor;
+	public var alphaBlendOperation: BlendingOperation;
+	
+	public var colorWriteMask(never, set): Bool;
+	public var colorWriteMaskRed: Bool;
+	public var colorWriteMaskGreen: Bool;
+	public var colorWriteMaskBlue: Bool;
+	public var colorWriteMaskAlpha: Bool;
+
+	inline function set_colorWriteMask(value: Bool ): Bool {
+		return colorWriteMaskRed = colorWriteMaskBlue = colorWriteMaskGreen = colorWriteMaskAlpha = value;
+	}
+
+	public var conservativeRasterization: Bool;
+}

--- a/Sources/kha/graphics5/RenderTarget.hx
+++ b/Sources/kha/graphics5/RenderTarget.hx
@@ -1,0 +1,5 @@
+package kha.graphics5;
+
+interface RenderTarget {
+	
+}

--- a/Sources/kha/graphics5/StencilAction.hx
+++ b/Sources/kha/graphics5/StencilAction.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef StencilAction = kha.graphics4.StencilAction;

--- a/Sources/kha/graphics5/TessellationControlShader.hx
+++ b/Sources/kha/graphics5/TessellationControlShader.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef TessellationControlShader = kha.graphics4.TessellationControlShader;

--- a/Sources/kha/graphics5/TessellationEvaluationShader.hx
+++ b/Sources/kha/graphics5/TessellationEvaluationShader.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef TessellationEvaluationShader = kha.graphics4.TessellationEvaluationShader;

--- a/Sources/kha/graphics5/TextureFormat.hx
+++ b/Sources/kha/graphics5/TextureFormat.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef TextureFormat = kha.graphics4.TextureFormat;

--- a/Sources/kha/graphics5/Usage.hx
+++ b/Sources/kha/graphics5/Usage.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef Usage = kha.graphics4.Usage;

--- a/Sources/kha/graphics5/VertexData.hx
+++ b/Sources/kha/graphics5/VertexData.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef VertexData = kha.graphics4.VertexData;

--- a/Sources/kha/graphics5/VertexElement.hx
+++ b/Sources/kha/graphics5/VertexElement.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef VertexElement = kha.graphics4.VertexElement;

--- a/Sources/kha/graphics5/VertexShader.hx
+++ b/Sources/kha/graphics5/VertexShader.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef VertexShader = kha.graphics4.VertexShader;

--- a/Sources/kha/graphics5/VertexStructure.hx
+++ b/Sources/kha/graphics5/VertexStructure.hx
@@ -1,0 +1,3 @@
+package kha.graphics5;
+
+typedef VertexStructure = kha.graphics4.VertexStructure;


### PR DESCRIPTION
Minimal implementation to get the triangle running, which should make further G5 development easier.

Some of the issues to be tackled:
- `kha.Shaders` assumes `kha.graphics4` shaders
- `Kha/Backends/Kore/main.cpp` contains `Graphics4::` calls
- `kha.Image` assumes  `kha.graphics4`

Examples:
https://github.com/luboslenco/ShaderG5
https://github.com/luboslenco/RayTraceG5