### PR TITLE
Fix compilation for node target

### DIFF
--- a/Backends/Node/kha/graphics4/FragmentShader.hx
+++ b/Backends/Node/kha/graphics4/FragmentShader.hx
@@ -4,10 +4,14 @@ import kha.Blob;
 
 class FragmentShader {
 	public function new(sources: Array<Blob>, files: Array<String>) {
-		
+
 	}
 
 	public static function fromSource(source: String): FragmentShader {
 		return null;
+	}
+
+	public function delete(): Void {
+
 	}
 }

--- a/Backends/Node/kha/graphics4/VertexShader.hx
+++ b/Backends/Node/kha/graphics4/VertexShader.hx
@@ -4,10 +4,14 @@ import kha.Blob;
 
 class VertexShader {
 	public function new(sources: Array<Blob>, files: Array<String>) {
-		
+
 	}
 
 	public static function fromSource(source: String): VertexShader {
 		return null;
+	}
+
+	public function delete(): Void {
+
 	}
 }

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -63,7 +63,11 @@ class EmptyGraphics4 implements Graphics {
 	public function refreshRate(): Int {
 		return 60;
 	}
-	
+
+	public function maxBoundTextures(): Int {
+		return 8;
+	}
+
 	public function clear(?color: Color, ?depth: Float, ?stencil: Int): Void {
 		
 	}

--- a/Backends/Node/kha/js/EmptyGraphics4.hx
+++ b/Backends/Node/kha/js/EmptyGraphics4.hx
@@ -29,15 +29,15 @@ import kha.math.Vector4;
 
 class EmptyGraphics4 implements Graphics {
 	public function new(width: Int, height: Int) {
-		
+
 	}
-	
+
 	public function init(?backbufferFormat: TextureFormat, antiAliasingSamples: Int = 1): Void {
 
 	}
-	
+
 	public function begin(additionalRenderTargets: Array<Canvas> = null): Void {
-		
+
 	}
 
 	public function beginFace(face: Int): Void {
@@ -45,17 +45,17 @@ class EmptyGraphics4 implements Graphics {
 	}
 
 	public function beginEye(eye: Int): Void {
-		
+
 	}
 
 	public function end(): Void {
-		
+
 	}
-	
+
 	public function flush(): Void {
-		
+
 	}
-	
+
 	public function vsynced(): Bool {
 		return true;
 	}
@@ -69,27 +69,27 @@ class EmptyGraphics4 implements Graphics {
 	}
 
 	public function clear(?color: Color, ?depth: Float, ?stencil: Int): Void {
-		
+
 	}
 
 	public function viewport(x : Int, y : Int, width : Int, height : Int): Void{
-		
+
 	}
-	
+
 	public function setCullMode(mode: CullMode): Void {
-		
+
 	}
-	
+
 	public function setDepthMode(write: Bool, mode: CompareMode): Void {
-		
+
 	}
 
 	public function setBlendingMode(source: BlendingOperation, destination: BlendingOperation): Void {
-		
+
 	}
 
 	public function setStencilParameters(compareMode: CompareMode, bothPass: StencilAction, depthFail: StencilAction, stencilFail: StencilAction, referenceValue: Int, readMask: Int = 0xff, writeMask: Int = 0xff): Void {
-		
+
 	}
 
 	public function setStencilReferenceValue(value: Int) {
@@ -97,35 +97,35 @@ class EmptyGraphics4 implements Graphics {
 	}
 
 	public function scissor(x: Int, y: Int, width: Int, height: Int): Void {
-		
+
 	}
 
 	public function disableScissor(): Void {
-		
+
 	}
-	
+
 	public function setVertexBuffer(vertexBuffer: VertexBuffer): Void {
-		
+
 	}
-	
+
 	public function setVertexBuffers(vertexBuffers: Array<kha.graphics4.VertexBuffer>): Void {
-		
+
 	}
 
 	public function setIndexBuffer(indexBuffer: IndexBuffer): Void {
-		
+
 	}
-	
+
 	public function setTexture(unit: TextureUnit, texture: Image): Void {
-		
+
 	}
 
 	public function setTextureArray(unit: TextureUnit, texture: kha.Image): Void {
-	
+
 	}
-	
+
 	public function setTextureDepth(unit: TextureUnit, texture: Image): Void {
-		
+
 	}
 
 	public function setVideoTexture(unit: kha.graphics4.TextureUnit, texture: kha.Video): Void {
@@ -137,11 +137,11 @@ class EmptyGraphics4 implements Graphics {
 	}
 
 	public function setTextureParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-		
+
 	}
 
 	public function setTexture3DParameters(texunit: TextureUnit, uAddressing: TextureAddressing, vAddressing: TextureAddressing, wAddressing: TextureAddressing, minificationFilter: TextureFilter, magnificationFilter: TextureFilter, mipmapFilter: MipMapFilter): Void {
-	
+
 	}
 
 	public function setTextureCompareMode(texunit: TextureUnit, enabled: Bool): Void {
@@ -149,94 +149,94 @@ class EmptyGraphics4 implements Graphics {
 	}
 
 	public function setCubeMapCompareMode(texunit: TextureUnit, enabled: Bool): Void {
-		
+
 	}
 
 	public function setCubeMap(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
-		
+
 	}
-	
+
 	public function setCubeMapDepth(stage: kha.graphics4.TextureUnit, cubeMap: kha.graphics4.CubeMap): Void {
-		
+
 	}
-	
+
 	public function setPipeline(pipeline: PipelineState): Void {
-		
+
 	}
-	
+
 	public function setBool(location: ConstantLocation, value: Bool): Void {
-		
+
 	}
 
 	public function setInt(location: ConstantLocation, value: Int): Void {
-		
+
 	}
 
 	public function setInt2(location: ConstantLocation, value1: Int, value2: Int): Void {
-		
+
 	}
 
 	public function setInt3(location: ConstantLocation, value1: Int, value2: Int, value3: Int): Void {
-		
+
 	}
 
 	public function setInt4(location: ConstantLocation, value1: Int, value2: Int, value3: Int, value4: Int): Void {
-		
+
 	}
 
 	public function setInts(location: ConstantLocation, values: kha.arrays.Int32Array): Void {
-		
+
 	}
 
 	public function setFloat(location: ConstantLocation, value: Float): Void {
-		
+
 	}
 
 	public function setFloat2(location: ConstantLocation, value1: Float, value2: Float): Void {
-		
+
 	}
 
 	public function setFloat3(location: ConstantLocation, value1: Float, value2: Float, value3: Float): Void {
-		
+
 	}
 
 	public function setFloat4(location: ConstantLocation, value1: Float, value2: Float, value3: Float, value4: Float): Void {
-		
+
 	}
 
 	public function setFloats(location: ConstantLocation, floats: Float32Array): Void {
-		
+
 	}
 
 	public function setVector2(location: ConstantLocation, value: FastVector2): Void {
-		
+
 	}
 
 	public function setVector3(location: ConstantLocation, value: FastVector3): Void {
-		
+
 	}
 
 	public function setVector4(location: ConstantLocation, value: FastVector4): Void {
-		
+
 	}
 
 	public function setMatrix(location: ConstantLocation, value: FastMatrix4): Void {
-		
+
 	}
 
 	public function setMatrix3(location: ConstantLocation, value: FastMatrix3): Void {
-		
+
 	}
-	
+
 	public function drawIndexedVertices(start: Int = 0, count: Int = -1): Void {
-		
+
 	}
-	
+
 	public function instancedRenderingAvailable(): Bool {
 		return true;
 	}
-	
+
 	public function drawIndexedVerticesInstanced(instanceCount: Int, start: Int = 0, count: Int = -1): Void {
-		
+
 	}
 }


### PR DESCRIPTION
- Implemented `EmptyGraphics4.maxBoundTextures()`, this fixes https://github.com/Kode/Kha/issues/1193. I wasn't sure about the correct return value (the node target doesn't produce any visible output), so this function returns 8 just as most of the other implementations.

- "Implemented" `VertexShader.delete()` and `FragementShader.delete()` - there are still way more fields missing for those classes, but I'm not sure about how to implement them.