### PR TITLE
Fix Image.at for WebGL images created via Image.fromBytes

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -123,10 +123,10 @@ class WebGLImage extends Image {
 			else createImageData();
 		}
 		
-		var r = data.data[y * Std.int(image.width) * 4 + x * 4];
-		var g = data.data[y * Std.int(image.width) * 4 + x * 4 + 1];
-		var b = data.data[y * Std.int(image.width) * 4 + x * 4 + 2];
-		var a = data.data[y * Std.int(image.width) * 4 + x * 4 + 3];
+		var r = data.data[y * width * 4 + x * 4];
+		var g = data.data[y * width * 4 + x * 4 + 1];
+		var b = data.data[y * width * 4 + x * 4 + 2];
+		var a = data.data[y * width * 4 + x * 4 + 3];
 		
 		return Color.fromValue((a << 24) | (r << 16) | (g << 8) | b);
 	}


### PR DESCRIPTION
When an `Image` has been created via `Image.fromBytes` (WebGL), its `image` property is a `Uint8Array` (has no `width` or `height`), but the broken code accesses these non-existent properties.

Broken:
`var r = data.data[y * Std.int(image.width) * 4 + x * 4];`

Fixed:
`var r = data.data[y * image.width * 4 + x * 4];`

Explanation:
`Std.int(image.width)`
becomes:
`undefined | 0`
becomes:
`0`

Therefore, `Image.at` multiples `y` with `0`, returning an incorrect result for all `y > 0`.