### PR TITLE
Changed `hl_kore_int16array_get` return type to `int` [fixes #1221]

### DIFF
--- a/Backends/KoreHL/KoreC/arrays.cpp
+++ b/Backends/KoreHL/KoreC/arrays.cpp
@@ -53,7 +53,7 @@ extern "C" void hl_kore_int16array_set(vbyte* i16array, int index, short value) 
 	arr[index] = value;
 }
 
-extern "C" short hl_kore_int16array_get(vbyte* i16array, int index) {
+extern "C" int hl_kore_int16array_get(vbyte* i16array, int index) {
 	short* arr = (short*)i16array;
 	return arr[index];
 }


### PR DESCRIPTION
Fixes #1221 and https://github.com/armory3d/armory/issues/1756 .