### PR TITLE
Fixes issues in KoreC Kinc-HL

### DIFF
--- a/Backends/Kinc-HL/KoreC/display.cpp
+++ b/Backends/Kinc-HL/KoreC/display.cpp
@@ -1,7 +1,7 @@
 #include <Kore/Display.h>
 #include <Kore/System.h>
 
-extern "C" int hl_kore_display_init() {
+extern "C" void hl_kore_display_init() {
 	return Kore::Display::init();
 }
 

--- a/Backends/Kinc-HL/KoreC/display.cpp
+++ b/Backends/Kinc-HL/KoreC/display.cpp
@@ -2,7 +2,7 @@
 #include <Kore/System.h>
 
 extern "C" void hl_kore_display_init() {
-	return Kore::Display::init();
+	Kore::Display::init();
 }
 
 extern "C" int hl_kore_display_count() {

--- a/Backends/Kinc-HL/KoreC/system.cpp
+++ b/Backends/Kinc-HL/KoreC/system.cpp
@@ -44,16 +44,16 @@ extern "C" void hl_kore_mouse_lock(int windowId) {
 	Kore::Mouse::the()->lock(windowId);
 }
 
-extern "C" void hl_kore_mouse_unlock(int windowId) {
-	Kore::Mouse::the()->unlock(windowId);
+extern "C" void hl_kore_mouse_unlock() {
+	Kore::Mouse::the()->unlock();
 }
 
-extern "C" bool hl_kore_can_lock_mouse(int windowId) {
-	return Kore::Mouse::the()->canLock(windowId);
+extern "C" bool hl_kore_can_lock_mouse() {
+	return Kore::Mouse::the()->canLock();
 }
 
-extern "C" bool hl_kore_is_mouse_locked(int windowId) {
-	return Kore::Mouse::the()->isLocked(windowId);
+extern "C" bool hl_kore_is_mouse_locked() {
+	return Kore::Mouse::the()->isLocked();
 }
 
 extern "C" void hl_kore_show_mouse(bool show) {

--- a/Backends/Kinc-HL/KoreC/video.cpp
+++ b/Backends/Kinc-HL/KoreC/video.cpp
@@ -22,12 +22,12 @@ extern "C" void hl_kore_video_stop(vbyte* video) {
 
 extern "C" int hl_kore_video_get_duration(vbyte* video) {
 	Kore::Video* vid = (Kore::Video*)video;
-	return static_cast<int>(vid->duration * 1000.0);
+	return static_cast<int>(vid->duration() * 1000.0);
 }
 
 extern "C" int hl_kore_video_get_position(vbyte* video) {
 	Kore::Video* vid = (Kore::Video*)video;
-	return static_cast<int>(vid->position * 1000.0);
+	return static_cast<int>(vid->position() * 1000.0);
 }
 
 extern "C" void hl_kore_video_set_position(vbyte* video, int value) {
@@ -37,7 +37,7 @@ extern "C" void hl_kore_video_set_position(vbyte* video, int value) {
 
 extern "C" bool hl_kore_video_is_finished(vbyte* video) {
 	Kore::Video* vid = (Kore::Video*)video;
-	return vid->finished;
+	return vid->finished();
 }
 
 extern "C" int hl_kore_video_width(vbyte* video) {


### PR DESCRIPTION
This PR fixes issues mentioned at https://github.com/armory3d/armory/issues/2267

Specifically, the following issues that occur in Visual Studio when targeting Kore-HL

```
'return Kore::Display::init()' : cannot convert from 'void' to 'int'
'Kore::Video::position': non-standard syntax; use '&' to create a pointer to member
'Kore::Video::finished': non-standard syntax; use '&' to create a pointer to member
'Kore::Video::duration': non-standard syntax; use '&' to create a pointer to member
'Kore::Mouse::unlock': function does not take 1 arguments
'Kore::Mouse::isLocked': function does not take 1 arguments
'Kore::Mouse::canLock': function does not take 1 arguments
```

Tested on Windows-HL and Android-HL targets with Armory3D projects and latest Kode repository.