### PR TITLE
[HTML5] Attempt to estimate device refresh rate at startup

### DIFF
--- a/Backends/HTML5/kha/Display.hx
+++ b/Backends/HTML5/kha/Display.hx
@@ -62,7 +62,7 @@ class Display {
 	public var frequency(get, never): Int;
 
 	function get_frequency(): Int {
-		return 60;
+		return SystemImpl.estimatedRefreshRate;
 	}
 
 	public var pixelsPerInch(get, never): Int;

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -214,7 +214,7 @@ class SystemImpl {
 	private static var lastFirstTouchX: Int = 0;
 	private static var lastFirstTouchY: Int = 0;
 
-	public static function init2(defaultWidth: Int, defaultHeight: Int, ?backbufferFormat: TextureFormat) {
+	private static function init2(defaultWidth: Int, defaultHeight: Int, ?backbufferFormat: TextureFormat) {
 		#if !kha_no_keyboard
 		keyboard = new Keyboard();
 		#end
@@ -567,9 +567,11 @@ class SystemImpl {
 		function detectRefreshRate(timestamp) {
 			var window: Dynamic = Browser.window;
 
-			if (initialTimestamp == 0) initialTimestamp = timestamp;
+			if (initialTimestamp == 0) {
+				initialTimestamp = timestamp;
+			}
 			var timeDifferential = (timestamp - prevTimestamp) - initialTimestamp;
-			prevTimestamp = (timestamp - initialTimestamp);
+			prevTimestamp = timestamp - initialTimestamp;
 			
 			if (timeDifferential != 0) {
 				timeDiffs.push(timeDifferential);

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -55,6 +55,7 @@ class SystemImpl {
 	private static var ie: Bool = false;
 	public static var insideInputEvent: Bool = false;
 	static var window: Window;
+	public static var estimatedRefreshRate: Int = 60;
 
 	private static function errorHandler(message: String, source: String, lineno: Int, colno: Int, error: Dynamic) {
 		Browser.console.error("Error: " + message);
@@ -99,7 +100,7 @@ class SystemImpl {
 
 	private static function initSecondStep(callback: Window -> Void): Void {
 		init2(options.window.width, options.window.height);
-		callback(window);
+		initAnimate(callback);
 	}
 
 	public static function initSensor(): Void {
@@ -424,7 +425,59 @@ class SystemImpl {
 
 		kha.vr.VrInterface.instance = new VrInterface();
 
-		Scheduler.start();
+		// Autofocus
+		canvas.focus();
+
+		#if kha_disable_context_menu
+		canvas.oncontextmenu = function (event: Dynamic) {
+			event.stopPropagation();
+			event.preventDefault();
+		}
+		#end
+
+		canvas.onmousedown = mouseDown;
+		canvas.onmousemove = mouseMove;
+		if(keyboard != null) {
+			canvas.onkeydown = keyDown;
+			canvas.onkeyup = keyUp;
+			canvas.onkeypress = keyPress;
+		}
+		canvas.onblur = onBlur;
+		canvas.onfocus = onFocus;
+		untyped (canvas.onmousewheel = canvas.onwheel = mouseWheel);
+		canvas.onmouseleave = mouseLeave;
+
+		canvas.addEventListener("wheel mousewheel", mouseWheel, false);
+		canvas.addEventListener("touchstart", touchDown, false);
+		canvas.addEventListener("touchend", touchUp, false);
+		canvas.addEventListener("touchmove", touchMove, false);
+		canvas.addEventListener("touchcancel", touchCancel, false);
+
+#if kha_debug_html5
+		Browser.document.addEventListener('dragover', function( event ) {
+			event.preventDefault();
+		});
+
+		Browser.document.addEventListener('drop', function( event: js.html.DragEvent ) {
+			event.preventDefault();
+
+			if (event.dataTransfer != null && event.dataTransfer.files != null) {
+				for (file in event.dataTransfer.files) {
+					// https://developer.mozilla.org/en-US/docs/Web/API/File
+					//  - use mozFullPath or webkitRelativePath?
+					System.dropFiles(Syntax.code('file.path'));
+				}
+			}
+		});
+#end
+
+		Browser.window.addEventListener("unload", function () {
+			System.shutdown();
+		});
+	}
+
+	private static function initAnimate(callback: Window -> Void) {
+		var canvas: CanvasElement = getCanvasElement();
 
 		var window: Dynamic = Browser.window;
 		var requestAnimationFrame = window.requestAnimationFrame;
@@ -476,58 +529,94 @@ class SystemImpl {
 			}
 		}
 
-		if (requestAnimationFrame == null) window.setTimeout(animate, 1000.0 / 60.0);
-		else requestAnimationFrame(animate);
+		var initialTimestamp: Int = 0;
+		var prevTimestamp: Int = 0;
+		var currentSamples: Int = 0;
+		var timeDiffs: Array<Int> = [];
 
-		// Autofocus
-		canvas.focus();
+		var SAMPLE_COUNT: Int = 90;
+		var MEAN_TRUNCATION_CUTOFF: Float = 1 / 3;
 
-		#if kha_disable_context_menu
-		canvas.oncontextmenu = function (event: Dynamic) {
-			event.stopPropagation();
-			event.preventDefault();
-		}
-		#end
+		function roundToKnownRefreshRate(hz:Int): Int {
+			var hz30 = {low: 27, high: 33, target: 30};
+			var hz60 = {low: 57, high: 63, target: 60};
+			var hz75 = {low: 72, high: 78, target: 75};
+			var hz90 = {low: 87, high: 93, target: 90};
+			var hz120 = {low: 117, high: 123, target: 120};
+			var hz144 = {low: 141, high: 147, target: 144};
+			var hz240 = {low: 237, high: 243, target: 240};
+			var hz340 = {low: 337, high: 343, target: 340};
+			var hz360 = {low: 357, high: 363, target: 360};
 
-		canvas.onmousedown = mouseDown;
-		canvas.onmousemove = mouseMove;
-		if(keyboard != null) {
-			canvas.onkeydown = keyDown;
-			canvas.onkeyup = keyUp;
-			canvas.onkeypress = keyPress;
-		}
-		canvas.onblur = onBlur;
-		canvas.onfocus = onFocus;
-		untyped (canvas.onmousewheel = canvas.onwheel = mouseWheel);
-		canvas.onmouseleave = mouseLeave;
+			var rates = [hz30, hz60, hz75, hz90, hz120, hz144, hz240, hz340, hz360];
 
-		canvas.addEventListener("wheel mousewheel", mouseWheel, false);
-		canvas.addEventListener("touchstart", touchDown, false);
-		canvas.addEventListener("touchend", touchUp, false);
-		canvas.addEventListener("touchmove", touchMove, false);
-		canvas.addEventListener("touchcancel", touchCancel, false);
-
-#if kha_debug_html5
-		Browser.document.addEventListener('dragover', function( event ) {
-			event.preventDefault();
-		});
-
-		Browser.document.addEventListener('drop', function( event: js.html.DragEvent ) {
-			event.preventDefault();
-
-			if (event.dataTransfer != null && event.dataTransfer.files != null) {
-				for (file in event.dataTransfer.files) {
-					// https://developer.mozilla.org/en-US/docs/Web/API/File
-					//  - use mozFullPath or webkitRelativePath?
-					System.dropFiles(Syntax.code('file.path'));
+			var nearestHz = hz;
+			for (rate in rates) {
+				if (hz >= rate.low && hz <= rate.high) {
+					nearestHz = rate.target;
 				}
 			}
-		});
-#end
 
-		Browser.window.addEventListener("unload", function () {
-			System.shutdown();
-		});
+			return nearestHz;
+		}
+
+		//HTML5 has no real way to query the actual monitor refresh rate
+		//The only thing that can be done is attempt to measure the interval between requestAnimationFrame calls
+		//Without requestAnimationFrame we're out of luck
+		//We try and make a best guess while nothing intensive is happening
+		function detectRefreshRate(timestamp) {
+			var window: Dynamic = Browser.window;
+
+			if (initialTimestamp == 0) initialTimestamp = timestamp;
+			var timeDifferential = (timestamp - prevTimestamp) - initialTimestamp;
+			prevTimestamp = (timestamp - initialTimestamp);
+			
+			if (timeDifferential != 0) {
+				timeDiffs.push(timeDifferential);
+			}
+
+			if (currentSamples < SAMPLE_COUNT) {
+				currentSamples++;
+
+				if (requestAnimationFrame == null) window.setTimeout(detectRefreshRate, 1000.0 / 60.0);
+				else requestAnimationFrame(detectRefreshRate);
+			}
+			else {
+				//Remove extreme frametime values before averaging
+				{
+					haxe.ds.ArraySort.sort(timeDiffs, (a, b) -> {
+						a - b;
+					});
+					
+					var truncatedTimeDiffs: Array<Int> = [];
+					var cutoff = Math.round(timeDiffs.length * MEAN_TRUNCATION_CUTOFF);
+					for (i in cutoff...timeDiffs.length - cutoff) {
+						truncatedTimeDiffs.push(timeDiffs[i]);
+					}
+
+					var total = 0;
+					for (time in truncatedTimeDiffs) {
+						total += time;
+					}
+
+					var avg = total / truncatedTimeDiffs.length;
+					//We may have an accurate frequency, but it might be possible to be off the actual refresh rate by a few hz
+					//Manually round to common refresh rates as well, just for security's sake
+					estimatedRefreshRate = roundToKnownRefreshRate(Math.round(1000 / avg));
+				}
+
+				Scheduler.start();
+
+				if (requestAnimationFrame == null) window.setTimeout(animate, 1000.0 / 60.0);
+				else requestAnimationFrame(animate);
+
+				callback(SystemImpl.window);
+			}
+		}
+
+		//Run through refresh rate detection first and then start animating
+		if (requestAnimationFrame == null) window.setTimeout(detectRefreshRate, 1000.0 / 60.0);
+		else requestAnimationFrame(detectRefreshRate);
 	}
 
 	public static function lockMouse(): Void {


### PR DESCRIPTION
I'm nooby so maybe this isn't a viable approach (or perhaps it's too naive), but I figured I would try adding this feature rather than not try. Sorry if it doesn't work out.

HTML5 does not have a way to just get the device's refresh rate through some query. It can only be estimated at this time.

This code briefly collects the frametime results for successive requestAnimationFrame calls, and tries its best to make an estimate of the monitor's refresh rate before animate() begins and before the System.start callback executes. This test is run at this point so that (hopefully) nothing else important or computation intensive is happening and we get mostly accurate results.

# Caveats:
* Introduces a variable amount of startup delay, dependent on the current refresh rate. I chose 90 frametime samples as a compromise between accuracy and duration of the test since it seemed reasonable (I considered 3 seconds on 30hz as the worst case scenario, 1.5 seconds on 60hz seems passable, etc). I know this isn't great but I don't see a way around it.
* Haven't tested it on toaster ovens. RequestAnimationFrame results there may be more prone to variance caused by computations in the background, which might cause inaccurate results. This may be an issue just generally speaking, but I haven't yet gotten an incorrect refresh rate from my limited tests, however the system I test on is pretty decent.
* Only set at startup once as of now. The refresh rate might possibly change, but I don't think there's a reliable/simple way to know if it actually changed or if something really intensive is occurring due to user code. 