### PR TITLE
Update Random with faster implementation + cleanup

### DIFF
--- a/Sources/kha/math/Random.hx
+++ b/Sources/kha/math/Random.hx
@@ -1,83 +1,81 @@
 package kha.math;
 
-//
-// Random number generator
-//
-// Please use this one instead of the native Haxe one to
-// keep consistency between different platforms.
-//
+// Small Fast Counter 32 (sfc32) PRNG implementation
+// sfc32 is public domain: http://pracrand.sourceforge.net/license.txt
+// Implementation derived from: https://github.com/bryc/code/blob/master/jshash/PRNGs.md
+// which is also public domain
 
-// Mersenne twister
+/**
+Random number generator
+
+Please use this one instead of the native Haxe one to
+keep consistency between different platforms.
+**/
 class Random {
+	var a:Int;
+	var b:Int;
+	var c:Int;
+	var d:Int;
+
 	public function new(seed: Int): Void {
-		MT = new Array<Int>();
-		MT[624 - 1] = 0;
-		MT[0] = seed;
-		for (i in 1...624) MT[i] = 0x6c078965 * (MT[i - 1] ^ (MT[i - 1] >> 30)) + i;
+		d = seed;
+		a = 0x36aef51a;
+		b = 0x21d4b3eb;
+		c = 0xf2517abf;
+		//Immediately skip a few possibly poor results the easy way
+		for (i in 0...15) {
+			this.Get();
+		}
 	}
-	
+
 	public function Get(): Int {
-		if (index == 0) GenerateNumbers();
-
-		var y: Int = MT[index];
-		y = y ^ (y >> 11);
-		y = y ^ ((y << 7) & (0x9d2c5680));
-		y = y ^ ((y << 15) & (0xefc60000));
-		y = y ^ (y >> 18);
-
-		index = (index + 1) % 624;
-		return y;
+		var t = (a + b | 0) + d | 0;
+		d = d + 1 | 0;
+		a = b ^ b >>> 9;
+		b = c + (c << 3) | 0;
+		c = c << 21 | c >>> 11;
+		c = c + t | 0;
+		return t & 0x7fffffff;
 	}
-	
+
 	public function GetFloat(): Float {
-		return Get() / 0x7ffffffe;
+		return Get() / 0x7fffffff;
 	}
-	
+
 	public function GetUpTo(max: Int): Int {
 		return Get() % (max + 1);
 	}
-	
+
 	public function GetIn(min: Int, max: Int): Int {
 		return Get() % (max + 1 - min) + min;
 	}
-	
+
 	public function GetFloatIn(min: Float, max: Float): Float {
 		return min + GetFloat() * (max - min);
 	}
-	
-	private var MT: Array<Int>;
-	private var index: Int = 0;
-	
-	private function GenerateNumbers(): Void {
-		for (i in 0...624) {
-			var y: Int = (MT[i] & 1) + (MT[(i + 1) % 624]) & 0x7fffffff;
-			MT[i] = MT[(i + 397) % 624] ^ (y >> 1);
-			if ((y % 2) != 0) MT[i] = MT[i] ^ 0x9908b0df;
-		}
-	}
-	
+
 	public static var Default: Random;
-	
+
 	public static function init(seed: Int): Void {
 		Default = new Random(seed);
 	}
-	
+
 	public static function get(): Int {
 		return Default.Get();
 	}
-	
+
 	public static function getFloat(): Float {
 		return Default.GetFloat();
 	}
-	
+
 	public static function getUpTo(max: Int): Int {
 		return Default.GetUpTo(max);
 	}
-	
+
 	public static function getIn(min: Int, max: Int): Int {
 		return Default.GetIn(min, max);
 	}
-	
+
 	public static function getFloatIn(min: Float, max: Float): Float {
 		return min + Default.GetFloat() * (max - min);
 	}


### PR DESCRIPTION
This replaces the current Mersenne Twister with a new pseudorandom number generator known as Small Fast Counter 32. SFC32 seemed to be the best all around PRNG that I could find that worked well across the targets I can test on (HTML5 Electron and Firefox, Windows...yeah still limited here, sorry). 

SFC32 was always faster or generated more numbers in a shorter time period than the current implementation in a few various test cases that I tried out which are all obviously contrived and more about trying to identify a noticeable difference rather than trying to extract an exact value. Those cases were the following:

1. Out of a list of 50k entities, select an entity and create a new Vector2 with a new random X and new random Y float position for it
2. Generate an array of 50k ints
3. Generate as many ints as possible in 10 seconds

For case 1 and 2, this was done over a period of 10 seconds 60 times per second. This was using a timetask, however these tests weren't stressful enough to trigger a slowdown which would mess with the final timings (I made sure to check for that). For case 3, I basically just ended up getting bottlenecked somewhere across all targets for both implementations. Dunno why, don't really care because SFC32 still wins.

For every case, the values are rough and eyeballed, but still show a trend. They were each also run once before hand before measurements were taken.

Test Case 1 (Vectors): Cumulative time spent
| Impl | Windows | Electron | Firefox |
|---|---|---|---|
| SFC32 | 0.382s | 0.997s | 0.999s |
| MT | 0.952s | 1.396s | 1.757s | 

Test Case 2 (Int Array): Cumulative time spent
| Impl | Windows | Electron | Firefox |
|---|---|---|---|
| SFC32 | 0.126s | 0.156s | 0.485s | 
| MT | 0.427s | 0.575s | 0.911s | 

Test Case 3 (Shit ton of ints over 10 seconds): Total count
| Impl | Windows | Electron | Firefox |
|---|---|---|---|
| SFC32 | 956000000? | 1943000000? | 1070000000?
| MT |      490000000? |      630000000? | 540000000?

SFC32 also comes with some bonuses like being more cryptographically secure than the Mersenne Twister according to some smart people who aren't me, and it is a public domain algorithm. You can verify that here: http://pracrand.sourceforge.net/

The implementation I used was derived from here, and slightly modified: https://github.com/bryc/code/blob/master/jshash/PRNGs.md#sfc32. Removing a few of the bitwise ORs resulted in no change to the output but slightly increased speed. The rest of them needed to remain, as removing them resulted in a slight speed decrease for the HTML5 targets.

Hopefully, this performance holds up across all targets that I am unable to test.

Thanks for reading my blog, have a nice day.