### PR TITLE
Allow spaces in path on windows for get_dlc

### DIFF
--- a/get_dlc.bat
+++ b/get_dlc.bat
@@ -1,5 +1,7 @@
-@git -C %~dp0 submodule update --init Tools/khamake
-@git -C %~dp0 submodule update --init Backends/Kinc-hxcpp/khacpp
-@git -C %~dp0 submodule update --init Tools/windows_x64
-@git -C %~dp0 submodule update --init Kinc
-@call %~dp0\Kinc\get_dlc.bat
+@pushd "%~dp0"
+@git submodule update --init Tools/khamake
+@git submodule update --init Backends/Kinc-hxcpp/khacpp
+@git submodule update --init Tools/windows_x64
+@git submodule update --init Kinc
+@call Kinc\get_dlc.bat
+@popd

--- a/get_dlc_dangerously.bat
+++ b/get_dlc_dangerously.bat
@@ -1,5 +1,7 @@
-@git -C %~dp0 submodule update --init --remote Tools/khamake
-@git -C %~dp0 submodule update --init --remote Backends/Kinc-hxcpp/khacpp
-@git -C %~dp0 submodule update --init --remote Tools/windows_x64
-@git -C %~dp0 submodule update --init --remote Kinc
-@call %~dp0\Kinc\get_dlc_dangerously.bat
+@pushd "%~dp0"
+@git submodule update --init --remote Tools/khamake
+@git submodule update --init --remote Backends/Kinc-hxcpp/khacpp
+@git submodule update --init --remote Tools/windows_x64
+@git submodule update --init --remote Kinc
+@call Kinc\get_dlc_dangerously.bat
+@popd


### PR DESCRIPTION
This fixes the "fatal: cannot change to path" error when running get_dlc if there is a space in the path on windows.