### PR TITLE
[Kinc-hxcpp] Avoid `Image.unload` failed assertion through GC finalizer

### DIFF
--- a/Backends/Kinc-hxcpp/kha/Image.hx
+++ b/Backends/Kinc-hxcpp/kha/Image.hx
@@ -170,9 +170,12 @@ class Image implements Canvas implements Resource {
 	")
 	function nullify() {}
 
-	@:void static function finalize(image: Image): Void {
-		image.unload();
-	}
+	@:functionCode("
+		if (image->imageType != KhaImageTypeNone) {
+			image->unload();
+		}
+	")
+	@:void static function finalize(image: Image): Void {}
 
 	static function getRenderTargetFormat(format: TextureFormat): Int {
 		switch (format) {


### PR DESCRIPTION
Using Kinc hxcpp backend, if you unload a Kha image calling it's `unload` method and then you assign another object to the same reference [1], a few seconds later the GC will call `finalize`, calling `unload` again, which would trigger this assertion → https://github.com/Kode/Kha/blob/master/Backends/Kinc-hxcpp/kha/Image.hx#L432

I think this happens since this commit → https://github.com/Kode/Kha/commit/a354a90e7b5399a05fe9ba688651e14a92ba8945#diff-6d8eac6ed9e4907561b445a6ec521a8eefbe4801487048aeb552ac3443ce9085R406

[1] As done for example here → https://github.com/armory3d/zui/blob/master/Sources/zui/Zui.hx#L1655-L1658