### PR TITLE
Update Krom Compute to Use Abstract Enums

### DIFF
--- a/Backends/Krom/kha/compute/Compute.hx
+++ b/Backends/Krom/kha/compute/Compute.hx
@@ -101,11 +101,11 @@ class Compute {
 	}
 
 	public static function setTextureParameters(unit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-		Krom.setTextureParametersCompute(unit, uAddressing.getIndex(), vAddressing.getIndex(), minificationFilter.getIndex(), magnificationFilter.getIndex(), mipmapFilter.getIndex());
+		Krom.setTextureParametersCompute(unit, uAddressing, vAddressing, minificationFilter, magnificationFilter, mipmapFilter);
 	}
 
 	public static function setTexture3DParameters(unit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-		Krom.setTexture3DParametersCompute(unit, uAddressing.getIndex(), vAddressing.getIndex(), wAddressing.getIndex(), minificationFilter.getIndex(), magnificationFilter.getIndex(), mipmapFilter.getIndex());
+		Krom.setTexture3DParametersCompute(unit, uAddressing, vAddressing, wAddressing, minificationFilter, magnificationFilter, mipmapFilter);
 	}
 
 	public static function setShader(shader: Shader) {


### PR DESCRIPTION
Armory game wouldn't compile until I updated this. Looks like it was because of a recent update: e28eaecfdca84168052de64c6d21157a41f2a107.