### PR TITLE
Revert back to using the Hack for size

### DIFF
--- a/Backends/HTML5/kha/Window.hx
+++ b/Backends/HTML5/kha/Window.hx
@@ -88,7 +88,7 @@ class Window {
 	public var width(get, set): Int;
 
 	function get_width(): Int {
-		return canvas.width;
+		return canvas.width == 0 ? defaultWidth : canvas.width;
 	}
 
 	function set_width(value: Int): Int {
@@ -98,7 +98,7 @@ class Window {
 	public var height(get, set): Int;
 
 	function get_height(): Int {
-		return canvas.height;
+		return canvas.height == 0 ? defaultHeight : canvas.height;
 	}
 
 	function set_height(value: Int): Int {


### PR DESCRIPTION
On some setups `get_width()` and `get_height()` return 0. 
This PR reintroduces the hack that was in place before.