### PR TITLE
hide navigation bar on android html5 in fullscreen

### DIFF
--- a/Backends/HTML5/kha/Window.hx
+++ b/Backends/HTML5/kha/Window.hx
@@ -108,7 +108,7 @@ class Window {
 
 	function requestFullscreen(): Void {
 		untyped if (canvas.requestFullscreen) {
-			canvas.requestFullscreen();
+			canvas.requestFullscreen({navigationUI:"hide"});
 		}
 		else if (canvas.msRequestFullscreen) {
 			canvas.msRequestFullscreen();


### PR DESCRIPTION
Make html5 use all the screen and hide the navigation bar
https://blog.chromium.org/2018/10/chrome-71-beta-relative-time-formats.html