### PR TITLE
HL/C: correctly assign sample rate to sounds from .wav files

### DIFF
--- a/Backends/Kinc-HL/KoreC/sound.cpp
+++ b/Backends/Kinc-HL/KoreC/sound.cpp
@@ -4,7 +4,7 @@
 #define STB_VORBIS_HEADER_ONLY
 #include <kinc/audio1/stb_vorbis.c>
 
-extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, float* outLength) {
+extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, int* outSampleRate, float* outLength) {
 	Kore::Sound* sound = new Kore::Sound((char*)filename);
 	float* uncompressedData = new float[sound->size * 2];
 	reinterpret_cast<unsigned int*>(outSize)[0] = sound->size * 2; // Return array size to Kha
@@ -14,6 +14,7 @@ extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, float*
 		uncompressedData[i * 2 + 0] = (float)(left [i] / 32767.0);
 		uncompressedData[i * 2 + 1] = (float)(right[i] / 32767.0);
 	}
+	*outSampleRate = sound->format.samplesPerSecond;
 	*outLength = sound->length;
 	delete sound;
 	return (vbyte*)uncompressedData;

--- a/Backends/Kinc-HL/kha/korehl/Sound.hx
+++ b/Backends/Kinc-HL/kha/korehl/Sound.hx
@@ -10,7 +10,9 @@ class Sound extends kha.Sound {
 	function initWav(filename: String) {
 		uncompressedData = new kha.arrays.Float32Array();
 		var dataSize = new kha.arrays.Uint32Array(1);
-		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData(), length);
+		final sampleRateRef: hl.Ref<Int> = sampleRate;
+		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData(), sampleRateRef, length);
+		sampleRate = sampleRateRef.get();
 		uncompressedData.setData(data, dataSize[0]);
 		dataSize.free();
 	}
@@ -32,7 +34,7 @@ class Sound extends kha.Sound {
 		}
 	}
 
-	@:hlNative("std", "kore_sound_init_wav") static function kore_sound_init_wav(filename: hl.Bytes, outSize: Pointer, outLength: hl.Ref<Float>): Pointer {
+	@:hlNative("std", "kore_sound_init_wav") static function kore_sound_init_wav(filename: hl.Bytes, outSize: Pointer, outSampleRate: hl.Ref<Int>, outLength: hl.Ref<Float>): Pointer {
 		return null;
 	}
 }


### PR DESCRIPTION
If a sound was exported by Khamake for HL with quality 1.0, the sample rate wasn't correctly set because it was only set if `uncompress()` was called. However, sounds with quality 1.0 are already uncompressed so `uncompress()` directly returns, leaving the sample rate at 0. This PR fixes that.

@ RobDangerous: The length of the sound also isn't correctly set due to the same `hl.Ref` problem that recently occured for the global sample rate, however if I add the workaround from https://github.com/Kode/Kha/pull/1361 the length is still not correct and shows something like 5e-138. Either there is some issue with float conversion or the length isn't read correctly from the file. Should I open an issue for that?