### PR TITLE
Fix compute shader compile for Kore

### DIFF
--- a/Backends/Kore/kha/compute/Shader.hx
+++ b/Backends/Kore/kha/compute/Shader.hx
@@ -8,12 +8,6 @@ import kha.Blob;
 #include <Kore/Compute/Compute.h>
 ')
 
-@:cppFileCode('
-#ifndef INCLUDED_haxe_io_Bytes
-#include <haxe/io/Bytes.h>
-#endif
-')
-
 @:headerClassCode("Kore::ComputeShader* shader;")
 class Shader {
 	public function new(sources: Array<Blob>, files: Array<String>) {
@@ -52,5 +46,9 @@ class Shader {
 	')
 	private function initTextureUnit(unit: TextureUnit, name: String): Void {
 		
+	}
+
+	function _forceInclude(): Void {
+		Bytes.alloc(0);
 	}
 }


### PR DESCRIPTION
Removes the `Bytes.h` include, unless there was some other reason to include it manually here. Otherwise throws:
```
kha\compute\shader.cpp(29): fatal error C1083: Cannot open include file: 'haxe/io/Bytes.h': No such file or directory
```
