### PR TITLE
More compilation fixes for node target

### DIFF
--- a/Sources/kha/compute/Shader.hx
+++ b/Sources/kha/compute/Shader.hx
@@ -3,7 +3,7 @@ package kha.compute;
 import kha.Blob;
 
 extern class Shader {
-	public function new(source: Blob, file: String);
+	public function new(sources: Array<Blob>, files: Array<String>);
 	public function delete(): Void;
 	public function getConstantLocation(name: String): ConstantLocation;
 	public function getTextureUnit(name: String): TextureUnit;

--- a/Sources/kha/graphics4/FragmentShader.hx
+++ b/Sources/kha/graphics4/FragmentShader.hx
@@ -3,7 +3,7 @@ package kha.graphics4;
 import kha.Blob;
 
 extern class FragmentShader {
-	public function new(source: Blob, file: String);
+	public function new(sources: Array<Blob>, files: Array<String>);
 	public function delete(): Void;
 
 	/**

--- a/Sources/kha/graphics4/GeometryShader.hx
+++ b/Sources/kha/graphics4/GeometryShader.hx
@@ -4,17 +4,17 @@ import kha.Blob;
 
 #if cpp
 extern class GeometryShader {
-	public function new(source: Blob);
+	public function new(sources: Array<Blob>);
 	public function delete(): Void;
 }
 #else
 class GeometryShader {
-	public function new(source: Blob) {
-		
+	public function new(sources: Array<Blob>) {
+
 	}
-	
+
 	public function delete(): Void {
-		
+
 	}
 }
 #end

--- a/Sources/kha/graphics4/TessellationControlShader.hx
+++ b/Sources/kha/graphics4/TessellationControlShader.hx
@@ -4,17 +4,17 @@ import kha.Blob;
 
 #if cpp
 extern class TessellationControlShader {
-	public function new(source: Blob, file: String);
+	public function new(sources: Array<Blob>, files: Array<String>);
 	public function delete();
 }
 #else
 class TessellationControlShader {
-	public function new(source: Blob, file: String) {
-		
+	public function new(sources: Array<Blob>, files: Array<String>) {
+
 	}
-	
+
 	public function delete(): Void {
-		
+
 	}
 }
 #end

--- a/Sources/kha/graphics4/TessellationEvaluationShader.hx
+++ b/Sources/kha/graphics4/TessellationEvaluationShader.hx
@@ -4,17 +4,17 @@ import kha.Blob;
 
 #if cpp
 extern class TessellationEvaluationShader {
-	public function new(source: Blob, file: String);
+	public function new(sources: Array<Blob>, files: Array<String>);
 	public function delete();
 }
 #else
 class TessellationEvaluationShader {
-	public function new(source: Blob, file: String) {
-		
+	public function new(sources: Array<Blob>, files: Array<String>) {
+
 	}
-	
+
 	public function delete(): Void {
-		
+
 	}
 }
 #end

--- a/Sources/kha/graphics4/VertexShader.hx
+++ b/Sources/kha/graphics4/VertexShader.hx
@@ -3,7 +3,7 @@ package kha.graphics4;
 import kha.Blob;
 
 extern class VertexShader {
-	public function new(source: Blob, file: String);
+	public function new(sources: Array<Blob>, files: Array<String>);
 	public function delete(): Void;
 
 	/**


### PR DESCRIPTION
When compiling to the node target, I got the following error:

```
.../Kha/Sources/kha/internal/ShadersBuilder.hx:66: characters 50-55 : Array<kha.Blob> should be kha.Blob
.../Kha/Sources/kha/internal/ShadersBuilder.hx:66: characters 50-55 : For function argument 'source'
.../Kha/Sources/kha/Shaders.hx:5: lines 5-7 : Defined in this class
```

The function signatures in the no-backend shader definitions were not the same as the signatures used by the individual backends. Hopefully this does not break any other target (only tested with node, html5 and krom and it worked so far), so lets see if the github build checks will succeed^^

Btw, there should probably be a node build check too :)