### PR TITLE
fix blurry rendering when the embedding html page contains a viewport meta tag

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -520,14 +520,13 @@ class SystemImpl {
 			Scheduler.executeFrame();
 
 			if (canvas.getContext != null) {
-				// Lookup the size the browser is displaying the canvas.
-				// TODO deal with window.devicePixelRatio ?
-				var displayWidth = canvas.clientWidth;
-				var displayHeight = canvas.clientHeight;
+				// clientWidth/Height is in downscaled "css pixels" when a <meta viewport="" /> is set in the html file
+				var displayWidth = canvas.clientWidth * Std.int(js.Browser.window.devicePixelRatio);
+				var displayHeight = canvas.clientHeight * Std.int(js.Browser.window.devicePixelRatio);
 
-				// Check if the canvas is not the same size.
+				// Check if the canvas rendering buffer is not the same size.
 				if (canvas.width != displayWidth || canvas.height != displayHeight) {
-					// Make the canvas the same size
+					// Make the canvas rendering buffer the same size
 					canvas.width = displayWidth;
 					canvas.height = displayHeight;
 				}

--- a/Backends/HTML5/kha/Window.hx
+++ b/Backends/HTML5/kha/Window.hx
@@ -88,7 +88,7 @@ class Window {
 	public var width(get, set): Int;
 
 	function get_width(): Int {
-		return canvas.clientWidth == 0 ? defaultWidth : canvas.clientWidth;
+		return canvas.width;
 	}
 
 	function set_width(value: Int): Int {
@@ -98,7 +98,7 @@ class Window {
 	public var height(get, set): Int;
 
 	function get_height(): Int {
-		return canvas.clientHeight == 0 ? defaultHeight : canvas.clientHeight;
+		return canvas.height;
 	}
 
 	function set_height(value: Int): Int {


### PR DESCRIPTION
Add `<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, minimal-ui">` in your html page, and you'll notice that rendering is blurry all of a sudden. This is due to the fact, that the rendering buffer of the canvas isn't the actual hardware pixel size anymore, but shrunk down by `window.devicePixelRatio`.