### PR TITLE
Use devicePixelRatio in canvas size

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -25,6 +25,8 @@ import kha.js.MobileWebAudio;
 import kha.js.vr.VrInterface;
 import kha.System;
 
+using StringTools;
+
 class GamepadStates {
 	public var axes: Array<Float>;
 	public var buttons: Array<Float>;
@@ -520,15 +522,9 @@ class SystemImpl {
 			Scheduler.executeFrame();
 
 			if (canvas.getContext != null) {
-				// clientWidth/Height is in downscaled "css pixels" when a <meta viewport="" /> is set in the html file
-				var displayWidth = Std.int(canvas.clientWidth);
-				var displayHeight = Std.int(canvas.clientHeight);
-
-				// Check if the canvas rendering buffer is not the same size.
-				if (canvas.width != displayWidth || canvas.height != displayHeight) {
-					// Make the canvas rendering buffer the same size
-					canvas.width = displayWidth;
-					canvas.height = displayHeight;
+				if (!canvas.style.width.endsWith("%")) {
+					canvas.style.width = Std.int(canvas.width / Browser.window.devicePixelRatio) + "px";
+					canvas.style.height = Std.int(canvas.height / Browser.window.devicePixelRatio) + "px";
 				}
 
 				System.render([frame]);

--- a/Backends/HTML5/kha/Window.hx
+++ b/Backends/HTML5/kha/Window.hx
@@ -31,7 +31,7 @@ class Window {
 				}
 			}
 			if (isResize) {
-				this.resize(canvas.clientWidth, canvas.clientHeight);
+				this.resize(canvas.width, canvas.height);
 			}
 		});
 		observer.observe(canvas, {attributes: true});


### PR DESCRIPTION
Update canvas style property to set size in pixels.

This basically re-reverts change https://github.com/Kode/Kha/pull/1309 by @sh-dave after revert in https://github.com/Kode/Kha/pull/1331 by @AndreiRudenko with some vague reason.

After this change, you will get canvas size in real pixels in html5 on any ppi/resolution.
To make full-window canvas, you can call this snippet after `System.start`:
```haxe
#if kha_html5
import js.Browser.document;
import js.Browser.window;
import js.html.CanvasElement;
import kha.Macros;
#end
...
final canvas:CanvasElement = cast document.getElementById(Macros.canvasId());
final resize = function() {
	final size = getDocumentSize();
	final w = document.documentElement.clientWidth;
	final h = document.documentElement.clientHeight;
	canvas.width = Std.int(w * window.devicePixelRatio);
	canvas.height = Std.int(h * window.devicePixelRatio);
	// You can also call it before System.start if you uncomment this block:
	// if (canvas.style.width == "") {
	//	canvas.style.width = "100%";
	//	canvas.style.height = "100%";
	// }
}
window.onresize = resize;
resize();
```

There is also some bug on Safari in some tiny portrait orientations, where you can get bigger canvas than screen with my snippet (will still fit full page, but look blurry). This happens because Kha can create canvas with `width` bigger than screen. To fix this, change canvas element size in `index.html` to smaller `width` (like 100px) with khamake flag, so page will don't get scrollbar before full-window code executes.