### PR TITLE
Fix browser zoom again

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -517,8 +517,8 @@ class SystemImpl {
 
 			if (canvas.getContext != null) {
 				// clientWidth/Height is in downscaled "css pixels" when a <meta viewport="" /> is set in the html file
-				var displayWidth = Std.int(canvas.clientWidth * js.Browser.window.devicePixelRatio);
-				var displayHeight = Std.int(canvas.clientHeight * js.Browser.window.devicePixelRatio);
+				var displayWidth = Std.int(canvas.clientWidth);
+				var displayHeight = Std.int(canvas.clientHeight);
 
 				// Check if the canvas rendering buffer is not the same size.
 				if (canvas.width != displayWidth || canvas.height != displayHeight) {


### PR DESCRIPTION
When browser page was zoomed, it was constantly zooming in or out. So hopefully this fixes not drawing on Mac Chrome at all, and on PC Edge/Chrome/Firefox, with zooming different than 100% (also works on Mac with zoom)

