### PR TITLE
prevent duplicate channels

### DIFF
--- a/Sources/kha/audio2/Audio1.hx
+++ b/Sources/kha/audio2/Audio1.hx
@@ -110,6 +110,11 @@ class Audio1 {
 		mutex.acquire();
 		#end
 		for (i in 0...channelCount) {
+			if (soundChannels[i] == channel) {
+				soundChannels[i] = null;
+			}
+		}
+		for (i in 0...channelCount) {
 			if (soundChannels[i] == null || soundChannels[i].finished || soundChannels[i] == channel) {
 				soundChannels[i] = channel;
 				break;


### PR DESCRIPTION
## steps to reproduce

- play sounds: `sound0`, `sound1`, `sound2`
- shortly after, pause `sound2`
- wait until `sound0` and `sound1` finished
- resume `sound2`
  - it will get inserted in `soundChannels[0]` (as `sound0` is already finished) and therefore appear twice in the array
  - this will in turn call `AudioChannel.nextSamples` twice per tick and speedup the playback
