### PR TITLE
Preliminary support for native cursors

### DIFF
--- a/Backends/HTML5/kha/input/MouseImpl.hx
+++ b/Backends/HTML5/kha/input/MouseImpl.hx
@@ -1,6 +1,7 @@
 package kha.input;
 
 import kha.SystemImpl;
+import kha.input.Mouse;
 
 class MouseImpl extends kha.input.Mouse {
 	public function new() {
@@ -37,5 +38,25 @@ class MouseImpl extends kha.input.Mouse {
 
 	override public function showSystemCursor(): Void {
 		SystemImpl.khanvas.style.cursor = "default";
+	}
+
+	override public function setSystemCursor(cursor: MouseCursor): Void {
+		SystemImpl.khanvas.style.cursor = switch (cursor) {
+		case Default: "default";
+		case Pointer: "pointer";
+		case Text: "text";
+		case EastWestResize: "ew-resize";
+		case NorthSouthResize: "ns-resize";
+		case NorthEastResize: "ne-resize";
+		case SouthEastResize: "se-resize";
+		case NorthWestResize: "nw-resize";
+		case SouthWestResize: "sw-resize";
+		case Grab: "grab";
+		case Grabbing: "grabbing";
+		case NotAllowed: "not-allowed";
+		case Wait: "wait";
+		case Crosshair: "crosshair";
+		default: "default";
+		}
 	}
 }

--- a/Backends/Kore/kha/SystemImpl.hx
+++ b/Backends/Kore/kha/SystemImpl.hx
@@ -262,6 +262,10 @@ class SystemImpl {
 		untyped __cpp__("Kore::Mouse::the()->show(true);");
 	}
 
+	public static function setSystemCursor(cursor: Int): Void {
+		untyped __cpp__("Kore::Mouse::the()->setCursor(cursor)");
+	}
+
 	public static function frame() {
 		/*
 		#if !ANDROID

--- a/Backends/Kore/kha/input/MouseImpl.hx
+++ b/Backends/Kore/kha/input/MouseImpl.hx
@@ -1,6 +1,7 @@
 package kha.input;
 
 import kha.SystemImpl;
+import kha.input.Mouse;
 
 class MouseImpl extends kha.input.Mouse {
 	public function new() {
@@ -37,5 +38,9 @@ class MouseImpl extends kha.input.Mouse {
 
 	override public function showSystemCursor(): Void {
 		SystemImpl.showSystemCursor();
+	}
+
+	override public function setSystemCursor(cursor: MouseCursor): Void {
+		SystemImpl.setSystemCursor(cursor.getIndex());
 	}
 }

--- a/Sources/kha/input/Mouse.hx
+++ b/Sources/kha/input/Mouse.hx
@@ -9,6 +9,23 @@ enum MouseEventBlockBehavior {
 	Custom(func: (event: Dynamic)->Bool);
 }
 
+enum MouseCursor {
+	Default;
+	Pointer;
+	Text;
+	EastWestResize;
+	NorthSouthResize;
+	NorthEastResize;
+	SouthEastResize;
+	NorthWestResize;
+	SouthWestResize;
+	Grab;
+	Grabbing;
+	NotAllowed;
+	Wait;
+	Crosshair;
+}
+
 @:allow(kha.SystemImpl)
 @:expose
 class Mouse extends Controller {
@@ -247,6 +264,14 @@ class Mouse extends Controller {
 	 * Show the system cursor
 	 */
 	public function showSystemCursor(): Void {
+
+	}
+
+	/**
+	 * Set the native system cursor
+	 * @param cursor The native cursor to show.
+	 */
+	public function setSystemCursor(cursor: MouseCursor): Void {
 
 	}
 


### PR DESCRIPTION
This contains HTML5 code for setting native cursors, and facilitates the setting the native cursors on other backends.