### PR TITLE
Improve ttc support

### DIFF
--- a/Sources/kha/Kravur.hx
+++ b/Sources/kha/Kravur.hx
@@ -160,7 +160,7 @@ class Kravur implements Resource {
 			KravurImage.charBlocks.push(glyphs[glyphs.length - 1]);
 		}
 
-		var imageIndex = fontSize * 10000 + glyphs.length;
+		var imageIndex = fontIndex * 10000000 + fontSize * 10000 + glyphs.length;
 		if (!images.exists(imageIndex)) {
 			var width: Int = 64;
 			var height: Int = 32;

--- a/Sources/kha/Kravur.hx
+++ b/Sources/kha/Kravur.hx
@@ -217,6 +217,10 @@ class Kravur implements Resource {
 		return _get(fontSize).getBaselinePosition();
 	}
 
+	public function setFontIndex(fontIndex: Int): Void {
+		this.fontIndex = fontIndex;
+	}
+
 	public function unload(): Void {
 		blob = null;
 		images = null;


### PR DESCRIPTION
If the font file is ttc, create an image cache for each font.