### PR TITLE
[HL] some sample rate fixes

### DIFF
--- a/Backends/Kinc-HL/KoreC/kore.cpp
+++ b/Backends/Kinc-HL/KoreC/kore.cpp
@@ -98,9 +98,9 @@ extern "C" void hl_init_kore(vbyte *title, int width, int height, int samplesPer
 extern "C" void hl_kore_init_audio(vclosure *callCallback, vclosure *readSample, int *outSamplesPerSecond) {
 	audioCallCallback = *((FN_AUDIO_CALL_CALLBACK*)(&callCallback->fun));
 	audioReadSample = *((FN_AUDIO_READ_SAMPLE*)(&readSample->fun));
-	*outSamplesPerSecond = Kore::Audio2::samplesPerSecond;
 	Kore::Audio2::audioCallback = mix;
 	Kore::Audio2::init();
+	*outSamplesPerSecond = Kore::Audio2::samplesPerSecond;
 }
 
 extern "C" void hl_run_kore() {

--- a/Backends/Kinc-HL/kha/SystemImpl.hx
+++ b/Backends/Kinc-HL/kha/SystemImpl.hx
@@ -37,11 +37,11 @@ class SystemImpl {
 		var g4 = new kha.korehl.graphics4.Graphics();
 		framebuffer = new Framebuffer(0, null, null, g4);
 		framebuffer.init(new kha.graphics2.Graphics1(framebuffer), new kha.korehl.graphics4.Graphics2(framebuffer), g4);
-		kha.audio2.Audio._init();
-		kha.audio1.Audio._init();
 		final samplesRef: hl.Ref<Int> = kha.audio2.Audio.samplesPerSecond;
 		kore_init_audio(kha.audio2.Audio._callCallback, kha.audio2.Audio._readSample, samplesRef);
 		kha.audio2.Audio.samplesPerSecond = samplesRef.get();
+		kha.audio1.Audio._init();
+		kha.audio2.Audio._init();
 		keyboard = new kha.input.Keyboard();
 		mouse = new kha.input.MouseImpl();
 		pen = new kha.input.Pen();

--- a/Backends/Kinc-HL/kha/audio2/Audio.hx
+++ b/Backends/Kinc-HL/kha/audio2/Audio.hx
@@ -10,7 +10,7 @@ class Audio {
 
 	public static function _init() {
 		var bufferSize = 1024 * 2;
-		buffer = new Buffer(bufferSize * 4, 2, 44100);
+		buffer = new Buffer(bufferSize * 4, 2, samplesPerSecond);
 	}
 
 	public static function _callCallback(samples: Int): Void {


### PR DESCRIPTION
If the system falls back to an alternative mix format with a different sample rate than preferred by Kinc, it could happen that the sample rate in the Haxe API wasn't correctly updated because it it was read before the audio was initialized.

Also, audio buffers used a hard-coded sample rate which would fail in the same situation. This would lead to playback with a wrong speed because the resampling code in resampling audio channels depends on the sample rate passed [here](https://github.com/Kode/Kha/blob/c70a8cce5d67e7a5296d610f668d5a17b83da2ae/Sources/kha/audio2/Audio1.hx#L95).

Btw, what's the reason why the sample rate is stored in each buffer when it's also a globally accessible variable? Are the buffers designed to be used for multiple purposes?

On Krom there are similar issues but I couldn't get Krom audio to work even after enabling it in main.cpp (see https://github.com/Kode/Krom/issues/138#issuecomment-558732832; I know of the issues because they exist in Armorcore and they are likely to exist in Kode/Krom as well). I will try to dig deeper in the next days and then eventually open an issue or add something to the linked issue.