### PR TITLE
Clean wheel event

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -468,10 +468,10 @@ class SystemImpl {
 		}
 		canvas.onblur = onBlur;
 		canvas.onfocus = onFocus;
-		untyped (canvas.onmousewheel = canvas.onwheel = mouseWheel);
 		canvas.onmouseleave = mouseLeave;
 
-		canvas.addEventListener("wheel mousewheel", mouseWheel, false);
+		// IE11 does not have canvas.onwheel
+		canvas.addEventListener("wheel", mouseWheel, false);
 		canvas.addEventListener("touchstart", touchDown, false);
 		canvas.addEventListener("touchend", touchUp, false);
 		canvas.addEventListener("touchmove", touchMove, false);


### PR DESCRIPTION
https://caniuse.com/mdn-api_element_wheel_event
Basically the only working part of this code is `canvas.onwheel = mouseWheel`, but
> Internet Explorer only exposes the wheel event via addEventListener; there is no onwheel attribute on DOM objects

And `wheel mousewheel` is not a event at all, it seems.
Closes https://github.com/Kode/Kha/issues/872