### PR TITLE
 implement multisampled render targets html5

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -27,6 +27,7 @@ class WebGLImage extends Image {
 	public var renderBuffer: Dynamic = null;
 	public var texture: Dynamic = null;
 	public var depthTexture: Dynamic = null;
+	public var colorBuffer:Dynamic=null;
 
 	private var graphics1: kha.graphics1.Graphics;
 	private var graphics2: kha.graphics2.Graphics;
@@ -210,19 +211,23 @@ class WebGLImage extends Image {
 				}
 			}
 			else {
-				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
-
-				// TODO: Multisampling
-				//var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
-				//SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
-				//untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER, 4, GL.RGBA8, realWidth, realHeight);
-				//SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, colorRenderbuffer);
+				if (SystemImpl.gl2) {
+					colorBuffer = SystemImpl.gl.createFramebuffer();
+					var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
+					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
+					untyped trace(SystemImpl.gl.getParameter(SystemImpl.gl.MAX_SAMPLES));
+					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, SystemImpl.gl.RGBA8, realWidth, realHeight);
+					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
+					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, colorRenderbuffer);
+					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, colorBuffer);
+				}
+				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER,GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
 			}
 
-			initDepthStencilBuffer(depthStencilFormat);
-
-			if (SystemImpl.gl.checkFramebufferStatus(GL.FRAMEBUFFER) != GL.FRAMEBUFFER_COMPLETE) {
-				trace("WebGL error: Framebuffer incomplete");
+			//initDepthStencilBuffer(depthStencilFormat);
+			var e=SystemImpl.gl.checkFramebufferStatus(GL.FRAMEBUFFER);
+			if (e != GL.FRAMEBUFFER_COMPLETE) {
+				trace(e);
 			}
 
 			SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, null);

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -216,7 +216,23 @@ class WebGLImage extends Image {
 					MSAAFramebuffer = SystemImpl.gl.createFramebuffer();
 					var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
 					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
-					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, SystemImpl.gl.RGBA8, realWidth, realHeight);
+					var MSAAFormat=switch (format) {
+					case DEPTH16:
+						GL.DEPTH_COMPONENT16;
+					case RGBA128:
+						untyped SystemImpl.gl.RGBA32F;
+					case RGBA64:
+						untyped SystemImpl.gl.RGBA16F;
+					case RGBA32:
+						untyped SystemImpl.gl.RGBA8;
+					case A32:
+						GL_R32F;
+					case A16:
+						GL_R16F;
+					default:
+						untyped SystemImpl.gl.RGBA8;
+					};
+					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, MSAAFormat, realWidth, realHeight);
 					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, colorRenderbuffer);
 					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFramebuffer);

--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -27,7 +27,9 @@ class WebGLImage extends Image {
 	public var renderBuffer: Dynamic = null;
 	public var texture: Dynamic = null;
 	public var depthTexture: Dynamic = null;
-	public var MSAAFramebuffer:Dynamic=null;
+	public var MSAAFrameBuffer:Dynamic=null;
+	var MSAAColorBuffer:Dynamic;
+	var MSAADepthBuffer:Dynamic;
 
 
 	private var graphics1: kha.graphics1.Graphics;
@@ -213,9 +215,9 @@ class WebGLImage extends Image {
 			}
 			else {
 				if (samples>1&&SystemImpl.gl2) {
-					MSAAFramebuffer = SystemImpl.gl.createFramebuffer();
-					var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
-					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
+					MSAAFrameBuffer = SystemImpl.gl.createFramebuffer();
+					MSAAColorBuffer = SystemImpl.gl.createRenderbuffer();
+					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, MSAAColorBuffer);
 					var MSAAFormat=switch (format) {
 					case DEPTH16:
 						GL.DEPTH_COMPONENT16;
@@ -234,8 +236,8 @@ class WebGLImage extends Image {
 					};
 					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, MSAAFormat, realWidth, realHeight);
 					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, colorRenderbuffer);
-					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFramebuffer);
+					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.COLOR_ATTACHMENT0, GL.RENDERBUFFER, MSAAColorBuffer);
+					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFrameBuffer);
 				}
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER,GL.COLOR_ATTACHMENT0, GL.TEXTURE_2D, texture, 0);
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, null);
@@ -301,12 +303,12 @@ class WebGLImage extends Image {
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 				
 				if (samples>1&&SystemImpl.gl2) {
-					var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
-					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
+					MSAADepthBuffer = SystemImpl.gl.createRenderbuffer();
+					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, MSAADepthBuffer);
 					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, GL.DEPTH_COMPONENT16, realWidth, realHeight);
 					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, colorRenderbuffer);
-					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFramebuffer);
+					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, MSAADepthBuffer);
+					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFrameBuffer);
 					
 				}
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
@@ -331,12 +333,12 @@ class WebGLImage extends Image {
 				SystemImpl.gl.texParameteri(GL.TEXTURE_2D, GL.TEXTURE_WRAP_T, GL.CLAMP_TO_EDGE);
 				SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 				if (samples>1&&SystemImpl.gl2) {
-					var colorRenderbuffer = SystemImpl.gl.createRenderbuffer();
-					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, colorRenderbuffer);
+					MSAADepthBuffer = SystemImpl.gl.createRenderbuffer();
+					SystemImpl.gl.bindRenderbuffer(GL.RENDERBUFFER, MSAADepthBuffer);
 					untyped SystemImpl.gl.renderbufferStorageMultisample(GL.RENDERBUFFER,samples, GL_DEPTH24_STENCIL8, realWidth, realHeight);
 					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
-					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.RENDERBUFFER, colorRenderbuffer);
-					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFramebuffer);
+					SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.RENDERBUFFER, MSAADepthBuffer);
+					SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, MSAAFrameBuffer);
 					
 				}
 				SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_STENCIL_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
@@ -479,7 +481,9 @@ class WebGLImage extends Image {
 		if (depthTexture != null) SystemImpl.gl.deleteTexture(depthTexture);
 		if (frameBuffer != null) SystemImpl.gl.deleteFramebuffer(frameBuffer);
 		if (renderBuffer != null) SystemImpl.gl.deleteRenderbuffer(renderBuffer);
-		if (MSAAFramebuffer != null) SystemImpl.gl.deleteRenderbuffer(MSAAFramebuffer);
+		if (MSAAFrameBuffer != null) SystemImpl.gl.deleteRenderbuffer(MSAAFrameBuffer);
+		if(MSAAColorBuffer != null)SystemImpl.gl.deleteRenderbuffer(MSAAColorBuffer);
+		if(MSAADepthBuffer != null)SystemImpl.gl.deleteRenderbuffer(MSAADepthBuffer);
 	}
 
 	override public function generateMipmaps(levels: Int): Void {

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -36,7 +36,7 @@ class Graphics implements kha.graphics4.Graphics {
 	private var indicesCount: Int;
 	private var renderTarget: Canvas;
 	private var renderTargetFrameBuffer: Dynamic;
-	private var renderTargetColor: Dynamic;
+	private var renderTargetMSAA: Dynamic;
 	private var renderTargetTexture: Dynamic;
 	private var isCubeMap: Bool = false;
 	private var isDepthAttachment: Bool = false;
@@ -73,7 +73,7 @@ class Graphics implements kha.graphics4.Graphics {
 		else {
 			var image: WebGLImage = cast(renderTarget, WebGLImage);
 			renderTargetFrameBuffer = image.frameBuffer;
-			renderTargetColor=image.colorBuffer;
+			renderTargetMSAA=image.MSAAFramebuffer;
 			renderTargetTexture = image.texture;
 		}
 	}
@@ -123,13 +123,14 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function end(): Void {
-		if (renderTarget != null) {
+		if (renderTargetMSAA != null) {
 			untyped SystemImpl.gl.bindFramebuffer(SystemImpl.gl.READ_FRAMEBUFFER, renderTargetFrameBuffer);
-			untyped SystemImpl.gl.bindFramebuffer(SystemImpl.gl.DRAW_FRAMEBUFFER, renderTargetColor);
+			untyped SystemImpl.gl.bindFramebuffer(SystemImpl.gl.DRAW_FRAMEBUFFER, renderTargetMSAA);
 			untyped SystemImpl.gl.clearBufferfv(SystemImpl.gl.COLOR, 0, [1.0, 1.0, 1.0, 1.0]);
 			untyped SystemImpl.gl.blitFramebuffer(0, 0, renderTarget.width, renderTarget.height,
 								0, 0, renderTarget.width, renderTarget.height,
 								GL.COLOR_BUFFER_BIT, GL.LINEAR);
+			
 		}
 		#if (debug || kha_debug_html5)
 		var error = SystemImpl.gl.getError();

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -73,7 +73,7 @@ class Graphics implements kha.graphics4.Graphics {
 		else {
 			var image: WebGLImage = cast(renderTarget, WebGLImage);
 			renderTargetFrameBuffer = image.frameBuffer;
-			renderTargetMSAA=image.MSAAFramebuffer;
+			renderTargetMSAA=image.MSAAFrameBuffer;
 			renderTargetTexture = image.texture;
 		}
 	}

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -36,6 +36,7 @@ class Graphics implements kha.graphics4.Graphics {
 	private var indicesCount: Int;
 	private var renderTarget: Canvas;
 	private var renderTargetFrameBuffer: Dynamic;
+	private var renderTargetColor: Dynamic;
 	private var renderTargetTexture: Dynamic;
 	private var isCubeMap: Bool = false;
 	private var isDepthAttachment: Bool = false;
@@ -72,6 +73,7 @@ class Graphics implements kha.graphics4.Graphics {
 		else {
 			var image: WebGLImage = cast(renderTarget, WebGLImage);
 			renderTargetFrameBuffer = image.frameBuffer;
+			renderTargetColor=image.colorBuffer;
 			renderTargetTexture = image.texture;
 		}
 	}
@@ -121,6 +123,14 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function end(): Void {
+		if (renderTarget != null) {
+			untyped SystemImpl.gl.bindFramebuffer(SystemImpl.gl.READ_FRAMEBUFFER, renderTargetFrameBuffer);
+			untyped SystemImpl.gl.bindFramebuffer(SystemImpl.gl.DRAW_FRAMEBUFFER, renderTargetColor);
+			untyped SystemImpl.gl.clearBufferfv(SystemImpl.gl.COLOR, 0, [1.0, 1.0, 1.0, 1.0]);
+			untyped SystemImpl.gl.blitFramebuffer(0, 0, renderTarget.width, renderTarget.height,
+								0, 0, renderTarget.width, renderTarget.height,
+								GL.COLOR_BUFFER_BIT, GL.LINEAR);
+		}
 		#if (debug || kha_debug_html5)
 		var error = SystemImpl.gl.getError();
 		switch (error) {


### PR DESCRIPTION
Not sure if blitFramebuffer should be done in the end function or in another place.

source : 
https://stackoverflow.com/questions/47934444/webgl-framebuffer-multisampling/55976760#55976760
http://www.realtimerendering.com/blog/webgl-2-new-features/
https://github.com/BabylonJS/Babylon.js/blob/5ac3ac40788e6fd551457015503facfe653de8b9/src/Engines/engine.ts