### PR TITLE
Image.getPixels() for non-render-targets

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -49,6 +49,7 @@ extern class Krom {
 	static function createTextureFromBytes(data: haxe.io.BytesData, width: Int, height: Int, format: Int, readable: Bool): Dynamic;
 	static function createTextureFromBytes3D(data: haxe.io.BytesData, width: Int, height: Int, depth: Int, format: Int, readable: Bool): Dynamic;
 	static function createTextureFromEncodedBytes(data: haxe.io.BytesData, format: String, readable: Bool): Dynamic;
+	static function getTexturePixels(texture: Dynamic): haxe.io.BytesData;
 	static function getRenderTargetPixels(renderTarget: Dynamic, data: haxe.io.BytesData): Void;
 	static function lockTexture(texture: Dynamic, level: Int): js.html.ArrayBuffer;
 	static function unlockTexture(texture: Dynamic): Void;

--- a/Backends/Krom/kha/Image.hx
+++ b/Backends/Krom/kha/Image.hx
@@ -164,10 +164,14 @@ class Image implements Canvas implements Resource {
 	private var pixels: Bytes = null;
 
 	public function getPixels(): Bytes {
-		if (renderTarget_ == null) return null;
-		if (pixels == null) pixels = Bytes.alloc(formatByteSize(format) * width * height);
-		Krom.getRenderTargetPixels(renderTarget_, pixels.getData());
-		return pixels;
+		if (renderTarget_ != null) {
+			if (pixels == null) pixels = Bytes.alloc(formatByteSize(format) * width * height);
+			Krom.getRenderTargetPixels(renderTarget_, pixels.getData());
+			return pixels;
+		}
+		else {
+			return Bytes.ofData(Krom.getTexturePixels(texture_));
+		}
 	}
 
 	private static function formatByteSize(format: TextureFormat): Int {


### PR DESCRIPTION
Right now `Image.getPixels()` fails for non-render-target images. This allows to retrieve bytes for `readable` images. Started with Krom.

- `Image.getPixels()` - read pixels
- `Image.lock()/unlock()` - modify pixels

Depends on https://github.com/Kode/Kore/pull/351 and https://github.com/Kode/Krom/pull/118.