### PR TITLE
colorWriteMask per render target

### DIFF
--- a/Backends/Kore/kha/graphics4/PipelineState.hx
+++ b/Backends/Kore/kha/graphics4/PipelineState.hx
@@ -227,10 +227,12 @@ class PipelineState extends PipelineStateBase {
 		pipeline->alphaBlendSource = (Kore::Graphics4::BlendingOperation)alphaBlendSource;
 		pipeline->alphaBlendDestination = (Kore::Graphics4::BlendingOperation)alphaBlendDestination;
 		
-		pipeline->colorWriteMaskRed = colorWriteMaskRed;
-		pipeline->colorWriteMaskGreen = colorWriteMaskGreen;
-		pipeline->colorWriteMaskBlue = colorWriteMaskBlue;
-		pipeline->colorWriteMaskAlpha = colorWriteMaskAlpha;
+		for (int i = 0; i < 8; ++i) {
+			pipeline->colorWriteMaskRed[i] = colorWriteMasksRed[i];
+			pipeline->colorWriteMaskGreen[i] = colorWriteMasksGreen[i];
+			pipeline->colorWriteMaskBlue[i] = colorWriteMasksBlue[i];
+			pipeline->colorWriteMaskAlpha[i] = colorWriteMasksAlpha[i];
+		}
 		
 		pipeline->conservativeRasterization = conservativeRasterization;
 	')

--- a/Backends/Kore/kha/graphics5/PipelineState.hx
+++ b/Backends/Kore/kha/graphics5/PipelineState.hx
@@ -227,10 +227,12 @@ class PipelineState extends PipelineStateBase {
 		pipeline->alphaBlendSource = (Kore::Graphics5::BlendingOperation)alphaBlendSource;
 		pipeline->alphaBlendDestination = (Kore::Graphics5::BlendingOperation)alphaBlendDestination;
 		
-		pipeline->colorWriteMaskRed = colorWriteMaskRed;
-		pipeline->colorWriteMaskGreen = colorWriteMaskGreen;
-		pipeline->colorWriteMaskBlue = colorWriteMaskBlue;
-		pipeline->colorWriteMaskAlpha = colorWriteMaskAlpha;
+		for (int i = 0; i < 8; ++i) {
+			pipeline->colorWriteMaskRed[i] = colorWriteMasksRed[i];
+			pipeline->colorWriteMaskGreen[i] = colorWriteMasksGreen[i];
+			pipeline->colorWriteMaskBlue[i] = colorWriteMasksBlue[i];
+			pipeline->colorWriteMaskAlpha[i] = colorWriteMasksAlpha[i];
+		}
 		
 		pipeline->conservativeRasterization = conservativeRasterization;
 	')

--- a/Backends/KoreHL/KoreC/shader.cpp
+++ b/Backends/KoreHL/KoreC/shader.cpp
@@ -198,10 +198,10 @@ extern "C" void hl_kore_pipeline_set_states(vbyte *pipeline,
 	pipe->alphaBlendSource = (Kore::Graphics4::BlendingOperation)alphaBlendSource;
 	pipe->alphaBlendDestination = (Kore::Graphics4::BlendingOperation)alphaBlendDestination;
 	
-	pipe->colorWriteMaskRed = colorWriteMaskRed;
-	pipe->colorWriteMaskGreen = colorWriteMaskGreen;
-	pipe->colorWriteMaskBlue = colorWriteMaskBlue;
-	pipe->colorWriteMaskAlpha = colorWriteMaskAlpha;
+	pipe->colorWriteMaskRed[0] = colorWriteMaskRed;
+	pipe->colorWriteMaskGreen[0] = colorWriteMaskGreen;
+	pipe->colorWriteMaskBlue[0] = colorWriteMaskBlue;
+	pipe->colorWriteMaskAlpha[0] = colorWriteMaskAlpha;
 	
 	pipe->conservativeRasterization = conservativeRasterization;
 }

--- a/Backends/Krom/kha/graphics4/PipelineState.hx
+++ b/Backends/Krom/kha/graphics4/PipelineState.hx
@@ -41,10 +41,10 @@ class PipelineState extends PipelineStateBase {
 			blendDestination: convertBlendingFactor(blendDestination),
 			alphaBlendSource: convertBlendingFactor(alphaBlendSource),
 			alphaBlendDestination: convertBlendingFactor(alphaBlendDestination),
-			colorWriteMaskRed: colorWriteMaskRed,
-			colorWriteMaskGreen: colorWriteMaskGreen,
-			colorWriteMaskBlue: colorWriteMaskBlue,
-			colorWriteMaskAlpha: colorWriteMaskAlpha,
+			colorWriteMaskRed: colorWriteMasksRed,
+			colorWriteMaskGreen: colorWriteMasksGreen,
+			colorWriteMaskBlue: colorWriteMasksBlue,
+			colorWriteMaskAlpha: colorWriteMasksAlpha,
 			conservativeRasterization: conservativeRasterization
 		});
 	}

--- a/Sources/kha/graphics4/PipelineStateBase.hx
+++ b/Sources/kha/graphics4/PipelineStateBase.hx
@@ -29,7 +29,14 @@ class PipelineStateBase {
 		alphaBlendDestination = BlendingFactor.BlendZero;
 		alphaBlendOperation = BlendingOperation.Add;
 		
-		colorWriteMask = true;
+		colorWriteMasksRed = [];
+		colorWriteMasksGreen = [];
+		colorWriteMasksBlue = [];
+		colorWriteMasksAlpha = [];
+		for (i in 0...8) colorWriteMasksRed.push(true);
+		for (i in 0...8) colorWriteMasksGreen.push(true);
+		for (i in 0...8) colorWriteMasksBlue.push(true);
+		for (i in 0...8) colorWriteMasksAlpha.push(true);
 
 		conservativeRasterization = false;
 	}
@@ -63,13 +70,50 @@ class PipelineStateBase {
 	public var alphaBlendOperation: BlendingOperation;
 	
 	public var colorWriteMask(never, set): Bool;
-	public var colorWriteMaskRed: Bool;
-	public var colorWriteMaskGreen: Bool;
-	public var colorWriteMaskBlue: Bool;
-	public var colorWriteMaskAlpha: Bool;
+	public var colorWriteMaskRed(get, set): Bool;
+	public var colorWriteMaskGreen(get, set): Bool;
+	public var colorWriteMaskBlue(get, set): Bool;
+	public var colorWriteMaskAlpha(get, set): Bool;
 
-	inline function set_colorWriteMask(value: Bool ): Bool {
+	public var colorWriteMasksRed: Array<Bool>;
+	public var colorWriteMasksGreen: Array<Bool>;
+	public var colorWriteMasksBlue: Array<Bool>;
+	public var colorWriteMasksAlpha: Array<Bool>;
+
+	inline function set_colorWriteMask(value: Bool): Bool {
 		return colorWriteMaskRed = colorWriteMaskBlue = colorWriteMaskGreen = colorWriteMaskAlpha = value;
+	}
+
+	inline function get_colorWriteMaskRed(): Bool {
+		return colorWriteMasksRed[0];
+	}
+
+	inline function set_colorWriteMaskRed(value: Bool): Bool {
+		return colorWriteMasksRed[0] = value;
+	}
+
+	inline function get_colorWriteMaskGreen(): Bool {
+		return colorWriteMasksGreen[0];
+	}
+
+	inline function set_colorWriteMaskGreen(value: Bool): Bool {
+		return colorWriteMasksGreen[0] = value;
+	}
+
+	inline function get_colorWriteMaskBlue(): Bool {
+		return colorWriteMasksBlue[0];
+	}
+
+	inline function set_colorWriteMaskBlue(value: Bool): Bool {
+		return colorWriteMasksBlue[0] = value;
+	}
+
+	inline function get_colorWriteMaskAlpha(): Bool {
+		return colorWriteMasksAlpha[0];
+	}
+
+	inline function set_colorWriteMaskAlpha(value: Bool): Bool {
+		return colorWriteMasksAlpha[0] = value;
 	}
 
 	public var conservativeRasterization: Bool;

--- a/Sources/kha/graphics5/PipelineStateBase.hx
+++ b/Sources/kha/graphics5/PipelineStateBase.hx
@@ -29,7 +29,14 @@ class PipelineStateBase {
 		alphaBlendDestination = BlendingFactor.BlendZero;
 		alphaBlendOperation = BlendingOperation.Add;
 		
-		colorWriteMask = true;
+		colorWriteMasksRed = [];
+		colorWriteMasksGreen = [];
+		colorWriteMasksBlue = [];
+		colorWriteMasksAlpha = [];
+		for (i in 0...8) colorWriteMasksRed.push(true);
+		for (i in 0...8) colorWriteMasksGreen.push(true);
+		for (i in 0...8) colorWriteMasksBlue.push(true);
+		for (i in 0...8) colorWriteMasksAlpha.push(true);
 
 		conservativeRasterization = false;
 	}
@@ -63,13 +70,50 @@ class PipelineStateBase {
 	public var alphaBlendOperation: BlendingOperation;
 	
 	public var colorWriteMask(never, set): Bool;
-	public var colorWriteMaskRed: Bool;
-	public var colorWriteMaskGreen: Bool;
-	public var colorWriteMaskBlue: Bool;
-	public var colorWriteMaskAlpha: Bool;
+	public var colorWriteMaskRed(get, set): Bool;
+	public var colorWriteMaskGreen(get, set): Bool;
+	public var colorWriteMaskBlue(get, set): Bool;
+	public var colorWriteMaskAlpha(get, set): Bool;
 
-	inline function set_colorWriteMask(value: Bool ): Bool {
+	public var colorWriteMasksRed: Array<Bool>;
+	public var colorWriteMasksGreen: Array<Bool>;
+	public var colorWriteMasksBlue: Array<Bool>;
+	public var colorWriteMasksAlpha: Array<Bool>;
+
+	inline function set_colorWriteMask(value: Bool): Bool {
 		return colorWriteMaskRed = colorWriteMaskBlue = colorWriteMaskGreen = colorWriteMaskAlpha = value;
+	}
+
+	inline function get_colorWriteMaskRed(): Bool {
+		return colorWriteMasksRed[0];
+	}
+
+	inline function set_colorWriteMaskRed(value: Bool): Bool {
+		return colorWriteMasksRed[0] = value;
+	}
+
+	inline function get_colorWriteMaskGreen(): Bool {
+		return colorWriteMasksGreen[0];
+	}
+
+	inline function set_colorWriteMaskGreen(value: Bool): Bool {
+		return colorWriteMasksGreen[0] = value;
+	}
+
+	inline function get_colorWriteMaskBlue(): Bool {
+		return colorWriteMasksBlue[0];
+	}
+
+	inline function set_colorWriteMaskBlue(value: Bool): Bool {
+		return colorWriteMasksBlue[0] = value;
+	}
+
+	inline function get_colorWriteMaskAlpha(): Bool {
+		return colorWriteMasksAlpha[0];
+	}
+
+	inline function set_colorWriteMaskAlpha(value: Bool): Bool {
+		return colorWriteMasksAlpha[0] = value;
 	}
 
 	public var conservativeRasterization: Bool;


### PR DESCRIPTION
Allows to set color write mask for individual render targets when using MRT. There are no changes to existing usage:

```hx
pipe.colorWriteMaskRed = false;
```

To set color mask for additional render targets:

```hx
pipe.colorWriteMasksRed[0] = false; // First render target
pipe.colorWriteMasksRed[1] = true; // Second render target
```

To go with https://github.com/Kode/Kore/pull/317 and https://github.com/Kode/Krom/pull/99.

Should only be merged once Krom api version thing is in, like mentioned at https://github.com/Kode/Kha/pull/893#issuecomment-427699581.
