### PR TITLE
Mark input listeners as nullable

### DIFF
--- a/Sources/kha/input/Gamepad.hx
+++ b/Sources/kha/input/Gamepad.hx
@@ -11,28 +11,28 @@ class Gamepad {
 		return instances[index];
 	}
 
-	public static function notifyOnConnect(connectListener: Int->Void, disconnectListener: Int->Void): Void {
+	public static function notifyOnConnect(?connectListener: Int->Void, ?disconnectListener: Int->Void): Void {
 		if (connectListener != null)
 			connectListeners.push(connectListener);
 		if (disconnectListener != null)
 			disconnectListeners.push(disconnectListener);
 	}
 
-	public static function removeConnect(connectListener: Int->Void, disconnectListener: Int->Void): Void {
+	public static function removeConnect(?connectListener: Int->Void, ?disconnectListener: Int->Void): Void {
 		if (connectListener != null)
 			connectListeners.remove(connectListener);
 		if (disconnectListener != null)
 			disconnectListeners.remove(disconnectListener);
 	}
 
-	public function notify(axisListener: Int->Float->Void, buttonListener: Int->Float->Void): Void {
+	public function notify(?axisListener: Int->Float->Void, ?buttonListener: Int->Float->Void): Void {
 		if (axisListener != null)
 			axisListeners.push(axisListener);
 		if (buttonListener != null)
 			buttonListeners.push(buttonListener);
 	}
 
-	public function remove(axisListener: Int->Float->Void, buttonListener: Int->Float->Void): Void {
+	public function remove(?axisListener: Int->Float->Void, ?buttonListener: Int->Float->Void): Void {
 		if (axisListener != null)
 			axisListeners.remove(axisListener);
 		if (buttonListener != null)

--- a/Sources/kha/input/Keyboard.hx
+++ b/Sources/kha/input/Keyboard.hx
@@ -37,11 +37,11 @@ class Keyboard extends Controller {
 
 	/**
 	 * Creates event handlers from passed functions.
-	 * @param downListener function with `key:KeyCode` argument, fired when a key is pressed down.
-	 * @param upListener function with `key:KeyCode` argument, fired when a key is released.
+	 * @param downListener (optional) function with `key:KeyCode` argument, fired when a key is pressed down.
+	 * @param upListener (optional) function with `key:KeyCode` argument, fired when a key is released.
 	 * @param pressListener (optional) function with `char:String` argument, fired when a key that produces a character value is pressed down.
 	 */
-	public function notify(downListener: (key: KeyCode) -> Void, upListener: (key: KeyCode) -> Void, pressListener: (char: String) -> Void = null): Void {
+	public function notify(?downListener: (key: KeyCode) -> Void, ?upListener: (key: KeyCode) -> Void, ?pressListener: (char: String) -> Void = null): Void {
 		if (downListener != null)
 			downListeners.push(downListener);
 		if (upListener != null)
@@ -53,7 +53,7 @@ class Keyboard extends Controller {
 	/**
 	 * Removes event handlers from the passed functions that were passed to `notify` function.
 	 */
-	public function remove(downListener: (key: KeyCode) -> Void, upListener: (key: KeyCode) -> Void, pressListener: (char: String) -> Void): Void {
+	public function remove(?downListener: (key: KeyCode) -> Void, ?upListener: (key: KeyCode) -> Void, ?pressListener: (char: String) -> Void): Void {
 		if (downListener != null)
 			downListeners.remove(downListener);
 		if (upListener != null)

--- a/Sources/kha/input/Mouse.hx
+++ b/Sources/kha/input/Mouse.hx
@@ -53,30 +53,30 @@ class Mouse extends Controller {
 
 	/**
 	 * Creates event handlers from passed functions.
-	 * @param downListener function with `button:Int`,`x:Int`,`y:Int` arguments, fired when a mouse is pressed down. `button:Int` is `0` for left button, `1` for right and `2` for middle.
-	 * @param upListener function with `button:Int`,`x:Int`,`y:Int` arguments, fired when a mouse is released.
-	 * @param moveListener function with `x:Int`,`y:Int`,`moveX:Int`,`moveY:Int` arguments, fired when a mouse is moved. `moveX`/`moveY` is the difference between the current coordinates and the last position of the mouse.
-	 * @param wheelListener function with `delta:Int` argument, fired when the wheel rotates. It can have a value of `1` or `-1` depending on the rotation.
+	 * @param downListener (optional) function with `button:Int`,`x:Int`,`y:Int` arguments, fired when a mouse is pressed down. `button:Int` is `0` for left button, `1` for right and `2` for middle.
+	 * @param upListener (optional) function with `button:Int`,`x:Int`,`y:Int` arguments, fired when a mouse is released.
+	 * @param moveListener (optional) function with `x:Int`,`y:Int`,`moveX:Int`,`moveY:Int` arguments, fired when a mouse is moved. `moveX`/`moveY` is the difference between the current coordinates and the last position of the mouse.
+	 * @param wheelListener (optional) function with `delta:Int` argument, fired when the wheel rotates. It can have a value of `1` or `-1` depending on the rotation.
 	 * @param leaveListener (optional) function without` arguments, when fired mouse leave canvas.
 	 */
-	public function notify(downListener: (button: Int, x: Int, y: Int) -> Void, upListener: (button: Int, x: Int, y: Int) -> Void,
-			moveListener: (x: Int, y: Int, moveX: Int, moveY: Int) -> Void, wheelListener: (delta: Int) -> Void, leaveListener: () -> Void = null): Void {
+	public function notify(?downListener: (button: Int, x: Int, y: Int) -> Void, ?upListener: (button: Int, x: Int, y: Int) -> Void,
+			?moveListener: (x: Int, y: Int, moveX: Int, moveY: Int) -> Void, ?wheelListener: (delta: Int) -> Void, ?leaveListener: () -> Void = null): Void {
 		notifyWindowed(0, downListener, upListener, moveListener, wheelListener, leaveListener);
 	}
 
 	/**
 	 * Removes event handlers from the passed functions that were passed to `notify` function.
 	 */
-	public function remove(downListener: (button: Int, x: Int, y: Int) -> Void, upListener: (button: Int, x: Int, y: Int) -> Void,
-			moveListener: (x: Int, y: Int, moveX: Int, moveY: Int) -> Void, wheelListener: (delta: Int) -> Void, leaveListener: () -> Void = null): Void {
+	public function remove(?downListener: (button: Int, x: Int, y: Int) -> Void, ?upListener: (button: Int, x: Int, y: Int) -> Void,
+			?moveListener: (x: Int, y: Int, moveX: Int, moveY: Int) -> Void, ?wheelListener: (delta: Int) -> Void, ?leaveListener: () -> Void = null): Void {
 		removeWindowed(0, downListener, upListener, moveListener, wheelListener, leaveListener);
 	}
 
 	/**
 	 * Creates event handlers from passed functions like `notify` function, but only for window with `windowId:Int` id argument. The windows are not supported by all the targets.
 	 */
-	public function notifyWindowed(windowId: Int, downListener: Int->Int->Int->Void, upListener: Int->Int->Int->Void, moveListener: Int->Int->Int->Int->Void,
-			wheelListener: Int->Void, leaveListener: Void->Void = null): Void {
+	public function notifyWindowed(windowId: Int, ?downListener: Int->Int->Int->Void, ?upListener: Int->Int->Int->Void, ?moveListener: Int->Int->Int->Int->Void,
+			?wheelListener: Int->Void, ?leaveListener: Void->Void = null): Void {
 		if (downListener != null) {
 			if (windowDownListeners == null) {
 				windowDownListeners = new Array();
@@ -141,8 +141,8 @@ class Mouse extends Controller {
 	/**
 	 * Removes event handlers for `windowId:Int` from the passed functions that were passed to `notifyWindowed` function.
 	 */
-	public function removeWindowed(windowId: Int, downListener: Int->Int->Int->Void, upListener: Int->Int->Int->Void, moveListener: Int->Int->Int->Int->Void,
-			wheelListener: Int->Void, leaveListener: Void->Void = null): Void {
+	public function removeWindowed(windowId: Int, ?downListener: Int->Int->Int->Void, ?upListener: Int->Int->Int->Void, ?moveListener: Int->Int->Int->Int->Void,
+			?wheelListener: Int->Void, ?leaveListener: Void->Void = null): Void {
 		if (downListener != null) {
 			if (windowDownListeners != null) {
 				if (windowId < windowDownListeners.length) {

--- a/Sources/kha/input/Pen.hx
+++ b/Sources/kha/input/Pen.hx
@@ -12,26 +12,26 @@ class Pen {
 
 	/**
 	 * Creates event handlers from passed functions.
-	 * @param downListener function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is pressed down. `pressure` is force of pressure on the screen in the range from `0` to `1`.
-	 * @param upListener function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is released.
-	 * @param moveListener function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is moved.
+	 * @param downListener (optional) function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is pressed down. `pressure` is force of pressure on the screen in the range from `0` to `1`.
+	 * @param upListener (optional) function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is released.
+	 * @param moveListener (optional) function with `x:Int`,`y:Int`,`pressure:Float` arguments, fired when a pen is moved.
 	 */
-	public function notify(downListener: Int->Int->Float->Void, upListener: Int->Int->Float->Void, moveListener: Int->Int->Float->Void): Void {
+	public function notify(?downListener: Int->Int->Float->Void, ?upListener: Int->Int->Float->Void, ?moveListener: Int->Int->Float->Void): Void {
 		notifyWindowed(0, downListener, upListener, moveListener);
 	}
 
 	/**
 	 * Removes event handlers from the passed functions that were passed to `notify` function.
 	 */
-	public function remove(downListener: Int->Int->Float->Void, upListener: Int->Int->Float->Void, moveListener: Int->Int->Float->Void): Void {
+	public function remove(?downListener: Int->Int->Float->Void, ?upListener: Int->Int->Float->Void, ?moveListener: Int->Int->Float->Void): Void {
 		removeWindowed(0, downListener, upListener, moveListener);
 	}
 
 	/**
 	 * Creates event handlers from passed functions like `notify` function, but only for window with `windowId:Int` id argument. The windows are not supported by all the targets.
 	 */
-	public function notifyWindowed(windowId: Int, downListener: Int->Int->Float->Void, upListener: Int->Int->Float->Void,
-			moveListener: Int->Int->Float->Void): Void {
+	public function notifyWindowed(windowId: Int, ?downListener: Int->Int->Float->Void, ?upListener: Int->Int->Float->Void,
+			?moveListener: Int->Int->Float->Void): Void {
 		if (downListener != null) {
 			if (windowDownListeners == null) {
 				windowDownListeners = [];
@@ -66,8 +66,8 @@ class Pen {
 	/**
 	 * Removes event handlers for `windowId:Int` from the passed functions that were passed to `notifyWindowed` function.
 	 */
-	public function removeWindowed(windowId: Int, downListener: Int->Int->Float->Void, upListener: Int->Int->Float->Void,
-			moveListener: Int->Int->Float->Void): Void {
+	public function removeWindowed(windowId: Int, ?downListener: Int->Int->Float->Void, ?upListener: Int->Int->Float->Void,
+			?moveListener: Int->Int->Float->Void): Void {
 		if (downListener != null && windowDownListeners != null) {
 			if (windowId < windowDownListeners.length) {
 				windowDownListeners[windowId].remove(downListener);

--- a/Sources/kha/input/Surface.hx
+++ b/Sources/kha/input/Surface.hx
@@ -35,12 +35,12 @@ class Surface {
 
 	/**
 	 * Creates event handlers from passed functions.
-	 * @param touchStartListener function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is pressed down. The finger `id` goes from 0 increasing by one. When the finger releases the screen, the old `id` is freed up and will be occupied with pressing the next finger (when releasing a finger, the shift of ids does not occur).
-	 * @param touchEndListener function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is released.
-	 * @param moveListener function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is moved.
+	 * @param touchStartListener (optional) function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is pressed down. The finger `id` goes from 0 increasing by one. When the finger releases the screen, the old `id` is freed up and will be occupied with pressing the next finger (when releasing a finger, the shift of ids does not occur).
+	 * @param touchEndListener (optional) function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is released.
+	 * @param moveListener (optional) function with `id:Int`,`x:Int`,`y:Int` arguments, fired when a surface is moved.
 	 */
-	public function notify(touchStartListener: (id: Int, x: Int, y: Int) -> Void, touchEndListener: (id: Int, x: Int, y: Int) -> Void,
-			moveListener: (id: Int, x: Int, y: Int) -> Void): Void {
+	public function notify(?touchStartListener: (id: Int, x: Int, y: Int) -> Void, ?touchEndListener: (id: Int, x: Int, y: Int) -> Void,
+			?moveListener: (id: Int, x: Int, y: Int) -> Void): Void {
 		if (touchStartListener != null)
 			touchStartListeners.push(touchStartListener);
 		if (touchEndListener != null)
@@ -52,8 +52,8 @@ class Surface {
 	/**
 	 * Removes event handlers from the passed functions that were passed to `notify` function.
 	 */
-	public function remove(touchStartListener: (id: Int, x: Int, y: Int) -> Void, touchEndListener: (id: Int, x: Int, y: Int) -> Void,
-			moveListener: (id: Int, x: Int, y: Int) -> Void): Void {
+	public function remove(?touchStartListener: (id: Int, x: Int, y: Int) -> Void, ?touchEndListener: (id: Int, x: Int, y: Int) -> Void,
+			?moveListener: (id: Int, x: Int, y: Int) -> Void): Void {
 		if (touchStartListener != null)
 			touchStartListeners.remove(touchStartListener);
 		if (touchEndListener != null)


### PR DESCRIPTION
Even though `Keyboard.notify()` and `Keyboard.remove()` treat all listeners as nullable, they are not marked as such. This leads to compile errors when using `--macro nullSafety('[...]', StrictThreaded)`. This PR marks the parameters as nullable.