### PR TITLE
Fixes playing `.ogg` sound in Android.

### DIFF
--- a/Backends/KoreHL/kha/korehl/Sound.hx
+++ b/Backends/KoreHL/kha/korehl/Sound.hx
@@ -8,25 +8,18 @@ using StringTools;
 @:keep
 class Sound extends kha.Sound {
 
-	function initWav(filename: String) {
+	function initSound(filename: String) {
 		uncompressedData = new kha.arrays.Float32Array();
 		var dataSize = new kha.arrays.Uint32Array(1);
 		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData(), length);
 		uncompressedData.setData(data, dataSize[0]);
 		dataSize.free();
 	}
-
-	function initOgg(filename: String) {
-		compressedData = File.getBytes(filename);
-	}
 	
 	public function new(filename: String) {
 		super();
-		if (filename.endsWith(".wav")) {
-			initWav(filename);
-		}
-		else if (filename.endsWith(".ogg")) {
-			initOgg(filename);
+		if (filename.endsWith(".wav") || filename.endsWith(".ogg")) {
+			initSound(filename);
 		}
 		else {
 			trace("Unknown sound format: " + filename);


### PR DESCRIPTION
This whole thing is explained in https://github.com/armory3d/armory/issues/1412 , and was worked out by @onelsonic and @DarthVernus — I'm simply composing this pull request using their shared code, a bit simplified because it looks like some of the changes are already present.

It just happened to me that my test app was crashing when trying to play `.ogg` sounds in Android, and with these changes it just works fine.