### PR TITLE
renaming remaining texPosition's

### DIFF
--- a/Backends/Android/kha/android/OpenGLPainter.hx
+++ b/Backends/Android/kha/android/OpenGLPainter.hx
@@ -112,12 +112,12 @@ class OpenGLPainter extends kha.Painter {
 
 		var vertexShader = getShader(GLES20.GL_VERTEX_SHADER,
 			"attribute vec3 vertexPosition;"
-			+ "attribute vec2 texPosition;"
+			+ "attribute vec2 vertexUV;"
 			+ "uniform mat4 projectionMatrix;"
 			+ "varying vec2 texCoord;"
 			+ "void main() {"
 			+ "gl_Position = projectionMatrix * vec4(vertexPosition, 1.0);"
-			+ "texCoord = texPosition;"
+			+ "texCoord = vertexUV;"
 			+ "}");
 
 		shaderProgram = GLES20.glCreateProgram();


### PR DESCRIPTION
Looks like i missed even more places with the renames, and it turns out i searched for `"texPosition"` instead of only `texPosition`, so it's a brainbug instead of vscode :smile: 

There is also one i missed in `khamake/Data/psm/Texture.vcg`, is that still a thing?