### PR TITLE
take file sizes into account when loading assets

### DIFF
--- a/Sources/kha/internal/AssetsBuilder.hx
+++ b/Sources/kha/internal/AssetsBuilder.hx
@@ -52,9 +52,10 @@ class AssetsBuilder {
 		var names = new Array<Expr>();
 
 		for (file in files) {
-			final name = file.name;
-			final filename = file.files[0];
+			var name = file.name;
 			final pos = Context.currentPos();
+			var filename: String = file.files[0];
+			var filesize: Int = file.file_sizes[0];
 
 			if (file.type == type) {
 
@@ -119,27 +120,36 @@ class AssetsBuilder {
 					pos: pos
 				});
 
+				fields.push({
+					name: name + "Size",
+					doc: null,
+					meta: [],
+					access: [APublic],
+					kind: FVar(macro: Dynamic, macro $v { filesize }),
+					pos: Context.currentPos()
+				});
+
 				var loadExpressions = macro { };
 				switch (type) {
 					case "image":
 						loadExpressions = macro {
-							Assets.loadImage($v{name}, function (image: Image) done(), failure);
+							Assets.loadImage($v{name}, function (image: Image) done($v{filesize}), failure);
 						};
 					case "sound":
 						loadExpressions = macro {
-							Assets.loadSound($v{name}, function (sound: Sound) done(), failure);
+							Assets.loadSound($v{name}, function (sound: Sound) done($v{filesize}), failure);
 						};
 					case "blob":
 						loadExpressions = macro {
-							Assets.loadBlob($v{name}, function (blob: Blob) done(), failure);
+							Assets.loadBlob($v{name}, function (blob: Blob) done($v{filesize}), failure);
 						};
 					case "font":
 						loadExpressions = macro {
-							Assets.loadFont($v{name}, function (font: Font) done(), failure);
+							Assets.loadFont($v{name}, function (font: Font) done($v{filesize}), failure);
 						};
 					case "video":
 						loadExpressions = macro {
-							Assets.loadVideo($v{name}, function (video: Video) done(), failure);
+							Assets.loadVideo($v{name}, function (video: Video) done($v{filesize}), failure);
 						};
 				}
 
@@ -153,7 +163,7 @@ class AssetsBuilder {
 						expr: loadExpressions,
 						args: [{
 							value: null,
-							type: Context.toComplexType(Context.getType("kha.internal.VoidCallback")),
+							type: Context.toComplexType(Context.getType("kha.internal.IntCallback")),
 							opt: null,
 							name: "done"
 						}, {

--- a/Sources/kha/internal/IntCallback.hx
+++ b/Sources/kha/internal/IntCallback.hx
@@ -1,0 +1,3 @@
+package kha.internal;
+
+typedef IntCallback = Int -> Void;


### PR DESCRIPTION
This PR relies on Kode/khamake#215. That PR adds file sizes to the generated `files.json` file. This PR makes use of those file sizes to provide:

1. A more detailed `Assets.progress`, such that the progress is changed based on file sizes rather than file counts (i.e. if you have two files, and one is only 10 KiB and the other is 90 KiB, loading the first file will only advance the progress by 0.1 instead of 0.5 [the old way]).
2. Adds `${asset}Size` field using a macro to query as asset's file size at run-time to facilitate custom loading. So, for example, you can use `Assets.images.lennaSize` to get the file size of the `lenna` image.

If accepted, this PR should be merged after Kode/khamake#215, and after updating the khamake submodule dependency.