### PR TITLE
fixing what seems to be a typo divide used instead of multiplying the…

### DIFF
--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -577,8 +577,8 @@ class SystemImpl {
 					canvas.width = clientWidth;
 					canvas.height = clientHeight;
 					if (scale != 1) {
-						canvas.style.width = Std.int(clientWidth / scale) + "px";
-						canvas.style.height = Std.int(clientHeight / scale) + "px";
+						canvas.style.width = Std.int(clientWidth * scale) + "px";
+						canvas.style.height = Std.int(clientHeight * scale) + "px";
 					}
 					lastCanvasClientWidth = canvas.clientWidth;
 					lastCanvasClientHeight = canvas.clientHeight;


### PR DESCRIPTION
… scale devicePixelRatio to correctly resize the canvas.

Hi there, seems there is an error here :
if you want to apply the scale you should multiply it not divide, corrected it should be :
canvas.style.width = Std.int(clientWidth * scale) + "px";
canvas.style.height = Std.int(clientHeight * scale) + "px";

some info on devicePixelRatio can be found here:
https://webglfundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
current method is : 
  const displayWidth  = Math.round(canvas.clientWidth * dpr);
  const displayHeight = Math.round(canvas.clientHeight * dpr);