### PR TITLE
Reduce output size

### DIFF
--- a/Sources/kha/audio2/ogg/vorbis/VorbisDecodeState.hx
+++ b/Sources/kha/audio2/ogg/vorbis/VorbisDecodeState.hx
@@ -227,7 +227,8 @@ class VorbisDecodeState
 
 
 
-    public inline function readBits(n:Int):Int
+    // public inline function readBits(n:Int):Int
+    public function readBits(n:Int):Int // Kha: reduce output size
     {
         if (validBits < 0) {
             return 0;


### PR DESCRIPTION
Playing with Haxe 4, I noticed the `kha.js` size went quite a bit up. Testing the [red triangle](https://github.com/luboslenco/kha3d_examples/tree/master/tutorial02) example:

Haxe 3 + dce - 326KB
Haxe 4 + dce - 452KB (ugh)

I found out that Haxe 4 output actually seems more effective, but it also allows more inlining. With this patch:

Haxe 4 + dce - 249KB (yay)
Haxe 4 + dce + jscompress + zip - 39KB