### PR TITLE
Fix Graphics1 on Krom

### DIFF
--- a/Sources/kha/graphics2/Graphics1.hx
+++ b/Sources/kha/graphics2/Graphics1.hx
@@ -31,7 +31,7 @@ class Graphics1 implements kha.graphics1.Graphics {
 	}
 
 	public function setPixel(x: Int, y: Int, color: Color): Void {
-		#if kha_html5
+		#if (kha_html5 || kha_krom)
 		pixels.setInt32(y * texture.realWidth * 4 + x * 4, Color.fromBytes(color.Bb, color.Gb, color.Rb, color.Ab));
 		#else
 		pixels.setInt32(y * texture.realWidth * 4 + x * 4, color);


### PR DESCRIPTION
Fixes https://github.com/Kode/Kha/issues/940 by having `Graphics1` swap `Color`'s R and B values on Krom like it already does on HTML5, tested using the MWE provided in the issue:
```haxe
fb.g1.begin();
for (x in 0...fb.width) {
	for (y in 0...fb.height) {
		fb.g1.setPixel(x, y, kha.Color.Red);
	}
}
fb.g1.end();
```