### PR TITLE
HL/C: correctly set the length of wav sounds

### DIFF
--- a/Backends/Kinc-HL/KoreC/sound.cpp
+++ b/Backends/Kinc-HL/KoreC/sound.cpp
@@ -4,7 +4,7 @@
 #define STB_VORBIS_HEADER_ONLY
 #include <kinc/audio1/stb_vorbis.c>
 
-extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, int* outSampleRate, float* outLength) {
+extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, int* outSampleRate, double* outLength) {
 	Kore::Sound* sound = new Kore::Sound((char*)filename);
 	float* uncompressedData = new float[sound->size * 2];
 	reinterpret_cast<unsigned int*>(outSize)[0] = sound->size * 2; // Return array size to Kha
@@ -15,7 +15,7 @@ extern "C" vbyte *hl_kore_sound_init_wav(vbyte* filename, vbyte* outSize, int* o
 		uncompressedData[i * 2 + 1] = (float)(right[i] / 32767.0);
 	}
 	*outSampleRate = sound->format.samplesPerSecond;
-	*outLength = sound->length;
+	*outLength = static_cast<double>(sound->length);
 	delete sound;
 	return (vbyte*)uncompressedData;
 }

--- a/Backends/Kinc-HL/kha/korehl/Sound.hx
+++ b/Backends/Kinc-HL/kha/korehl/Sound.hx
@@ -11,8 +11,10 @@ class Sound extends kha.Sound {
 		uncompressedData = new kha.arrays.Float32Array();
 		var dataSize = new kha.arrays.Uint32Array(1);
 		final sampleRateRef: hl.Ref<Int> = sampleRate;
-		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData(), sampleRateRef, length);
+		final lengthRef: hl.Ref<Float> = length;
+		var data = kore_sound_init_wav(StringHelper.convert(filename), dataSize.getData(), sampleRateRef, lengthRef);
 		sampleRate = sampleRateRef.get();
+		length = lengthRef.get();
 		uncompressedData.setData(data, dataSize[0]);
 		dataSize.free();
 	}


### PR DESCRIPTION
Fixes https://github.com/Kode/Kha/issues/1363, it was much easier to fix than I thought at first (C++ noob here). The cause was a simple conversion issue because `Float` in Haxe is a double and the length is parsed as a float.