### PR TITLE
Correctly set samplesPerSecond on HL: workaround for haxe#9803 

### DIFF
--- a/Backends/Kinc-HL/kha/SystemImpl.hx
+++ b/Backends/Kinc-HL/kha/SystemImpl.hx
@@ -39,7 +39,9 @@ class SystemImpl {
 		framebuffer.init(new kha.graphics2.Graphics1(framebuffer), new kha.korehl.graphics4.Graphics2(framebuffer), g4);
 		kha.audio2.Audio._init();
 		kha.audio1.Audio._init();
-		kore_init_audio(kha.audio2.Audio._callCallback, kha.audio2.Audio._readSample, kha.audio2.Audio.samplesPerSecond);
+		final samplesRef: hl.Ref<Int> = kha.audio2.Audio.samplesPerSecond;
+		kore_init_audio(kha.audio2.Audio._callCallback, kha.audio2.Audio._readSample, samplesRef);
+		kha.audio2.Audio.samplesPerSecond = samplesRef.get();
 		keyboard = new kha.input.Keyboard();
 		mouse = new kha.input.MouseImpl();
 		pen = new kha.input.Pen();

--- a/Backends/Kinc-HL/kha/SystemImpl.hx
+++ b/Backends/Kinc-HL/kha/SystemImpl.hx
@@ -387,7 +387,7 @@ class SystemImpl {
 	public static function getGamepadVendor(index: Int): String {
 		return "";
 	}
-	
+
 	public static function setGamepadRumble(index: Int, leftAmount: Float, rightAmount: Float) {}
 
 	public static function safeZone(): Float {


### PR DESCRIPTION
Fixes the HL part of https://github.com/Kode/Kha/issues/1360. As long as https://github.com/HaxeFoundation/haxe/issues/9803 is still unresolved, we need to use this workaround to ensure that the sample rate is correctly set on application start.