### PR TITLE
Fixes opengl surface height that causes touch coordinates mismatch

### DIFF
--- a/Backends/Android/android/opengl/GLES20.hx
+++ b/Backends/Android/android/opengl/GLES20.hx
@@ -47,6 +47,7 @@ extern class GLES20 {
 	public static var GL_DEPTH_BUFFER_BIT: Int;
 	public static var GL_STENCIL_BUFFER_BIT: Int;
 	public static var GL_DEPTH_TEST: Int;
+    public static var GL_SCISSOR_TEST: Int;
 	public static var GL_ALWAYS: Int;
 	public static var GL_NEVER: Int;
 	public static var GL_EQUAL: Int;
@@ -126,6 +127,7 @@ extern class GLES20 {
 	public static function glCompileShader(shader : Int) : Void;
 	public static function glBlendFunc(srcfunc : Int, destfunc : Int) : Void;
 	public static function glViewport(x : Int, y : Int, width : Int, height : Int) : Void;
+    public static function glScissor(x : Int, y : Int, width : Int, height : Int) : Void;
 	public static function glClearColor(r : Single, g : Single, b : Single, a : Single) : Void;
 	public static function glClearDepthf(depth : Single) : Void;
 	public static function glAttachShader(program : Int, shader : Int) : Void;

--- a/Backends/Android/kha/Window.hx
+++ b/Backends/Android/kha/Window.hx
@@ -57,7 +57,7 @@ class Window {
 
 	@:functionCode('
 		android.util.DisplayMetrics metrics = new android.util.DisplayMetrics();
-		tech.kode.kha.KhaActivity.the().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+		tech.kode.kha.KhaActivity.the().getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
 		return metrics.widthPixels;
 	')
 	public function get_width(): Int {
@@ -72,7 +72,7 @@ class Window {
 	
 	@:functionCode('
 		android.util.DisplayMetrics metrics = new android.util.DisplayMetrics();
-		tech.kode.kha.KhaActivity.the().getWindowManager().getDefaultDisplay().getMetrics(metrics);
+		tech.kode.kha.KhaActivity.the().getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
 		return metrics.heightPixels;
 	')
 	public function get_height(): Int {

--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -455,10 +455,11 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function scissor(x: Int, y: Int, width: Int, height: Int): Void {
-
+        GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
+        GLES20.glScissor(x,y,width,height);
 	}
 
 	public function disableScissor(): Void {
-
+        GLES20.glDisable(GLES20.GL_SCISSOR_TEST);
 	}
 }

--- a/Backends/Android/kha/android/Graphics.hx
+++ b/Backends/Android/kha/android/Graphics.hx
@@ -456,7 +456,8 @@ class Graphics implements kha.graphics4.Graphics {
 
 	public function scissor(x: Int, y: Int, width: Int, height: Int): Void {
         GLES20.glEnable(GLES20.GL_SCISSOR_TEST);
-        GLES20.glScissor(x,y,width,height);
+        // Workaround to transform opengl y coordinate into kha's
+        GLES20.glScissor(x,System.windowHeight()-y-height,width,height);
 	}
 
 	public function disableScissor(): Void {


### PR DESCRIPTION
The wrong value of height can cause touch coordinate mismatch and prevent Kha from drawing on the entire screen.

This fixes issue #1159.