### PR TITLE
Assure range of -Pi..Pi for angle method

### DIFF
--- a/Sources/kha/math/FastVector2.hx
+++ b/Sources/kha/math/FastVector2.hx
@@ -66,7 +66,7 @@ class FastVector2 {
 	}
 
 	@:extern public inline function angle(v: FastVector2): FastFloat {
-		return Math.atan2(y, x) - Math.atan2(v.y, v.x);
+		return Math.atan2(x * v.y - y * v.x, x * v.x + y * v.y);
 	}
 
 	public function toString() {

--- a/Sources/kha/math/Vector2.hx
+++ b/Sources/kha/math/Vector2.hx
@@ -62,7 +62,7 @@ class Vector2 {
 	}
 
 	@:extern public inline function angle(v: Vector2): Float {
-		return Math.atan2(y, x) - Math.atan2(v.y, v.x);
+		return Math.atan2(x * v.y - y * v.x, x * v.x + y * v.y);
 	}
 
 	@:extern public inline function fast(): FastVector2 {


### PR DESCRIPTION
The current implementation can yield results < -Pi or > Pi, which
technically isn't a relative angle and depends on the orientation
of the two vectors.