### PR TITLE
[HL] Don't try to close file twice when loading a blob

### DIFF
--- a/Backends/Kinc-HL/KoreC/kore.cpp
+++ b/Backends/Kinc-HL/KoreC/kore.cpp
@@ -124,7 +124,6 @@ extern "C" vbyte *hl_kore_file_contents(vbyte *name, int *size) {
 	hl_blocking(true);
 	if (!size) content[len] = 0; // final 0 for UTF8
 	file.read(content, len);
-	file.close();
 	hl_blocking(false);
 	return content;
 }


### PR DESCRIPTION
Closing a file is automatically done in the [`FileReader`'s destructor](https://github.com/Kode/Kinc/blob/1f6b3c2d7db05dedb54b5477303604e1ce5428aa/Sources/Kore/IO/FileReader.winrt.cpp#L47-L49) which previously led to an invalid handle exception because Kinc attempted to close the file twice. The now removed line was originally committed before the destructor did call `close()`.