### PR TITLE
Add Uint8array

### DIFF
--- a/Backends/Android/kha/arrays/Uint8Array.hx
+++ b/Backends/Android/kha/arrays/Uint8Array.hx
@@ -1,0 +1,47 @@
+package kha.arrays;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.IntBuffer;
+
+abstract Uint8Array(IntBuffer) {
+	private static inline var elementSize = 1;
+
+	public inline function new(elements: Int) {
+		this = ByteBuffer.allocateDirect(elements * elementSize).order(ByteOrder.nativeOrder()).asIntBuffer();
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.remaining();
+	}
+
+	public function set(index: Int, value: Int): Int {
+		this.put(index, value);
+		return value;
+	}
+
+	public inline function get(index: Int): Int {
+		return this.get(index);
+	}
+
+	public inline function data(): IntBuffer {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this.get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		this.put(index, value);
+		return value;
+	}
+
+	//public inline function subarray(start: Int, ?end: Int): Uint8Array {
+	//	return cast this.subarray(start, end);
+	//}
+}

--- a/Backends/Empty/kha/arrays/Uint8Array.hx
+++ b/Backends/Empty/kha/arrays/Uint8Array.hx
@@ -1,0 +1,39 @@
+package kha.arrays;
+
+abstract Uint8Array(Dynamic) {
+	public inline function new(elements: Int) {
+		this = null;
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return 0;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return 0;
+	}
+
+	public inline function get(index: Int): Int {
+		return 0;
+	}
+
+	public inline function data(): Dynamic {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return 0;
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return 0;
+	}
+
+	public inline function subarray(start: Int, ?end: Int): Uint8Array {
+		return this;
+	}
+}

--- a/Backends/Flash/kha/arrays/Uint8Array.hx
+++ b/Backends/Flash/kha/arrays/Uint8Array.hx
@@ -1,0 +1,20 @@
+package kha.arrays;
+
+import flash.Vector;
+
+@:forward(length)
+abstract Uint8Array(Vector<Int>) to Vector<Int> {
+	public inline function new(elements: Int) {
+		this = new Vector(elements);
+	}
+
+	@:arrayAccess
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	@:arrayAccess
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+}

--- a/Backends/HTML5-Worker/kha/arrays/Int16Array.hx
+++ b/Backends/HTML5-Worker/kha/arrays/Int16Array.hx
@@ -1,25 +1,25 @@
 package kha.arrays;
 
-abstract Int16Array(js.html.Int16Array) {
+abstract Int16Array(js.lib.Int16Array) {
 	public inline function new(elements: Int) {
-		this = new js.html.Int16Array(elements);
+		this = new js.lib.Int16Array(elements);
 	}
-	
+
 	public var length(get, never): Int;
 
 	inline function get_length(): Int {
 		return this.length;
 	}
-	
+
 	public inline function set(index: Int, value: Int): Int {
 		return this[index] = value;
 	}
-	
+
 	public inline function get(index: Int): Int {
 		return this[index];
 	}
-	
-	public inline function data(): js.html.Int16Array {
+
+	public inline function data(): js.lib.Int16Array {
 		return this;
 	}
 

--- a/Backends/HTML5-Worker/kha/arrays/Uint8Array.hx
+++ b/Backends/HTML5-Worker/kha/arrays/Uint8Array.hx
@@ -1,0 +1,39 @@
+package kha.arrays;
+
+abstract Uint8Array(js.lib.Uint8Array) {
+	public inline function new(elements: Int) {
+		this = new js.lib.Uint8Array(elements);
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.length;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+
+	public inline function data(): js.lib.Uint8Array {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this[index];
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function subarray(start: Int, ?end: Int): Uint8Array {
+		return cast this.subarray(start, end);
+	}
+}

--- a/Backends/HTML5/kha/arrays/Uint8Array.hx
+++ b/Backends/HTML5/kha/arrays/Uint8Array.hx
@@ -1,0 +1,39 @@
+package kha.arrays;
+
+abstract Uint8Array(js.lib.Uint8Array) {
+	public inline function new(elements: Int) {
+		this = new js.lib.Uint8Array(elements);
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.length;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+
+	public inline function data(): js.lib.Uint8Array {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this[index];
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function subarray(start: Int, ?end: Int): Uint8Array {
+		return cast this.subarray(start, end);
+	}
+}

--- a/Backends/Kore/kha/arrays/Uint8Array.hx
+++ b/Backends/Kore/kha/arrays/Uint8Array.hx
@@ -1,0 +1,81 @@
+package kha.arrays;
+
+import cpp.vm.Gc;
+import haxe.ds.Vector;
+
+@:unreflective
+@:structAccess
+@:include("cpp_uint8array.h")
+@:native("uint8array")
+extern class Uint8ArrayData {
+	@:native("uint8array")
+	public static function create(): Uint8ArrayData;
+
+	public var length(get, never): Int;
+
+	@:native("length")
+	function get_length(): Int;
+
+	public function alloc(elements: Int): Void;
+
+	public function free(): Void;
+
+	public function get(index: Int): Int;
+
+	public function set(index: Int, value: Int): Int;
+}
+
+class Uint8ArrayPrivate {
+	public var self: Uint8ArrayData;
+
+	public inline function new(elements: Int = 0) {
+		self = Uint8ArrayData.create();
+		if (elements > 0) {
+			self.alloc(elements);
+		}
+
+		Gc.setFinalizer(this, cpp.Function.fromStaticFunction(finalize));
+	}
+
+	@:void static function finalize(arr: Uint8ArrayPrivate): Void {
+		arr.self.free();
+	}
+}
+
+abstract Uint8Array(Uint8ArrayPrivate) {
+	public inline function new(elements: Int = 0) {
+		this = new Uint8ArrayPrivate(elements);
+	}
+
+	public inline function free(): Void {
+		this.self.free();
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.self.length;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return this.self.set(index, value);
+	}
+
+	public inline function get(index: Int): Int {
+		return this.self.get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this.self.get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this.self.set(index, value);
+	}
+
+	//public inline function subarray(start: Int, ?end: Int): Uint8Array {
+	//	return cast this.self.subarray(start, end);
+	//}
+}

--- a/Backends/KoreHL/KoreC/arrays.cpp
+++ b/Backends/KoreHL/KoreC/arrays.cpp
@@ -76,3 +76,22 @@ extern "C" int hl_kore_int32array_get(vbyte* i32array, int index) {
 	int* arr = (int*)i32array;
 	return arr[index];
 }
+
+extern "C" vbyte *hl_kore_uint8array_alloc(int elements) {
+	unsigned char *data = new unsigned char[elements];
+	return (vbyte*)data;
+}
+
+extern "C" void hl_kore_uint8array_free(vbyte *u8array) {
+	delete[] u8array;
+}
+
+extern "C" void hl_kore_uint8array_set(vbyte *u8array, int index, unsigned char value) {
+	unsigned char *arr = (unsigned char *)u8array;
+	arr[index] = value;
+}
+
+extern "C" unsigned char hl_kore_uint8array_get(vbyte *u8array, int index) {
+	unsigned char *arr = (unsigned char *)u8array;
+	return arr[index];
+}

--- a/Backends/KoreHL/kha/arrays/Uint8Array.hx
+++ b/Backends/KoreHL/kha/arrays/Uint8Array.hx
@@ -1,0 +1,60 @@
+package kha.arrays;
+
+class Uint8ArrayPrivate {
+	// Has to be wrapped in class..
+	public var self: Pointer;
+	public var length: Int;
+	public inline function new() {}
+}
+
+abstract Uint8Array(Uint8ArrayPrivate) {
+
+	public inline function new(elements: Int = 0) {
+		this = new Uint8ArrayPrivate();
+		this.length = elements;
+		if (elements > 0) this.self = kore_uint8array_alloc(elements);
+	}
+
+	public inline function free(): Void {
+		kore_uint8array_free(this.self);
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.length;
+	}
+
+	public inline function getData():Pointer {
+		return this.self;
+	}
+
+	public inline function setData(ar:Pointer, elements: Int): Void {
+		this.self = ar;
+		this.length = elements;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		kore_uint8array_set(this.self, index, value);
+		return value;
+	}
+
+	public inline function get(index: Int): Int {
+		return kore_uint8array_get(this.self, index);
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return get(index);
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return set(index, value);
+	}
+
+	@:hlNative("std", "kore_uint8array_alloc") static function kore_uint8array_alloc(elements: Int): Pointer { return null; }
+	@:hlNative("std", "kore_uint8array_free") static function kore_uint8array_free(u8array: Pointer): Void { }
+	@:hlNative("std", "kore_uint8array_set") static function kore_uint8array_set(u8array: Pointer, index: Int, value: Int): Void { }
+	@:hlNative("std", "kore_uint8array_get") static function kore_uint8array_get(u8array: Pointer, index: Int): Int { return 0; }
+}

--- a/Backends/Krom/kha/arrays/Uint8Array.hx
+++ b/Backends/Krom/kha/arrays/Uint8Array.hx
@@ -1,0 +1,39 @@
+package kha.arrays;
+
+abstract Uint8Array(js.lib.Uint8Array) {
+	public inline function new(elements: Int) {
+		this = new js.lib.Uint8Array(elements);
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.length;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+
+	public inline function data(): js.lib.Uint8Array {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this[index];
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function subarray(start: Int, ?end: Int): Uint8Array {
+		return cast this.subarray(start, end);
+	}
+}

--- a/Backends/Node/kha/arrays/Uint8Array.hx
+++ b/Backends/Node/kha/arrays/Uint8Array.hx
@@ -1,0 +1,39 @@
+package kha.arrays;
+
+abstract Uint8Array(js.lib.Uint8Array) {
+	public inline function new(elements: Int) {
+		this = new js.lib.Uint8Array(elements);
+	}
+
+	public var length(get, never): Int;
+
+	inline function get_length(): Int {
+		return this.length;
+	}
+
+	public inline function set(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function get(index: Int): Int {
+		return this[index];
+	}
+
+	public inline function data(): js.lib.Uint8Array {
+		return this;
+	}
+
+	@:arrayAccess
+	public inline function arrayRead(index: Int): Int {
+		return this[index];
+	}
+
+	@:arrayAccess
+	public inline function arrayWrite(index: Int, value: Int): Int {
+		return this[index] = value;
+	}
+
+	public inline function subarray(start: Int, ?end: Int): Uint8Array {
+		return cast this.subarray(start, end);
+	}
+}


### PR DESCRIPTION
Requires https://github.com/Kode/khacpp/pull/11

On the HL target I've used `unsigned char` instead of `uint8_t` just like the other array types use `short` etc. Is there a reason for that? The byte sizes in the current implementations don't seem to be guaranteed because of that.

I could not test it on Android and Flash but it closely follows the current implementations of the other array types.