### PR TITLE
Fixes Kore `VertexBuffer.lockInt16` not updating `lastLockCount`

### DIFF
--- a/Backends/Kore/kha/graphics4/VertexBuffer.hx
+++ b/Backends/Kore/kha/graphics4/VertexBuffer.hx
@@ -90,6 +90,7 @@ class VertexBuffer {
 	public function lockInt16(?start: Int, ?count: Int): Int16Array {
 		if (start == null) start = 0;
 		if (count == null) count = this.count();
+		lastLockCount = count;
 		if (dataInt16 == null) dataInt16 = new Int16Array();
 		return lockInt16Private(start, count);
 	}


### PR DESCRIPTION
Fixes #1275 .