### PR TITLE
cleanup Float32Array array access functions a bit

### DIFF
--- a/Backends/Android/kha/arrays/Float32Array.hx
+++ b/Backends/Android/kha/arrays/Float32Array.hx
@@ -17,28 +17,19 @@ abstract Float32Array(java.NativeArray<Single>) {
 		return this.length;
 	}
 
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		this[index] = value;
 		return value;
 	}
 
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return this[index];
 	}
 
 	public inline function data(count:Int): FloatBuffer {
 		return FloatBuffer.wrap(this, 0, count);
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return get(index);
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		set(index, value);
-		return value;
 	}
 
 	//public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/Empty/kha/arrays/Float32Array.hx
+++ b/Backends/Empty/kha/arrays/Float32Array.hx
@@ -6,33 +6,25 @@ abstract Float32Array(Dynamic) {
 	public inline function new(elements: Int) {
 		this = null;
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
 		return 0;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return 0;
 	}
-	
+
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return 0;
 	}
-	
+
 	public inline function data(): Dynamic {
 		return this;
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return 0;
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return 0;
 	}
 
 	public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/Flash/kha/arrays/Float32Array.hx
+++ b/Backends/Flash/kha/arrays/Float32Array.hx
@@ -5,40 +5,32 @@ import kha.FastFloat;
 
 abstract Float32Array(ByteArray) {
 	private static inline var elementSize = 4;
-	
+
 	public inline function new(elements: Int) {
 		this = new ByteArray();
 		this.endian = flash.utils.Endian.LITTLE_ENDIAN;
 		this.length = elements * elementSize;
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
 		return this.length >> 2;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		this.position = index * elementSize;
 		this.writeFloat(value);
 		return value;
 	}
-	
+
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		this.position = index * elementSize;
 		return this.readFloat();
 	}
 
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return get(index);
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return set(index, value);
-	}
-	
 	public inline function data(): ByteArray {
 		return this;
 	}

--- a/Backends/HTML5-Worker/kha/arrays/Float32Array.hx
+++ b/Backends/HTML5-Worker/kha/arrays/Float32Array.hx
@@ -13,26 +13,18 @@ abstract Float32Array(js.lib.Float32Array) {
 		return this.length;
 	}
 
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return this[index] = value;
 	}
 
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return this[index];
 	}
 
 	public inline function data(): js.lib.Float32Array {
 		return this;
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return this[index];
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this[index] = value;
 	}
 
 	public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/HTML5/kha/arrays/Float32Array.hx
+++ b/Backends/HTML5/kha/arrays/Float32Array.hx
@@ -6,33 +6,25 @@ abstract Float32Array(js.lib.Float32Array) {
 	public inline function new(elements: Int) {
 		this = new js.lib.Float32Array(elements);
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
 		return this.length;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return this[index] = value;
 	}
-	
+
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return this[index];
 	}
-	
+
 	public inline function data(): js.lib.Float32Array {
 		return this;
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return this[index];
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this[index] = value;
 	}
 
 	public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/Kore/kha/arrays/Float32Array.hx
+++ b/Backends/Kore/kha/arrays/Float32Array.hx
@@ -10,18 +10,18 @@ import kha.FastFloat;
 extern class Float32ArrayData {
 	@:native("float32array")
 	public static function create(): Float32ArrayData;
-	
+
 	public var length(get, never): Int;
 
 	@:native("length")
 	function get_length(): Int;
-	
+
 	public function alloc(elements: Int): Void;
 
 	public function free(): Void;
 
 	public function get(index: Int): FastFloat;
-		
+
 	public function set(index: Int, value: FastFloat): FastFloat;
 }
 
@@ -55,23 +55,15 @@ abstract Float32Array(Float32ArrayPrivate) {
 	inline function get_length(): Int {
 		return this.self.length;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return this.self.set(index, value);
 	}
-	
-	public inline function get(index: Int): FastFloat {
-		return this.self.get(index);
-	}
-	
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return this.self.get(index);
-	}
 
 	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this.self.set(index, value);
+	public inline function get(index: Int): FastFloat {
+		return this.self.get(index);
 	}
 
 	//public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/KoreHL/kha/arrays/Float32Array.hx
+++ b/Backends/KoreHL/kha/arrays/Float32Array.hx
@@ -10,7 +10,7 @@ class Float32ArrayPrivate {
 }
 
 abstract Float32Array(Float32ArrayPrivate) {
-	
+
 	public inline function new(elements: Int = 0) {
 		this = new Float32ArrayPrivate();
 		this.length = elements;
@@ -20,7 +20,7 @@ abstract Float32Array(Float32ArrayPrivate) {
 	public inline function free(): Void {
 		kore_float32array_free(this.self);
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
@@ -35,24 +35,16 @@ abstract Float32Array(Float32ArrayPrivate) {
 		this.self = ar;
 		this.length = elements;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		kore_float32array_set(this.self, index, value);
 		return value;
 	}
-	
+
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return kore_float32array_get(this.self, index);
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return get(index);
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return set(index, value);
 	}
 
 	@:hlNative("std", "kore_float32array_alloc") static function kore_float32array_alloc(elements: Int): Pointer { return null; }

--- a/Backends/Krom/kha/arrays/Float32Array.hx
+++ b/Backends/Krom/kha/arrays/Float32Array.hx
@@ -19,26 +19,18 @@ abstract Float32Array(js.lib.Float32Array) {
 		return this.length;
 	}
 
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return this[index] = value;
 	}
 
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return this[index];
 	}
 
 	public inline function data(): js.lib.Float32Array {
 		return this;
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return this[index];
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this[index] = value;
 	}
 
 	public inline function subarray(start: Int, ?end: Int): Float32Array {

--- a/Backends/Node/kha/arrays/Float32Array.hx
+++ b/Backends/Node/kha/arrays/Float32Array.hx
@@ -6,33 +6,25 @@ abstract Float32Array(js.html.Float32Array) {
 	public inline function new(elements: Int) {
 		this = new js.html.Float32Array(elements);
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
 		return this.length;
 	}
-	
+
+	@:arrayAccess
 	public inline function set(index: Int, value: FastFloat): FastFloat {
 		return this[index] = value;
 	}
-	
+
+	@:arrayAccess
 	public inline function get(index: Int): FastFloat {
 		return this[index];
 	}
-	
+
 	public inline function data(): js.html.Float32Array {
 		return this;
-	}
-
-	@:arrayAccess
-	public inline function arrayRead(index: Int): FastFloat {
-		return this[index];
-	}
-
-	@:arrayAccess
-	public inline function arrayWrite(index: Int, value: FastFloat): FastFloat {
-		return this[index] = value;
 	}
 
 	public inline function subarray(start: Int, ?end: Int): Float32Array {


### PR DESCRIPTION
Just move `@:arrayAccess` meta to the `get`/`set` functions themselves and remove `arrayRead`/`arrayWrite` as they are redundant (also, even if they weren't, there's no need for `@:arrayAccess` methods to be public).

PS: my editor trimmed trailing whitespace again. i think that's for the best, but let met know if you disagree and I'll disable it