### PR TITLE
Added getter for g4 when g2 is on g4

### DIFF
--- a/Sources/kha/graphics2/Graphics.hx
+++ b/Sources/kha/graphics2/Graphics.hx
@@ -228,6 +228,12 @@ class Graphics {
 		setPipeline(pipeline);
 		return pipe = pipeline;
 	}
+
+	public var g4(get, never): kha.graphics4.Graphics;
+	
+	private function get_g4(): kha.graphics4.Graphics {
+		return null;
+	}
 	#end
 
 	private var transformations: Array<FastMatrix3>;

--- a/Sources/kha/graphics4/Graphics2.hx
+++ b/Sources/kha/graphics4/Graphics2.hx
@@ -751,6 +751,10 @@ class Graphics2 extends kha.graphics2.Graphics {
 		}
 	}
 
+	override private function get_g4(): kha.graphics4.Graphics {
+		return g;
+	}
+
 	private static function upperPowerOfTwo(v: Int): Int {
 		v--;
 		v |= v >>> 1;


### PR DESCRIPTION
When g2 is running on an underlying g4 instance, we can set a custom pipeline. However if that pipeline deviates at all from the default pipelines, there aren't really any ways to control it. Implementation for #1006

For example, in my use-case, my custom pipeline samples from two textures (the default one provided by ImageShaderPainter, and a custom one in a custom shader I'm using). In order to set that second texture, I need access to the underlying g4 instance, hence this small change to give access.

Tested and works in my use-case, but let me know if there are any problems.