### PR TITLE
Add setTextureCompareMode

### DIFF
--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -277,6 +277,14 @@ class Graphics implements kha.graphics4.Graphics {
 	
 	}
 
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+		
+	}
+
 	public function setCullMode(mode: CullMode): Void {
 		switch (mode) {
 		case None:

--- a/Backends/Flash/kha/flash/graphics4/Graphics.hx
+++ b/Backends/Flash/kha/flash/graphics4/Graphics.hx
@@ -213,6 +213,14 @@ class Graphics implements kha.graphics4.Graphics {
 	
 	}
 
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+		
+	}
+
 	private function getBlendFactor(op: BlendingFactor): Context3DBlendFactor {
 		switch (op) {
 			case BlendZero, Undefined:

--- a/Backends/HTML5-Worker/kha/html5worker/Graphics.hx
+++ b/Backends/HTML5-Worker/kha/html5worker/Graphics.hx
@@ -117,6 +117,14 @@ class Graphics implements kha.graphics4.Graphics {
 	
 	}
 
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+		
+	}
+
 	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
 
 	}

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -313,8 +313,9 @@ class WebGLImage extends Image {
 	}
 
 	override public function setDepthStencilFrom(image: Image): Void {
+		depthTexture = cast(image, WebGLImage).depthTexture;
 		SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-		SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, cast(image, WebGLImage).depthTexture, 0);
+		SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
 	}
 
 	private static function formatByteSize(format: TextureFormat): Int {

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -42,6 +42,12 @@ class Graphics implements kha.graphics4.Graphics {
 	private var instancedExtension: Dynamic;
 	private var blendMinMaxExtension: Dynamic;
 
+	// WebGL2 constants
+	// https://www.khronos.org/registry/webgl/specs/2.0.0/
+	private static inline var GL_TEXTURE_COMPARE_MODE = 0x884C;
+	private static inline var GL_TEXTURE_COMPARE_FUNC = 0x884D;
+	private static inline var GL_COMPARE_REF_TO_TEXTURE = 0x884E;
+
 	public function new(renderTarget: Canvas = null) {
 		this.renderTarget = renderTarget;
 		init();
@@ -417,6 +423,26 @@ class Graphics implements kha.graphics4.Graphics {
 
 	public function setTexture3DParameters(texunit: kha.graphics4.TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
 	
+	}
+
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool) {
+		if (enabled) {
+			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL.LEQUAL);
+		}
+		else {
+			SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL.NONE);
+		}
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool) {
+		if (enabled) {
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_REF_TO_TEXTURE);
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL_TEXTURE_COMPARE_FUNC, GL.LEQUAL);
+		}
+		else {
+			SystemImpl.gl.texParameteri(GL.TEXTURE_CUBE_MAP, GL_TEXTURE_COMPARE_MODE, GL.NONE);
+		}
 	}
 
 	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {

--- a/Backends/Kore/kha/kore/graphics4/Graphics.hx
+++ b/Backends/Kore/kha/kore/graphics4/Graphics.hx
@@ -262,6 +262,16 @@ class Graphics implements kha.graphics4.Graphics {
 		setTexture3DWrapNative(cast texunit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureAddressing(wAddressing));
 		setTexture3DFiltersNative(cast texunit, getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
 	}
+
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool) {
+		var koreUnit = cast(texunit, kha.kore.graphics4.TextureUnit);
+		untyped __cpp__("Kore::Graphics4::setTextureCompareMode(koreUnit->unit, enabled);");
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool) {
+		var koreUnit = cast(texunit, kha.kore.graphics4.TextureUnit);
+		untyped __cpp__("Kore::Graphics4::setCubeMapCompareMode(koreUnit->unit, enabled);");
+	}
 	
 	@:functionCode('
 		if (texture->texture != nullptr) Kore::Graphics4::setTexture(unit->unit, texture->texture);

--- a/Backends/KoreHL/KoreC/graphics.cpp
+++ b/Backends/KoreHL/KoreC/graphics.cpp
@@ -69,6 +69,16 @@ extern "C" void hl_kore_graphics_set_texture3d_parameters(vbyte *unit, int uAddr
 	Kore::Graphics4::setTexture3DMipmapFilter(*u, (Kore::Graphics4::MipmapFilter)mipmapFilter);
 }
 
+extern "C" void hl_kore_graphics_set_texture_compare_mode(vbyte *unit, bool enabled) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::setTextureCompareMode(*u, enabled);
+}
+
+extern "C" void hl_kore_graphics_set_cube_map_compare_mode(vbyte *unit, bool enabled) {
+	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
+	Kore::Graphics4::setCubeMapCompareMode(*u, enabled);
+}
+
 extern "C" void hl_kore_graphics_set_texture(vbyte *unit, vbyte *texture) {
 	Kore::Graphics4::TextureUnit* u = (Kore::Graphics4::TextureUnit*)unit;
 	Kore::Graphics4::Texture* tex = (Kore::Graphics4::Texture*)texture;

--- a/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
+++ b/Backends/KoreHL/kha/korehl/graphics4/Graphics.hx
@@ -138,6 +138,14 @@ class Graphics implements kha.graphics4.Graphics {
 		kore_graphics_set_texture3d_parameters(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, getTextureAddressing(uAddressing), getTextureAddressing(vAddressing), getTextureAddressing(wAddressing), getTextureFilter(minificationFilter), getTextureFilter(magnificationFilter), getTextureMipMapFilter(mipmapFilter));
 	}
 	
+	public function setTextureCompareMode(unit: kha.graphics4.TextureUnit, enabled: Bool) {
+		kore_graphics_set_texture_compare_mode(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, enabled);
+	}
+
+	public function setCubeMapCompareMode(unit: kha.graphics4.TextureUnit, enabled: Bool) {
+		kore_graphics_set_cube_map_compare_mode(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, enabled);
+	}
+
 	public function setTexture(unit: kha.graphics4.TextureUnit, texture: kha.Image): Void {
 		if (texture == null) return;
 		if (texture._texture != null) kore_graphics_set_texture(cast(unit, kha.korehl.graphics4.TextureUnit)._unit, texture._texture);
@@ -287,6 +295,8 @@ class Graphics implements kha.graphics4.Graphics {
 	@:hlNative("std", "kore_graphics_render_targets_inverted_y") static function kore_graphics_render_targets_inverted_y(): Bool { return false; }
 	@:hlNative("std", "kore_graphics_set_texture_parameters") static function kore_graphics_set_texture_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
 	@:hlNative("std", "kore_graphics_set_texture3d_parameters") static function kore_graphics_set_texture3d_parameters(unit: Pointer, uAddressing: Int, vAddressing: Int, wAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void { }
+	@:hlNative("std", "kore_graphics_set_texture_compare_mode") static function kore_graphics_set_texture_compare_mode(unit: Pointer, enabled: Bool): Void { }
+	@:hlNative("std", "kore_graphics_set_cube_map_compare_mode") static function kore_graphics_set_cube_map_compare_mode(unit: Pointer, enabled: Bool): Void { }
 	@:hlNative("std", "kore_graphics_set_texture") static function kore_graphics_set_texture(unit: Pointer, texture: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_texture_depth") static function kore_graphics_set_texture_depth(unit: Pointer, renderTarget: Pointer): Void { }
 	@:hlNative("std", "kore_graphics_set_texture_array") static function kore_graphics_set_texture_array(unit: Pointer, textureArray: Pointer): Void { }

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -23,6 +23,8 @@ extern class Krom {
 	static function setImageTexture(stage: kha.graphics4.TextureUnit, texture: Dynamic): Void;
 	static function setTextureParameters(texunit: kha.graphics4.TextureUnit, uAddressing: Int, vAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void;
 	static function setTexture3DParameters(texunit: kha.graphics4.TextureUnit, uAddressing: Int, vAddressing: Int, wAddressing: Int, minificationFilter: Int, magnificationFilter: Int, mipmapFilter: Int): Void;
+	static function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void;
+	static function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void;
 	static function setBool(location: kha.graphics4.ConstantLocation, value: Bool): Void;
 	static function setInt(location: kha.graphics4.ConstantLocation, value: Int): Void;
 	static function setFloat(location: kha.graphics4.ConstantLocation, value: Float): Void;

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -131,6 +131,14 @@ class Graphics implements kha.graphics4.Graphics {
 		Krom.setTexture3DParameters(texunit, uAddressing, vAddressing, wAddressing, minificationFilter, magnificationFilter, mipmapFilter);
 	}
 
+	public function setTextureCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+		Krom.setTextureCompareMode(texunit, enabled);
+	}
+
+	public function setCubeMapCompareMode(texunit: kha.graphics4.TextureUnit, enabled: Bool): Void {
+		Krom.setCubeMapCompareMode(texunit, enabled);
+	}
+
 	public function setPipeline(pipeline: PipelineState): Void {
 		pipeline.set();
 	}

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -140,6 +140,14 @@ class EmptyGraphics4 implements Graphics {
 	
 	}
 
+	public function setTextureCompareMode(texunit: TextureUnit, enabled: Bool): Void {
+
+	}
+
+	public function setCubeMapCompareMode(texunit: TextureUnit, enabled: Bool): Void {
+		
+	}
+
 	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
 		
 	}

--- a/Sources/kha/graphics1/Graphics4.hx
+++ b/Sources/kha/graphics1/Graphics4.hx
@@ -87,7 +87,7 @@ class Graphics4 implements kha.graphics4.Graphics {
 
 	public function setTextureArray(unit: TextureUnit, texture: Image): Void {
 
-	};
+	}
 
 	public function setVideoTexture(unit: TextureUnit, texture: Video): Void {
 		
@@ -95,13 +95,21 @@ class Graphics4 implements kha.graphics4.Graphics {
 
 	public function setImageTexture(unit: TextureUnit, texture: Image): Void {
 
-	};
+	}
 
 	public function setTextureParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
 		
 	}
 
 	public function setTexture3DParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
+		
+	}
+
+	public function setTextureCompareMode(texunit: TextureUnit, enabled: Bool): Void {
+
+	}
+
+	public function setCubeMapCompareMode(texunit: TextureUnit, enabled: Bool): Void {
 		
 	}
 

--- a/Sources/kha/graphics4/Graphics.hx
+++ b/Sources/kha/graphics4/Graphics.hx
@@ -37,6 +37,8 @@ interface Graphics {
 	function setImageTexture(unit: TextureUnit, texture: Image): Void;
 	function setTextureParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void;
 	function setTexture3DParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void;
+	function setTextureCompareMode(texunit: TextureUnit, enabled: Bool): Void;
+	function setCubeMapCompareMode(texunit: TextureUnit, enabled: Bool): Void;
 	function setCubeMap(unit: TextureUnit, cubeMap: CubeMap): Void;
 	function setCubeMapDepth(unit: TextureUnit, cubeMap: CubeMap): Void;
 	//function maxTextureSize(): Int;


### PR DESCRIPTION
This lets us (after all these years) sample the depth textures / shadow maps faster.

After enabling the compare mode using `g.setTextureCompareMode(unit, true);`, `sampler2DShadow` & `samplerCubeShadow` will work like expected. krafix already has the support built-in.

I kept the implementation as simple as possible for now, nothing fancy. Works for Krom, hl/c, hxcpp, html5 + opengl, webgl2, d3d11.

To go with https://github.com/Kode/Kore/pull/329 and https://github.com/Kode/Krom/pull/109.
