### PR TITLE
fix canvas.getContext check

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -450,7 +450,7 @@ class SystemImpl {
 
 			Scheduler.executeFrame();
 
-			if (untyped canvas.getContext) {
+			if (canvas.getContext != null) {
 
 				// Lookup the size the browser is displaying the canvas.
 				//TODO deal with window.devicePixelRatio ?


### PR DESCRIPTION
With that `untyped`, Haxe will generate `if($bind(canvas,canvas.getContext))` which doesn't make sense, however with the simple null check it's going to be `if(canvas.getContext != null)` which I believe was the intention here.

Related: https://github.com/HaxeFoundation/haxe/issues/6297