### PR TITLE
Live reload html5/electron

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -4,6 +4,7 @@ import js.Syntax;
 import js.html.webgl.GL;
 import js.html.WheelEvent;
 import js.Browser;
+import js.html.WebSocket;
 import js.html.CanvasElement;
 import js.html.KeyboardEvent;
 import js.html.MouseEvent;
@@ -87,6 +88,18 @@ class SystemImpl {
 		mobileAudioPlaying = !mobile && !chrome && !firefox;
 
 		initSecondStep(callback);
+		#end
+
+		#if kha_live_reload
+		function openWebSocket():Void {
+			var host = Browser.location.hostname;
+			if (host == "") host = "localhost";
+			var port = Std.parseInt(Browser.location.port);
+			if (port == null) port = 80;
+			final ws = new WebSocket('ws://$host:${port + 1}');
+			ws.onmessage = () -> Browser.location.reload();
+		}
+		openWebSocket();
 		#end
 	}
 


### PR DESCRIPTION
Perfect vscode html5 launch task:
```json
{
	"name": "HTML5-watch",
	"request": "launch",
	"type": "pwa-node",
	"program": "${command:kha.findKha}/make",
	"args": [
		"html5",
		"--watch",
		"--server",
		"--port",
		"4200",
		"--livereload"
	],
	"killBehavior": "polite"
}
```
(run and open `localhost:4200`, use ctrl-s to rebuild and reload page).
For debug-html5 it is little more complicated, because you need to open Electron after watch-compilation, so this is just example:
[live_electron.zip](https://github.com/Kode/Kha/files/8356067/live_electron.zip)
(works better with electron window on separate screen, because page reload resets window cords)

