### PR TITLE
Fix construction of https URLs in HTML5 backend Http.request

### DIFF
--- a/Backends/HTML5/kha/network/Http.hx
+++ b/Backends/HTML5/kha/network/Http.hx
@@ -18,7 +18,7 @@ class Http {
 	
 	public static function request(url: String, path: String, data: String, port: Int, secure: Bool, method: HttpMethod, contentType: String, callback: Int->Int->String->Void /*error, response, body*/): Void {
 		var req = new XMLHttpRequest("");
-		var completeUrl = secure ? "https://" : "http://" + url + ":" + port + "/" + path;
+		var completeUrl = (secure ? "https://" : "http://") + url + ":" + port + "/" + path;
 		req.open(methodToString(method), completeUrl, true);
 		if (contentType != null) req.setRequestHeader("Content-type", contentType);
 		req.onreadystatechange = function () {


### PR DESCRIPTION
Previous logic was constructing all URLs with `secure == true` as just the string `"https://"`