### PR TITLE
Implementation of Android onKeyPress

### DIFF
--- a/Backends/Android/android/view/KeyEvent.hx
+++ b/Backends/Android/android/view/KeyEvent.hx
@@ -11,4 +11,5 @@ extern class KeyEvent {
 	public static var KEYCODE_VOLUME_UP: Int;
 	public function isAltPressed(): Bool;
 	public function getKeyCode(): Int;
+    public function getUnicodeChar(): Int;
 }

--- a/Backends/Android/kha/SystemImpl.hx
+++ b/Backends/Android/kha/SystemImpl.hx
@@ -237,7 +237,7 @@ class SystemImpl {
 			keyboard.sendDownEvent(KeyCode.Return);
 		case 0x00000004:
 			keyboard.sendDownEvent(KeyCode.Back);
-		default:
+		default: keyboard.sendPressEvent(String.fromCharCode(code).toLowerCase());
 
 		}
 	}

--- a/Backends/Android/kha/SystemImpl.hx
+++ b/Backends/Android/kha/SystemImpl.hx
@@ -237,7 +237,7 @@ class SystemImpl {
 			keyboard.sendDownEvent(KeyCode.Return);
 		case 0x00000004:
 			keyboard.sendDownEvent(KeyCode.Back);
-		default: keyboard.sendPressEvent(String.fromCharCode(code).toLowerCase());
+		default:
 
 		}
 	}
@@ -257,6 +257,11 @@ class SystemImpl {
 
 		}
 	}
+	
+	public static function keyPress(char: String): Void {
+        	keyboard.sendPressEvent(char);
+    	}
+	
 
 	public static var showKeyboard: Bool;
 

--- a/Backends/Android/tech/kode/kha/KhaRenderer.hx
+++ b/Backends/Android/tech/kode/kha/KhaRenderer.hx
@@ -76,7 +76,7 @@ class KhaRenderer implements GLSurfaceViewRenderer {
 		SystemImpl.setWidthHeight(width, height); // , context.getResources().getAssets(), context.getApplicationInfo().sourceDir, context.getFilesDir().toString());
 	}
 	
-	public function key(keyCode: Int, down: Bool): Void {
+	public function key(keyCode: Int, down: Bool, char:String): Void {
 		switch (keyCode) {
 		case 59: // shift
 			if (down) SystemImpl.keyDown(0x00000120);

--- a/Backends/Android/tech/kode/kha/KhaRenderer.hx
+++ b/Backends/Android/tech/kode/kha/KhaRenderer.hx
@@ -92,7 +92,7 @@ class KhaRenderer implements GLSurfaceViewRenderer {
 			else SystemImpl.keyUp(KeyEvent.KEYCODE_BACK);
 		default:
 			var code = keyMap.get(keyCode, MetaKeyKeyListener.META_SHIFT_ON);
-			if (down) SystemImpl.keyDown(code);
+			if (down) {SystemImpl.keyDown(code); SystemImpl.keyPress(char);}
 			else SystemImpl.keyUp(code);
 		}
 	}

--- a/Backends/Android/tech/kode/kha/KhaView.hx
+++ b/Backends/Android/tech/kode/kha/KhaView.hx
@@ -31,31 +31,35 @@ class OnTouchRunner implements Runnable {
 }
 
 class OnKeyDownRunner implements Runnable {
-	private var renderer: KhaRenderer;
-	private var keyCode: Int;
+    private var renderer: KhaRenderer;
+    private var keyCode: Int;
+    private var char: String;
 
-	public function new(renderer: KhaRenderer, keyCode: Int) {
-		this.renderer = renderer;
-		this.keyCode = keyCode;
-	}
+    public function new(renderer: KhaRenderer, keyCode: Int, char: String) {
+        this.renderer = renderer;
+        this.keyCode = keyCode;
+        this.char = char;
+    }
 
-	public function run(): Void {
-		renderer.key(keyCode, true);
-	}
+    public function run(): Void {
+        renderer.key(keyCode, true, char);
+    }
 }
 
 class OnKeyUpRunner implements Runnable {
-	private var renderer: KhaRenderer;
-	private var keyCode: Int;
+    private var renderer: KhaRenderer;
+    private var keyCode: Int;
+    private var char: String;
 
-	public function new(renderer: KhaRenderer, keyCode: Int) {
-		this.renderer = renderer;
-		this.keyCode = keyCode;
-	}
+    public function new(renderer: KhaRenderer, keyCode: Int, char: String) {
+        this.renderer = renderer;
+        this.keyCode = keyCode;
+        this.char = char;
+    }
 
-	public function run(): Void {
-		renderer.key(keyCode, false);
-	}
+    public function run(): Void {
+        renderer.key(keyCode, false, char);
+    }
 }
 
 @:keep
@@ -137,7 +141,7 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 			return true;
 		}*/
 		
-		this.queueEvent(new OnKeyDownRunner(renderer, keyCode));
+		this.queueEvent(new OnKeyDownRunner(renderer, keyCode, String.fromCharCode(event.getUnicodeChar())));
 		return true;
 	}
 
@@ -147,7 +151,7 @@ class KhaView extends GLSurfaceView implements ViewOnTouchListener {
 			|| event.getKeyCode() == KeyEvent.KEYCODE_VOLUME_UP) {
 			return false;
 		}
-		this.queueEvent(new OnKeyUpRunner(renderer, keyCode));
+		this.queueEvent(new OnKeyUpRunner(renderer, keyCode, '')); //doesn't make sense to send text
 	    return true;
 	}
 


### PR DESCRIPTION
This adds support to Android onKeyPress and so will enable:

```haxe
Keyboard.get().notify(onKeyDown,onKeyUp,onKeyPress);
```

This fix issue #1138 and supports inserting special characters like 'ç'.