### PR TITLE
Link MSAADepthBuffer on setDepthStencilFrom

### DIFF
--- a/Backends/HTML5/kha/WebGLImage.hx
+++ b/Backends/HTML5/kha/WebGLImage.hx
@@ -367,6 +367,10 @@ class WebGLImage extends Image {
 		depthTexture = cast(image, WebGLImage).depthTexture;
 		SystemImpl.gl.bindFramebuffer(GL.FRAMEBUFFER, frameBuffer);
 		SystemImpl.gl.framebufferTexture2D(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.TEXTURE_2D, depthTexture, 0);
+		if (samples > 1 && SystemImpl.gl2){
+			MSAADepthBuffer = cast(image, WebGLImage).MSAADepthBuffer;
+			SystemImpl.gl.framebufferRenderbuffer(GL.FRAMEBUFFER, GL.DEPTH_ATTACHMENT, GL.RENDERBUFFER, MSAADepthBuffer);
+		}
 	}
 
 	private static function formatByteSize(format: TextureFormat): Int {


### PR DESCRIPTION
I only link the depth MSAA because the stencil was not attach and I don't have a working example with stencil to test it.
It also asumes image has the same sample number as the source depth image