### PR TITLE
Fix gamepad init in HTML

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -212,7 +212,11 @@ class SystemImpl {
 			gamepadStates[i] = new GamepadStates();
 		}
 		js.Browser.window.addEventListener("gamepadconnected", (e) -> {
-			Gamepad.sendConnectEvent(e.gamepad.index);
+			var pad:js.html.Gamepad = e.gamepad;
+			Gamepad.sendConnectEvent(pad.index);
+			for (i in 0...pad.buttons.length) {
+				gamepadStates[pad.index].buttons[i] = 0;
+			}
 		});
 		js.Browser.window.addEventListener("gamepaddisconnected", (e) -> {
 			Gamepad.sendDisconnectEvent(e.gamepad.index);


### PR DESCRIPTION
When you press gamepad button for first time it send event "reseased" for all avialable buttons.
It happens because gamepadState buttons array is empty [here](https://github.com/Kode/Kha/blob/master/Backends/HTML5/kha/SystemImpl.hx#L314)