### PR TITLE
Short2Norm and Short4Norm vertex data

### DIFF
--- a/Backends/Android/kha/arrays/Int16Array.hx
+++ b/Backends/Android/kha/arrays/Int16Array.hx
@@ -1,0 +1,47 @@
+package kha.arrays;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+abstract Int16Array(IntBuffer) {
+	private static inline var elementSize = 2;
+		
+	public inline function new(elements: Int) {
+		this = ByteBuffer.allocateDirect(elements * elementSize).order(ByteOrder.nativeOrder()).asIntBuffer();
+	}
+	
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.remaining();
+	}
+	
+	public function set(index: Int, value: Int): Int {
+		this.put(index, value);
+		return value;
+	}
+	
+	public inline function get(index: Int): Int {
+		return this.get(index);
+	}
+	
+	public inline function data(): IntBuffer {
+		return this;
+	}
+	
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this.get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		this.put(index, value);
+		return value;
+	}
+
+	//public inline function subarray(start: Int, ?end: Int): Int16Array {
+	//	return cast this.subarray(start, end);
+	//}
+}

--- a/Backends/Android/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Android/kha/graphics4/VertexBuffer.hx
@@ -35,6 +35,10 @@ class VertexBuffer {
 				myStride += 4 * 4;
 			case VertexData.Float4x4:
 				myStride += 4 * 4 * 4;
+			case VertexData.Short2Norm:
+				myStride += 2 * 2;
+			case VertexData.Short4Norm:
+				myStride += 2 * 4;
 			}
 		}
 	
@@ -61,6 +65,10 @@ class VertexBuffer {
 				size = 4;
 			case VertexData.Float4x4:
 				size = 4 * 4;
+			case VertexData.Short2Norm:
+				size = 2;
+			case VertexData.Short4Norm:
+				size = 4;
 			}
 			sizes[index] = size;
 			offsets[index] = offset;
@@ -75,6 +83,10 @@ class VertexBuffer {
 				offset += 4 * 4;
 			case VertexData.Float4x4:
 				offset += 4 * 4 * 4;
+			case VertexData.Short2Norm:
+				offset += 2 * 2;
+			case VertexData.Short4Norm:
+				offset += 2 * 4;
 			}
 			++index;
 		}

--- a/Backends/Empty/kha/arrays/Int16Array.hx
+++ b/Backends/Empty/kha/arrays/Int16Array.hx
@@ -1,39 +1,39 @@
 package kha.arrays;
 
-abstract Uint32Array(js.html.Uint32Array) {
+abstract Int16Array(Dynamic) {
 	public inline function new(elements: Int) {
-		this = new js.html.Uint32Array(elements);
+		this = null;
 	}
 	
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
-		return this.length;
+		return 0;
 	}
 	
 	public inline function set(index: Int, value: Int): Int {
-		return this[index] = value;
+		return 0;
 	}
 	
 	public inline function get(index: Int): Int {
-		return this[index];
+		return 0;
 	}
 	
-	public inline function data(): js.html.Uint32Array {
+	public inline function data(): Dynamic {
 		return this;
 	}
 
 	@:arrayAccess
 	public inline function arrayRead(index: Int): Int {
-		return this[index];
+		return 0;
 	}
 
 	@:arrayAccess
 	public inline function arrayWrite(index: Int, value: Int): Int {
-		return this[index] = value;
+		return 0;
 	}
 
-	public inline function subarray(start: Int, ?end: Int): Uint32Array {
-		return cast this.subarray(start, end);
+	public inline function subarray(start: Int, ?end: Int): Int16Array {
+		return this;
 	}
 }

--- a/Backends/Flash/kha/arrays/Int16Array.hx
+++ b/Backends/Flash/kha/arrays/Int16Array.hx
@@ -1,0 +1,20 @@
+package kha.arrays;
+
+import flash.Vector;
+
+@:forward(length)
+abstract Int16Array(Vector<Int>) to Vector<Int> {
+	public inline function new(elements: Int) {
+		this = new Vector(elements);
+	}
+
+	@:arrayAccess
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	@:arrayAccess
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+}

--- a/Backends/Flash/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Flash/kha/graphics4/VertexBuffer.hx
@@ -30,6 +30,10 @@ class VertexBuffer {
 				myStride += 4;
 			case VertexData.Float4x4:
 				myStride += 4 * 4;
+			case VertexData.Short2Norm:
+				myStride += 2;
+			case VertexData.Short4Norm:
+				myStride += 4;
 			}
 		}
 		myStructure = structure;
@@ -80,6 +84,14 @@ class VertexBuffer {
 					offset += 4;
 					++index;
 				}
+			case VertexData.Short2Norm:
+				kha.flash.graphics4.Graphics.context.setVertexBufferAt(index, vertexBuffer, offset, Context3DVertexBufferFormat.FLOAT_2);
+				offset += 2;
+				++index;
+			case VertexData.Short4Norm:
+				kha.flash.graphics4.Graphics.context.setVertexBufferAt(index, vertexBuffer, offset, Context3DVertexBufferFormat.FLOAT_4);
+				offset += 4;
+				++index;
 			}
 		}
 		for (i in index...8) kha.flash.graphics4.Graphics.context.setVertexBufferAt(i, null);

--- a/Backends/HTML5-Worker/kha/arrays/Int16Array.hx
+++ b/Backends/HTML5-Worker/kha/arrays/Int16Array.hx
@@ -1,8 +1,8 @@
 package kha.arrays;
 
-abstract Uint32Array(js.html.Uint32Array) {
+abstract Int16Array(js.html.Int16Array) {
 	public inline function new(elements: Int) {
-		this = new js.html.Uint32Array(elements);
+		this = new js.html.Int16Array(elements);
 	}
 	
 	public var length(get, never): Int;
@@ -19,7 +19,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index];
 	}
 	
-	public inline function data(): js.html.Uint32Array {
+	public inline function data(): js.html.Int16Array {
 		return this;
 	}
 
@@ -33,7 +33,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index] = value;
 	}
 
-	public inline function subarray(start: Int, ?end: Int): Uint32Array {
+	public inline function subarray(start: Int, ?end: Int): Int16Array {
 		return cast this.subarray(start, end);
 	}
 }

--- a/Backends/HTML5/kha/arrays/Int16Array.hx
+++ b/Backends/HTML5/kha/arrays/Int16Array.hx
@@ -1,8 +1,8 @@
 package kha.arrays;
 
-abstract Uint32Array(js.html.Uint32Array) {
+abstract Int16Array(js.html.Int16Array) {
 	public inline function new(elements: Int) {
-		this = new js.html.Uint32Array(elements);
+		this = new js.html.Int16Array(elements);
 	}
 	
 	public var length(get, never): Int;
@@ -19,7 +19,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index];
 	}
 	
-	public inline function data(): js.html.Uint32Array {
+	public inline function data(): js.html.Int16Array {
 		return this;
 	}
 
@@ -33,7 +33,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index] = value;
 	}
 
-	public inline function subarray(start: Int, ?end: Int): Uint32Array {
+	public inline function subarray(start: Int, ?end: Int): Int16Array {
 		return cast this.subarray(start, end);
 	}
 }

--- a/Backends/HTML5/kha/graphics4/VertexBuffer.hx
+++ b/Backends/HTML5/kha/graphics4/VertexBuffer.hx
@@ -12,6 +12,7 @@ class VertexBuffer {
 	private var myStride: Int;
 	private var sizes: Array<Int>;
 	private var offsets: Array<Int>;
+	private var types: Array<Int>;
 	private var usage: Usage;
 	private var instanceDataStepRate: Int;
 	
@@ -32,6 +33,10 @@ class VertexBuffer {
 				myStride += 4 * 4;
 			case Float4x4:
 				myStride += 4 * 4 * 4;
+			case Short2Norm:
+				myStride += 2 * 2;
+			case Short4Norm:
+				myStride += 2 * 4;
 			}
 		}
 	
@@ -40,27 +45,42 @@ class VertexBuffer {
 		
 		sizes = new Array<Int>();
 		offsets = new Array<Int>();
+		types = new Array<Int>();
 		sizes[structure.elements.length - 1] = 0;
 		offsets[structure.elements.length - 1] = 0;
+		types[structure.elements.length - 1] = 0;
 		
 		var offset = 0;
 		var index = 0;
 		for (element in structure.elements) {
 			var size;
+			var type;
 			switch (element.data) {
 			case Float1:
 				size = 1;
+				type = GL.FLOAT;
 			case Float2:
 				size = 2;
+				type = GL.FLOAT;
 			case Float3:
 				size = 3;
+				type = GL.FLOAT;
 			case Float4:
 				size = 4;
+				type = GL.FLOAT;
 			case Float4x4:
 				size = 4 * 4;
+				type = GL.FLOAT;
+			case Short2Norm:
+				size = 2;
+				type = GL.SHORT;
+			case Short4Norm:
+				size = 4;
+				type = GL.SHORT;
 			}
 			sizes[index] = size;
 			offsets[index] = offset;
+			types[index] = type;
 			switch (element.data) {
 			case Float1:
 				offset += 4 * 1;
@@ -72,6 +92,10 @@ class VertexBuffer {
 				offset += 4 * 4;
 			case Float4x4:
 				offset += 4 * 4 * 4;
+			case Short2Norm:
+				offset += 2 * 2;
+			case Short4Norm:
+				offset += 2 * 4;
 			}
 			++index;
 		}
@@ -126,8 +150,9 @@ class VertexBuffer {
 				}
 			}
 			else {
+				var normalized = types[i] == GL.FLOAT ? false : true;
 				SystemImpl.gl.enableVertexAttribArray(offset + attributesOffset);
-				SystemImpl.gl.vertexAttribPointer(offset + attributesOffset, sizes[i], GL.FLOAT, false, myStride, offsets[i]);
+				SystemImpl.gl.vertexAttribPointer(offset + attributesOffset, sizes[i], types[i], normalized, myStride, offsets[i]);
 				if (ext) {
 					if (SystemImpl.gl2) {
 						untyped SystemImpl.gl.vertexAttribDivisor(offset + attributesOffset, instanceDataStepRate);

--- a/Backends/HTML5/kha/graphics4/VertexBuffer.hx
+++ b/Backends/HTML5/kha/graphics4/VertexBuffer.hx
@@ -2,6 +2,7 @@ package kha.graphics4;
 
 import js.html.webgl.GL;
 import kha.arrays.Float32Array;
+import kha.arrays.Int16Array;
 import kha.graphics4.Usage;
 import kha.graphics4.VertexStructure;
 
@@ -110,6 +111,10 @@ class VertexBuffer {
 		if (start == null) start = 0;
 		if (count == null) count = mySize;
 		return _data.subarray(start * stride(), (start + count) * stride());
+	}
+
+	public function lockInt16(?start: Int, ?count: Int): Int16Array {
+		return new Int16Array(untyped lock(start, count).buffer);
 	}
 	
 	public function unlock(): Void {

--- a/Backends/Kore/kha/arrays/Int16Array.hx
+++ b/Backends/Kore/kha/arrays/Int16Array.hx
@@ -1,0 +1,74 @@
+package kha.arrays;
+
+import cpp.RawPointer;
+import haxe.ds.Vector;
+
+@:unreflective
+@:structAccess
+@:include("cpp_int16array.h")
+@:native("int16array")
+extern class Int16ArrayData {
+	@:native("int16array")
+	public static function create(): Int16ArrayData;
+	
+	public var length(get, never): Int;
+
+	@:native("length")
+	function get_length(): Int;
+
+	public function alloc(elements: Int): Void;
+
+	public function free(): Void;
+	
+	public function get(index: Int): Int;
+		
+	public function set(index: Int, value: Int): Int;
+}
+
+class Int16ArrayPrivate {
+
+	public var self: Int16ArrayData;
+
+	public inline function new(elements: Int = 0) {
+		self = Int16ArrayData.create();
+		if (elements > 0) self.alloc(elements);
+	}
+}
+
+abstract Int16Array(Int16ArrayPrivate) {
+	public inline function new(elements: Int = 0) {
+		this = new Int16ArrayPrivate(elements);
+	}
+
+	public inline function free(): Void {
+		this.self.free();
+	}
+	
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.self.length;
+	}
+	
+	public inline function set(index: Int, value: Int): Int {
+		return this.self.set(index, value);
+	}
+	
+	public inline function get(index: Int): Int {
+		return this.self.get(index);
+	}
+	
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this.self.get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this.self.set(index, value);
+	}
+
+	//public inline function subarray(start: Int, ?end: Int): Int16Array {
+	//	return cast this.self.subarray(start, end);
+	//}
+}

--- a/Backends/Kore/kha/graphics4/PipelineState.hx
+++ b/Backends/Kore/kha/graphics4/PipelineState.hx
@@ -99,6 +99,12 @@ class PipelineState extends PipelineStateBase {
 				case 4:
 					data = Kore::Graphics4::Float4x4VertexData;
 					break;
+				case 5:
+					data = Kore::Graphics4::Short2NormVertexData;
+					break;
+				case 6:
+					data = Kore::Graphics4::Short4NormVertexData;
+					break;
 				}
 				pipeline->inputLayout[i1] = structures2[i1];
 				pipeline->inputLayout[i1]->add((*structures[i1])->get(i2)->name, data);

--- a/Backends/Kore/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics4/VertexBuffer.hx
@@ -1,6 +1,7 @@
 package kha.graphics4;
 
 import kha.arrays.Float32Array;
+import kha.arrays.Int16Array;
 import kha.graphics4.VertexData;
 import kha.graphics4.VertexElement;
 import kha.graphics4.VertexStructure;
@@ -13,6 +14,7 @@ import kha.graphics4.VertexStructure;
 @:headerClassCode("Kore::Graphics4::VertexBuffer* buffer;")
 class VertexBuffer {
 	private var data: Float32Array;
+	private var dataInt16: Int16Array;
 
 	public function new(vertexCount: Int, structure: VertexStructure, usage: Usage, instanceDataStepRate: Int = 0, canRead: Bool = false) {
 		init(vertexCount, structure, usage, instanceDataStepRate);
@@ -43,6 +45,12 @@ class VertexBuffer {
 			case 4:
 				data = Kore::Graphics4::Float4x4VertexData;
 				break;
+			case 5:
+				data = Kore::Graphics4::Short2NormVertexData;
+				break;
+			case 6:
+				data = Kore::Graphics4::Short4NormVertexData;
+				break;
 			}
 			structure2.add(structure->get(i)->name, data);
 		}
@@ -57,14 +65,30 @@ class VertexBuffer {
 		data->self.myLength = count * buffer->stride() / 4;
 		return data;
 	')
-	private function lock2(start: Int, count: Int): Float32Array {
+	private function lockPrivate(start: Int, count: Int): Float32Array {
 		return data;
 	}
 
 	public function lock(?start: Int, ?count: Int): Float32Array {
 		if (start == null) start = 0;
 		if (count == null) count = this.count();
-		return lock2(start, count);
+		return lockPrivate(start, count);
+	}
+
+	@:functionCode('
+		dataInt16->self.data = (short*)buffer->lock() + start * buffer->stride() / 2;
+		dataInt16->self.myLength = count * buffer->stride() / 2;
+		return dataInt16;
+	')
+	private function lockInt16Private(start: Int, count: Int): Int16Array {
+		return dataInt16;
+	}
+
+	public function lockInt16(?start: Int, ?count: Int): Int16Array {
+		if (start == null) start = 0;
+		if (count == null) count = this.count();
+		if (dataInt16 == null) dataInt16 = new Int16Array();
+		return lockInt16Private(start, count);
 	}
 
 	@:functionCode('buffer->unlock();')

--- a/Backends/KoreHL/KoreC/arrays.cpp
+++ b/Backends/KoreHL/KoreC/arrays.cpp
@@ -21,7 +21,7 @@ extern "C" float hl_kore_float32array_get(vbyte* f32array, int index) {
 }
 
 extern "C" vbyte* hl_kore_uint32array_alloc(int elements) {
-	unsigned int* data = new unsigned int [elements];
+	unsigned int* data = new unsigned int[elements];
 	return (vbyte*)data;
 }
 
@@ -34,7 +34,26 @@ extern "C" void hl_kore_uint32array_set(vbyte* u32array, int index, unsigned int
 	arr[index] = value;
 }
 
-extern "C" unsigned int  hl_kore_uint32array_get(vbyte* u32array, int index) {
+extern "C" unsigned int hl_kore_uint32array_get(vbyte* u32array, int index) {
 	unsigned int* arr = (unsigned int*)u32array;
+	return arr[index];
+}
+
+extern "C" vbyte* hl_kore_int16array_alloc(int elements) {
+	short* data = new short[elements];
+	return (vbyte*)data;
+}
+
+extern "C" void hl_kore_int16array_free(vbyte* i16array) {
+	delete[] i16array;
+}
+
+extern "C" void hl_kore_int16array_set(vbyte* i16array, int index, short value) {
+	short* arr = (short*)i16array;
+	arr[index] = value;
+}
+
+extern "C" short hl_kore_int16array_get(vbyte* i16array, int index) {
+	short* arr = (short*)i16array;
 	return arr[index];
 }

--- a/Backends/KoreHL/kha/arrays/Int16Array.hx
+++ b/Backends/KoreHL/kha/arrays/Int16Array.hx
@@ -1,22 +1,22 @@
 package kha.arrays;
 
-class Uint32ArrayPrivate {
+class Int16ArrayPrivate {
 	// Has to be wrapped in class..
 	public var self: Pointer;
 	public var length: Int;
 	public inline function new() {}
 }
 
-abstract Uint32Array(Uint32ArrayPrivate) {
+abstract Int16Array(Int16ArrayPrivate) {
 	
 	public inline function new(elements: Int = 0) {
-		this = new Uint32ArrayPrivate();
+		this = new Int16ArrayPrivate();
 		this.length = elements;
-		if (elements > 0) this.self = kore_uint32array_alloc(elements);
+		if (elements > 0) this.self = kore_int16array_alloc(elements);
 	}
 
 	public inline function free(): Void {
-		kore_uint32array_free(this.self);
+		kore_int16array_free(this.self);
 	}
 	
 	public var length(get, never): Int;
@@ -35,12 +35,12 @@ abstract Uint32Array(Uint32ArrayPrivate) {
 	}
 	
 	public inline function set(index: Int, value: Int): Int {
-		kore_uint32array_set(this.self, index, value);
+		kore_int16array_set(this.self, index, value);
 		return value;
 	}
 	
 	public inline function get(index: Int): Int {
-		return kore_uint32array_get(this.self, index);
+		return kore_int16array_get(this.self, index);
 	}
 
 	@:arrayAccess
@@ -53,8 +53,8 @@ abstract Uint32Array(Uint32ArrayPrivate) {
 		return set(index, value);
 	}
 
-	@:hlNative("std", "kore_uint32array_alloc") static function kore_uint32array_alloc(elements: Int): Pointer { return null; }
-	@:hlNative("std", "kore_uint32array_free") static function kore_uint32array_free(u32array: Pointer): Void { }
-	@:hlNative("std", "kore_uint32array_set") static function kore_uint32array_set(u32array: Pointer, index: Int, value: Int): Void { }
-	@:hlNative("std", "kore_uint32array_get") static function kore_uint32array_get(u32array: Pointer, index: Int): Int { return 0; }
+	@:hlNative("std", "kore_int16array_alloc") static function kore_int16array_alloc(elements: Int): Pointer { return null; }
+	@:hlNative("std", "kore_int16array_free") static function kore_int16array_free(u16array: Pointer): Void { }
+	@:hlNative("std", "kore_int16array_set") static function kore_int16array_set(u16array: Pointer, index: Int, value: Int): Void { }
+	@:hlNative("std", "kore_int16array_get") static function kore_int16array_get(u16array: Pointer, index: Int): Int { return 0; }
 }

--- a/Backends/KoreHL/kha/graphics4/PipelineState.hx
+++ b/Backends/KoreHL/kha/graphics4/PipelineState.hx
@@ -48,6 +48,10 @@ class PipelineState extends PipelineStateBase {
 					data = 4;
 				case VertexData.Float4x4:
 					data = 5; // Kore::Graphics4::Float4x4VertexData;
+				case VertexData.Short2Norm:
+					data = 6;
+				case VertexData.Short4Norm:
+					data = 7;
 				}
 				VertexBuffer.kore_vertexstructure_add(kore_structure, StringHelper.convert(structures[i].get(j).name), data);
 			}

--- a/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
+++ b/Backends/KoreHL/kha/graphics4/VertexBuffer.hx
@@ -1,6 +1,7 @@
 package kha.graphics4;
 
 import kha.arrays.Float32Array;
+import kha.arrays.Int16Array;
 import kha.graphics4.VertexData;
 import kha.graphics4.VertexElement;
 import kha.graphics4.VertexStructure;
@@ -23,6 +24,10 @@ class VertexBuffer {
 				data = 4;
 			case VertexData.Float4x4:
 				data = 5;
+			case VertexData.Short2Norm:
+				data = 6;
+			case VertexData.Short4Norm:
+				data = 7;
 			}
 			kore_vertexstructure_add(structure2, StringHelper.convert(structure.get(i).name), data);
 		}
@@ -37,6 +42,12 @@ class VertexBuffer {
 		var f32array = new Float32Array();
 		f32array.setData(kore_vertexbuffer_lock(_buffer), this.count() * Std.int(stride() / 4));
 		return f32array;
+	}
+
+	public function lockInt16(?start: Int, ?count: Int): Int16Array {
+		var i16array = new Int16Array();
+		i16array.setData(kore_vertexbuffer_lock(_buffer), this.count() * Std.int(stride() / 2));
+		return i16array;
 	}
 	
 	public function unlock(): Void {

--- a/Backends/Krom/kha/arrays/Int16Array.hx
+++ b/Backends/Krom/kha/arrays/Int16Array.hx
@@ -1,8 +1,8 @@
 package kha.arrays;
 
-abstract Uint32Array(js.html.Uint32Array) {
+abstract Int16Array(js.html.Int16Array) {
 	public inline function new(elements: Int) {
-		this = new js.html.Uint32Array(elements);
+		this = new js.html.Int16Array(elements);
 	}
 	
 	public var length(get, never): Int;
@@ -19,7 +19,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index];
 	}
 	
-	public inline function data(): js.html.Uint32Array {
+	public inline function data(): js.html.Int16Array {
 		return this;
 	}
 
@@ -33,7 +33,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index] = value;
 	}
 
-	public inline function subarray(start: Int, ?end: Int): Uint32Array {
+	public inline function subarray(start: Int, ?end: Int): Int16Array {
 		return cast this.subarray(start, end);
 	}
 }

--- a/Backends/Krom/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Krom/kha/graphics4/VertexBuffer.hx
@@ -1,6 +1,7 @@
 package kha.graphics4;
 
 import kha.arrays.Float32Array;
+import kha.arrays.Int16Array;
 import kha.graphics4.Usage;
 import kha.graphics4.VertexStructure;
 import kha.graphics4.VertexData;
@@ -25,6 +26,10 @@ class VertexBuffer {
 	public function lock(?start: Int, ?count: Int): Float32Array {
 		_data = Krom.lockVertexBuffer(buffer);
 		return _data;
+	}
+
+	public function lockInt16(?start: Int, ?count: Int): Int16Array {
+		return new Int16Array(untyped lock(start, count).buffer);
 	}
 
 	public function unlock(): Void {

--- a/Backends/Node/kha/arrays/Int16Array.hx
+++ b/Backends/Node/kha/arrays/Int16Array.hx
@@ -1,8 +1,8 @@
 package kha.arrays;
 
-abstract Uint32Array(js.html.Uint32Array) {
+abstract Int16Array(js.html.Int16Array) {
 	public inline function new(elements: Int) {
-		this = new js.html.Uint32Array(elements);
+		this = new js.html.Int16Array(elements);
 	}
 	
 	public var length(get, never): Int;
@@ -19,7 +19,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index];
 	}
 	
-	public inline function data(): js.html.Uint32Array {
+	public inline function data(): js.html.Int16Array {
 		return this;
 	}
 
@@ -33,7 +33,7 @@ abstract Uint32Array(js.html.Uint32Array) {
 		return this[index] = value;
 	}
 
-	public inline function subarray(start: Int, ?end: Int): Uint32Array {
+	public inline function subarray(start: Int, ?end: Int): Int16Array {
 		return cast this.subarray(start, end);
 	}
 }

--- a/Sources/kha/graphics4/VertexData.hx
+++ b/Sources/kha/graphics4/VertexData.hx
@@ -6,4 +6,6 @@ package kha.graphics4;
 	var Float3 = 2;
 	var Float4 = 3;
 	var Float4x4 = 4;
+	var Short2Norm = 5;
+	var Short4Norm = 6;
 }

--- a/Sources/kha/graphics4/VertexStructure.hx
+++ b/Sources/kha/graphics4/VertexStructure.hx
@@ -40,6 +40,10 @@ class VertexStructure {
 				return 4 * 4;
 			case Float4x4:
 				return 4 * 4 * 4;
+			case Short2Norm:
+				return 2 * 2;
+			case Short4Norm:
+				return 2 * 4;
 		}
 		return 0;
 	}


### PR DESCRIPTION
- Exposes `VertexData.Short2Norm` and `VertexData.Short4Norm` : signed, normalized, 16bit vertex data
- Only 2/4 channels, to prevent padding
- Works for D3D11, OpenGL, WebGL + Krom, HLC, hxcpp, HTML5
- Implements `kha.arrays.Int16Array`

To go with https://github.com/Kode/Krom/pull/114 https://github.com/Kode/khacpp/pull/7 https://github.com/Kode/Kore/pull/339