### PR TITLE
Improve Krom trace

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -73,7 +73,7 @@ extern class Krom {
 	static function loadBlob(file: String): js.html.ArrayBuffer;
 	
 	static function init(title: String, width: Int, height: Int, samplesPerPixel: Int, vSync: Bool, windowMode: Int, windowFeatures: Int): Void;
-	static function log(string: String): Void;
+	static function log(v: Dynamic): Void;
 	static function setCallback(callback: Void->Void): Void;
 	static function setDropFilesCallback(callback: String->Void): Void;
 	static function setKeyboardDownCallback(callback: Int->Void): Void;

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -106,7 +106,7 @@ class SystemImpl {
 
 		start = Krom.getTime();
 		
-		haxe.Log.trace = function(v:Dynamic, ?infos:haxe.PosInfos) {
+		haxe.Log.trace = function(v: Dynamic, ?infos: haxe.PosInfos) {
 			infos != null ? Krom.log(infos.className + ":" + infos.lineNumber + ": " + v) : Krom.log(v);
 		};
 

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -107,7 +107,7 @@ class SystemImpl {
 		start = Krom.getTime();
 		
 		haxe.Log.trace = function(v:Dynamic, ?infos:haxe.PosInfos) {
-			infos != null ? Krom.log(infos.fileName + ":" + infos.lineNumber + ": " + v) : Krom.log(v);
+			infos != null ? Krom.log(infos.className + ":" + infos.lineNumber + ": " + v) : Krom.log(v);
 		};
 
 		new Window(0);

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -106,8 +106,9 @@ class SystemImpl {
 
 		start = Krom.getTime();
 		
-		haxe.Log.trace = function(v: Dynamic, ?infos: haxe.PosInfos) {
-			infos != null ? Krom.log(infos.className + ":" + infos.lineNumber + ": " + v) : Krom.log(v);
+		haxe.Log.trace = function(v:Dynamic, ?infos:haxe.PosInfos) {
+			var message = infos != null ? infos.className + ":" + infos.lineNumber + ": " + v : Std.string(v);
+			Krom.log(message.substr(0, 512 - 1));
 		};
 
 		new Window(0);

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -106,8 +106,8 @@ class SystemImpl {
 
 		start = Krom.getTime();
 		
-		haxe.Log.trace = function(v, ?infos) {
-			Krom.log(Std.string(v));
+		haxe.Log.trace = function(v:Dynamic, ?infos:haxe.PosInfos) {
+			infos != null ? Krom.log(infos.fileName + ":" + infos.lineNumber + ": " + v) : Krom.log(v);
 		};
 
 		new Window(0);

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -106,7 +106,7 @@ class SystemImpl {
 
 		start = Krom.getTime();
 		
-		haxe.Log.trace = function(v:Dynamic, ?infos:haxe.PosInfos) {
+		haxe.Log.trace = function(v: Dynamic, ?infos: haxe.PosInfos) {
 			var message = infos != null ? infos.className + ":" + infos.lineNumber + ": " + v : Std.string(v);
 			Krom.log(message.substr(0, 512 - 1));
 		};


### PR DESCRIPTION
- No longer crashes if message is too long, gets capped at 512 chars
- Can handle non-string types now
- Traces class name and line number similar to other targets

To go with https://github.com/Kode/Krom/pull/86.