### PR TITLE
Added Image.fromCanvas for HTML5 target

### DIFF
--- a/Backends/HTML5/kha/Image.hx
+++ b/Backends/HTML5/kha/Image.hx
@@ -2,6 +2,7 @@ package kha;
 
 import haxe.io.Bytes;
 import js.html.ImageElement;
+import js.html.CanvasElement;
 import js.html.webgl.GL;
 import kha.graphics4.TextureFormat;
 import kha.graphics4.DepthStencilFormat;
@@ -23,6 +24,21 @@ class Image implements Canvas implements Resource {
 		if (format == null) format = TextureFormat.RGBA32;
 		if (SystemImpl.gl == null) return new CanvasImage(width, height, format, true);
 		else return new WebGLImage(width, height, format, true, depthStencil, antiAliasingSamples);
+	}
+
+	public static function fromCanvas(canvas: CanvasElement): Image {
+		if (SystemImpl.gl == null) {
+			var img = new CanvasImage(canvas.width, canvas.height, TextureFormat.RGBA32, false);
+			img.image = canvas;
+			img.createTexture();
+			return img;
+		}
+		else {
+			var img = new WebGLImage(canvas.width, canvas.height, TextureFormat.RGBA32, false, DepthStencilFormat.NoDepthAndStencil, 1);
+			img.image = canvas;
+			img.createTexture();
+			return img;
+		}
 	}
 
 	public static function fromImage(image: ImageElement, readable: Bool): Image {


### PR DESCRIPTION
As requested in Kode/Kha#1099

Tested and confirmed working in Firefox for canvas, webgl1, and webgl2 backends.