### PR TITLE
vector.normalize changes

### DIFF
--- a/Sources/kha/math/FastMatrix4.hx
+++ b/Sources/kha/math/FastMatrix4.hx
@@ -142,10 +142,8 @@ class FastMatrix4 {
 	}
 
 	public static inline function lookAt(eye: FastVector3, at: FastVector3, up: FastVector3): FastMatrix4 {
-		var zaxis = at.sub(eye);
-		zaxis.normalize();
-		var xaxis = zaxis.cross(up);
-		xaxis.normalize();
+		var zaxis = at.sub(eye).normalized();
+		var xaxis = zaxis.cross(up).normalized();
 		var yaxis = xaxis.cross(zaxis);
 
 		return new FastMatrix4(

--- a/Sources/kha/math/FastVector2.hx
+++ b/Sources/kha/math/FastVector2.hx
@@ -20,7 +20,7 @@ class FastVector2 {
 		this.y = v.y;
 	}
 
-	private function get_length(): FastFloat {
+	private inline function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y);
 	}
 
@@ -55,12 +55,12 @@ class FastVector2 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): FastVector2 {
 		var v = new FastVector2(x, y);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/FastVector2.hx
+++ b/Sources/kha/math/FastVector2.hx
@@ -6,15 +6,15 @@ class FastVector2 {
 		this.x = x;
 		this.y = y;
 	}
-	
+
 	public static function fromVector2(v: Vector2): FastVector2 {
 		return new FastVector2(v.x, v.y);
 	}
-	
+
 	public var x: FastFloat;
 	public var y: FastFloat;
 	public var length(get, set): FastFloat;
-	
+
 	@:extern public inline function setFrom(v: FastVector2): Void {
 		this.x = v.x;
 		this.y = v.y;
@@ -23,7 +23,7 @@ class FastVector2 {
 	private function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y);
 	}
-	
+
 	private function set_length(length: FastFloat): FastFloat {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -32,35 +32,42 @@ class FastVector2 {
 		y *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: FastVector2): FastVector2 {
 		return new FastVector2(x + vec.x, y + vec.y);
 	}
-	
+
 	@:extern public inline function sub(vec: FastVector2): FastVector2 {
 		return new FastVector2(x - vec.x, y - vec.y);
 	}
-	
+
 	@:extern public inline function mult(value: FastFloat): FastVector2 {
 		return new FastVector2(x * value, y * value);
 	}
-	
+
 	@:extern public inline function div(value: FastFloat): FastVector2 {
 		return mult(1 / value);
 	}
-	
+
 	@:extern public inline function dot(v: FastVector2): FastFloat {
 		return x * v.x + y * v.y;
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
 	}
-	
+
+	@:extern public inline function normalized(): FastVector2 {
+		var v = new FastVector2(x, y);
+		v.length = 1;
+		return v;
+	}
+
 	@:extern public inline function angle(v: FastVector2): FastFloat {
 		return Math.atan2(y,x) - Math.atan2(v.y,v.x);
 	}
-	
+
 	public function toString() {
 		return 'FastVector2($x, $y)';
 	}

--- a/Sources/kha/math/FastVector3.hx
+++ b/Sources/kha/math/FastVector3.hx
@@ -23,7 +23,7 @@ class FastVector3 {
 		this.z = v.z;
 	}
 
-	private function get_length(): FastFloat {
+	private inline function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y + z * z);
 	}
 
@@ -62,12 +62,12 @@ class FastVector3 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): FastVector3 {
 		var v = new FastVector3(x, y, z);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/FastVector3.hx
+++ b/Sources/kha/math/FastVector3.hx
@@ -7,16 +7,16 @@ class FastVector3 {
 		this.y = y;
 		this.z = z;
 	}
-	
+
 	public static function fromVector3(v: Vector3): FastVector3 {
 		return new FastVector3(v.x, v.y, v.z);
 	}
-	
+
 	public var x: FastFloat;
 	public var y: FastFloat;
 	public var z: FastFloat;
 	public var length(get, set): FastFloat;
-	
+
 	@:extern public inline function setFrom(v: FastVector3): Void {
 		this.x = v.x;
 		this.y = v.y;
@@ -26,7 +26,7 @@ class FastVector3 {
 	private function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y + z * z);
 	}
-	
+
 	private function set_length(length: FastFloat): FastFloat {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -36,34 +36,41 @@ class FastVector3 {
 		z *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: FastVector3): FastVector3 {
 		return new FastVector3(x + vec.x, y + vec.y, z + vec.z);
 	}
-	
+
 	@:extern public inline function sub(vec: FastVector3): FastVector3 {
 		return new FastVector3(x - vec.x, y - vec.y, z - vec.z);
 	}
-	
+
 	@:extern public inline function mult(value: FastFloat): FastVector3 {
 		return new FastVector3(x * value, y * value, z * value);
 	}
-	
+
 	@:extern public inline function dot(v: FastVector3): FastFloat {
 		return x * v.x + y * v.y + z * v.z;
 	}
-	
+
 	@:extern public inline function cross(v: FastVector3): FastVector3 {
 		var _x = y * v.z - z * v.y;
 		var _y = z * v.x - x * v.z;
 		var _z = x * v.y - y * v.x;
 		return new FastVector3(_x, _y, _z);
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
 	}
-	
+
+	@:extern public inline function normalized(): FastVector3 {
+		var v = new FastVector3(x, y, z);
+		v.length = 1;
+		return v;
+	}
+
 	public function toString() {
 		return 'FastVector3($x, $y, $z)';
 	}

--- a/Sources/kha/math/FastVector4.hx
+++ b/Sources/kha/math/FastVector4.hx
@@ -8,11 +8,11 @@ class FastVector4 {
 		this.z = z;
 		this.w = w;
 	}
-	
+
 	public static function fromVector4(v: Vector4): FastVector4 {
 		return new FastVector4(v.x, v.y, v.z, v.w);
 	}
-	
+
 	public var x: FastFloat;
 	public var y: FastFloat;
 	public var z: FastFloat;
@@ -25,11 +25,11 @@ class FastVector4 {
 		this.z = v.z;
 		this.w = v.w;
 	}
-	
+
 	private function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y + z * z + w * w);
 	}
-	
+
 	private function set_length(length: FastFloat): FastFloat {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -40,23 +40,30 @@ class FastVector4 {
 		w *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: FastVector4): FastVector4 {
 		return new FastVector4(x + vec.x, y + vec.y, z + vec.z, w + vec.w);
 	}
-	
+
 	@:extern public inline function sub(vec: FastVector4): FastVector4 {
 		return new FastVector4(x - vec.x, y - vec.y, z - vec.z, w - vec.w);
 	}
-	
+
 	@:extern public inline function mult(value: FastFloat): FastVector4 {
 		return new FastVector4(x * value, y * value, z * value, w * value);
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
 	}
-	
+
+	@:extern public inline function normalized(): FastVector4 {
+		var v = new FastVector4(x, y, z, w);
+		v.length = 1;
+		return v;
+	}
+
 	public function toString() {
 		return 'FastVector4($x, $y, $z, $w)';
 	}

--- a/Sources/kha/math/FastVector4.hx
+++ b/Sources/kha/math/FastVector4.hx
@@ -26,7 +26,7 @@ class FastVector4 {
 		this.w = v.w;
 	}
 
-	private function get_length(): FastFloat {
+	private inline function get_length(): FastFloat {
 		return Math.sqrt(x * x + y * y + z * z + w * w);
 	}
 
@@ -55,12 +55,12 @@ class FastVector4 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): FastVector4 {
 		var v = new FastVector4(x, y, z, w);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/Matrix4.hx
+++ b/Sources/kha/math/Matrix4.hx
@@ -142,10 +142,8 @@ class Matrix4 {
 	}
 
 	public static function lookAt(eye: Vector3, at: Vector3, up: Vector3): Matrix4 {
-		var zaxis = at.sub(eye);
-		zaxis.normalize();
-		var xaxis = zaxis.cross(up);
-		xaxis.normalize();
+		var zaxis = at.sub(eye).normalized();
+		var xaxis = zaxis.cross(up).normalized();
 		var yaxis = xaxis.cross(zaxis);
 
 		return new Matrix4(

--- a/Sources/kha/math/Vector2.hx
+++ b/Sources/kha/math/Vector2.hx
@@ -16,7 +16,7 @@ class Vector2 {
 		this.y = v.y;
 	}
 
-	private function get_length(): Float {
+	private inline function get_length(): Float {
 		return Math.sqrt(x * x + y * y);
 	}
 
@@ -51,12 +51,12 @@ class Vector2 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): Vector2 {
 		var v = new Vector2(x, y);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/Vector2.hx
+++ b/Sources/kha/math/Vector2.hx
@@ -6,7 +6,7 @@ class Vector2 {
 		this.x = x;
 		this.y = y;
 	}
-	
+
 	public var x: Float;
 	public var y: Float;
 	public var length(get, set): Float;
@@ -15,11 +15,11 @@ class Vector2 {
 		this.x = v.x;
 		this.y = v.y;
 	}
-	
+
 	private function get_length(): Float {
 		return Math.sqrt(x * x + y * y);
 	}
-	
+
 	private function set_length(length: Float): Float {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -28,31 +28,38 @@ class Vector2 {
 		y *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: Vector2): Vector2 {
 		return new Vector2(x + vec.x, y + vec.y);
 	}
-	
+
 	@:extern public inline function sub(vec: Vector2): Vector2 {
 		return new Vector2(x - vec.x, y - vec.y);
 	}
-	
+
 	@:extern public inline function mult(value: Float): Vector2 {
 		return new Vector2(x * value, y * value);
 	}
-	
+
 	@:extern public inline function div(value: Float): Vector2 {
 		return mult(1 / value);
 	}
-	
+
 	@:extern public inline function dot(v: Vector2): Float {
 		return x * v.x + y * v.y;
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
 	}
-	
+
+	@:extern public inline function normalized(): Vector2 {
+		var v = new Vector2(x, y);
+		v.length = 1;
+		return v;
+	}
+
 	@:extern public inline function angle(v: Vector2): Float {
 		return Math.atan2(y,x) - Math.atan2(v.y,v.x);
 	}

--- a/Sources/kha/math/Vector3.hx
+++ b/Sources/kha/math/Vector3.hx
@@ -7,7 +7,7 @@ class Vector3 {
 		this.y = y;
 		this.z = z;
 	}
-	
+
 	public var x: Float;
 	public var y: Float;
 	public var z: Float;
@@ -18,11 +18,11 @@ class Vector3 {
 		this.y = v.y;
 		this.z = v.z;
 	}
-	
+
 	private function get_length(): Float {
 		return Math.sqrt(x * x + y * y + z * z);
 	}
-	
+
 	private function set_length(length: Float): Float {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -32,32 +32,39 @@ class Vector3 {
 		z *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: Vector3): Vector3 {
 		return new Vector3(x + vec.x, y + vec.y, z + vec.z);
 	}
-	
+
 	@:extern public inline function sub(vec: Vector3): Vector3 {
 		return new Vector3(x - vec.x, y - vec.y, z - vec.z);
 	}
-	
+
 	@:extern public inline function mult(value: Float): Vector3 {
 		return new Vector3(x * value, y * value, z * value);
 	}
-	
+
 	@:extern public inline function dot(v: Vector3): Float {
 		return x * v.x + y * v.y + z * v.z;
 	}
-	
+
 	@:extern public inline function cross(v: Vector3): Vector3 {
 		var _x = y * v.z - z * v.y;
 		var _y = z * v.x - x * v.z;
 		var _z = x * v.y - y * v.x;
 		return new Vector3(_x, _y, _z);
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
+	}
+
+	@:extern public inline function normalized(): Vector3 {
+		var v = new Vector3(x, y, z);
+		v.length = 1;
+		return v;
 	}
 
 	@:extern public inline function fast(): FastVector3 {

--- a/Sources/kha/math/Vector3.hx
+++ b/Sources/kha/math/Vector3.hx
@@ -19,7 +19,7 @@ class Vector3 {
 		this.z = v.z;
 	}
 
-	private function get_length(): Float {
+	private inline function get_length(): Float {
 		return Math.sqrt(x * x + y * y + z * z);
 	}
 
@@ -58,12 +58,12 @@ class Vector3 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): Vector3 {
 		var v = new Vector3(x, y, z);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/Vector4.hx
+++ b/Sources/kha/math/Vector4.hx
@@ -22,7 +22,7 @@ class Vector4 {
 		this.w = v.w;
 	}
 
-	private function get_length(): Float {
+	private inline function get_length(): Float {
 		return Math.sqrt(x * x + y * y + z * z + w * w);
 	}
 
@@ -51,12 +51,12 @@ class Vector4 {
 
 	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
-		length = 1;
+		#if haxe4 inline #end set_length(1);
 	}
 
 	@:extern public inline function normalized(): Vector4 {
 		var v = new Vector4(x, y, z, w);
-		v.length = 1;
+		#if haxe4 inline #end v.set_length(1);
 		return v;
 	}
 

--- a/Sources/kha/math/Vector4.hx
+++ b/Sources/kha/math/Vector4.hx
@@ -8,7 +8,7 @@ class Vector4 {
 		this.z = z;
 		this.w = w;
 	}
-	
+
 	public var x: Float;
 	public var y: Float;
 	public var z: Float;
@@ -21,11 +21,11 @@ class Vector4 {
 		this.z = v.z;
 		this.w = v.w;
 	}
-	
+
 	private function get_length(): Float {
 		return Math.sqrt(x * x + y * y + z * z + w * w);
 	}
-	
+
 	private function set_length(length: Float): Float {
 		var currentLength = get_length();
 		if (currentLength == 0) return 0;
@@ -36,21 +36,28 @@ class Vector4 {
 		w *= mul;
 		return length;
 	}
-	
+
 	@:extern public inline function add(vec: Vector4): Vector4 {
 		return new Vector4(x + vec.x, y + vec.y, z + vec.z, w + vec.w);
 	}
-	
+
 	@:extern public inline function sub(vec: Vector4): Vector4 {
 		return new Vector4(x - vec.x, y - vec.y, z - vec.z, w - vec.w);
 	}
-	
+
 	@:extern public inline function mult(value: Float): Vector4 {
 		return new Vector4(x * value, y * value, z * value, w * value);
 	}
-	
+
+	@:deprecated("normalize() will be deprecated soon, use the immutable normalized() instead")
 	@:extern public inline function normalize(): Void {
 		length = 1;
+	}
+
+	@:extern public inline function normalized(): Vector4 {
+		var v = new Vector4(x, y, z, w);
+		v.length = 1;
+		return v;
 	}
 
 	@:extern public inline function fast(): FastVector4 {


### PR DESCRIPTION
see https://github.com/Kode/Kha/issues/1027

With these changes the new `normalized()` doesn't generate function calls and the `kha_math_Vector` constructors anymore (tested in JS). I'm not sure about making `set_length` inline (i haven't needed to set a length after construction yet in my code), but i guess it wouldn't hurt?
