### PR TITLE
Use Kore::FileReader for HL

### DIFF
--- a/Backends/KoreHL/KoreC/kore.cpp
+++ b/Backends/KoreHL/KoreC/kore.cpp
@@ -98,3 +98,25 @@ extern "C" void hl_kore_init_audio(vclosure *callCallback, vclosure *readSample)
 extern "C" void hl_run_kore() {
 	Kore::System::start();
 }
+
+#include <Kore/IO/FileReader.h>
+
+extern "C" vbyte *hl_kore_file_contents(vbyte *name, int *size) {
+	int len;
+	int p = 0;
+	vbyte *content;
+	Kore::FileReader file;
+	if (!file.open((char*)name))
+		return NULL;
+	hl_blocking(true);
+	len = file.size();
+	if (size) *size = len;
+	hl_blocking(false);
+	content = (vbyte*)hl_gc_alloc_noptr(size ? len : len+1);
+	hl_blocking(true);
+	if (!size) content[len] = 0; // final 0 for UTF8
+	file.read(content, len);
+	file.close();
+	hl_blocking(false);
+	return content;
+}

--- a/Backends/KoreHL/kha/LoaderImpl.hx
+++ b/Backends/KoreHL/kha/LoaderImpl.hx
@@ -24,7 +24,10 @@ class LoaderImpl {
 	}
 	
 	public static function loadBlobFromDescription(desc: Dynamic, done: Blob -> Void, failed: AssetError -> Void) {
-		done(new Blob(File.getBytes(desc.files[0])));
+		// done(new Blob(File.getBytes(desc.files[0])));
+		var size = 0;
+		var bytes = kore_file_contents(StringHelper.convert(desc.files[0]), size);
+		done(new Blob(@:privateAccess new haxe.io.Bytes(bytes, size)));
 	}
 	
 	public static function loadFontFromDescription(desc: Dynamic, done: Font -> Void, failed: AssetError -> Void): Void {
@@ -45,4 +48,6 @@ class LoaderImpl {
 	public static function getVideoFormats(): Array<String> {
 		return [videoFormat()];
 	}
+
+	@:hlNative("std", "kore_file_contents") static function kore_file_contents(name: hl.Bytes, size: hl.Ref<Int>): Pointer { return null; }
 }


### PR DESCRIPTION
Makes HL take advantage of the `Kore::FileReader`, ie. reading blobs works perfectly on Android now.

Once `Kore::FileReader` is ported to C, we can patch the `hl_file_contents()` directly at:
https://github.com/Kode/Kha/blob/master/Backends/KoreHL/hl/src/std/file.c#L146

Like we do for hxcpp at:
https://github.com/Kode/khacpp/blob/cc0097dd4822f75c707b6e87e6acfec68bcf38d1/src/hx/libs/std/File.cpp#L347

(HL + Android build times are awesome!)