### PR TITLE
HashLink for Android

### DIFF
--- a/Backends/KoreHL/korefile.js
+++ b/Backends/KoreHL/korefile.js
@@ -2,6 +2,7 @@ let project = new Project('Kha', __dirname);
 
 project.addFiles('KoreC/**', 'hl/include/**', 'hl/src/std/**', 'hl/src/alloc.c', 'hl/src/hl.h', 'hl/src/hlc.h', 'hl/src/hlmodule.h', 'hl/src/opcodes.h');
 project.addExcludes('hl/src/std/unicase.c');
+project.addExcludes('hl/src/std/debug.c');
 project.addIncludeDirs('hl/src', 'hl/include/pcre');
 
 if (platform == Platform.OSX) project.addDefine('KORE_DEBUGDIR="osx-hl"');
@@ -11,6 +12,7 @@ project.addDefine('KORE');
 project.addDefine('KOREC');
 project.addDefine('ROTATE90');
 project.addDefine('LIBHL_STATIC');
+project.cpp11 = true;
 
 if (platform === Platform.Windows || platform === Platform.WindowsApp) {
 	project.addDefine('_WINSOCK_DEPRECATED_NO_WARNINGS');


### PR DESCRIPTION
Also works on Android now, compile with `node Kha/make android-native-hl`.
To go with https://github.com/Kode/Kore/pull/314.