### PR TITLE
add parentheses  to avoid optimization error

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -173,7 +173,7 @@ class SystemImpl {
 	}
 
 	public static function getTime(): Float {
-		var performance = (Syntax.code("window.performance ? window.performance : window.Date"));
+		var performance = (Syntax.code("(window.performance ? window.performance : window.Date)"));
 		return performance.now() / 1000;
 	}
 


### PR DESCRIPTION
when use with analyzer-optimize the line gets optimize wrong, even in haxe 4.1 
