### PR TITLE
[Krom/HL] Implement asset loading failed callbacks for most cases

### DIFF
--- a/Backends/Kinc-HL/kha/Image.hx
+++ b/Backends/Kinc-HL/kha/Image.hx
@@ -182,6 +182,9 @@ class Image implements Canvas implements Resource {
 		var isFloat = StringTools.endsWith(filename, ".hdr");
 		image.myFormat = isFloat ? TextureFormat.RGBA128 : TextureFormat.RGBA32;
 		image.initFromFile(filename);
+		if (image._texture == null) {
+			return null;
+		}
 		return image;
 	}
 

--- a/Backends/Kinc-HL/kha/LoaderImpl.hx
+++ b/Backends/Kinc-HL/kha/LoaderImpl.hx
@@ -16,7 +16,16 @@ class LoaderImpl {
 
 	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void, failed: AssetError->Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		done(kha.Image.fromFile(desc.files[0], readable));
+		var image = kha.Image.fromFile(desc.files[0], readable);
+		if (image == null) {
+			failed({
+				url: desc.files.join(","),
+				error: "Could not load image(s)",
+			});
+		}
+		else {
+			done(image);
+		}
 	}
 
 	public static function getImageFormats(): Array<String> {
@@ -27,13 +36,24 @@ class LoaderImpl {
 		// done(new Blob(File.getBytes(desc.files[0])));
 		var size = 0;
 		var bytes = kinc_file_contents(StringHelper.convert(desc.files[0]), size);
-		done(new Blob(@:privateAccess new haxe.io.Bytes(bytes, size)));
+		if (bytes == null) {
+			failed({
+				url: desc.files.join(","),
+				error: "Could not load blob(s)",
+			});
+		}
+		else {
+			done(new Blob(@:privateAccess new haxe.io.Bytes(bytes, size)));
+		}
 	}
 
 	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void, failed: AssetError->Void): Void {
 		loadBlobFromDescription(desc, function(blob: Blob) {
 			done(new Kravur(blob));
-		}, failed);
+		}, (a: AssetError) -> {
+			a.error = "Could not load font(s)";
+			failed(a);
+		});
 	}
 
 	public static function loadVideoFromDescription(desc: Dynamic, done: Video->Void, failed: AssetError->Void) {

--- a/Backends/Krom/kha/LoaderImpl.hx
+++ b/Backends/Krom/kha/LoaderImpl.hx
@@ -13,7 +13,16 @@ class LoaderImpl {
 
 	public static function loadImageFromDescription(desc: Dynamic, done: kha.Image->Void, failed: AssetError->Void) {
 		var readable = Reflect.hasField(desc, "readable") ? desc.readable : false;
-		done(Image._fromTexture(Krom.loadImage(desc.files[0], readable)));
+		var texture = Krom.loadImage(desc.files[0], readable);
+		if (texture == null) {
+			failed({
+				url: desc.files.join(","),
+				error: "Could not load image(s)",
+			});
+		}
+		else {
+			done(Image._fromTexture(texture));
+		}
 	}
 
 	public static function getSoundFormats(): Array<String> {
@@ -21,22 +30,48 @@ class LoaderImpl {
 	}
 
 	public static function loadSoundFromDescription(desc: Dynamic, done: kha.Sound->Void, failed: AssetError->Void) {
-		done(new kha.krom.Sound(Bytes.ofData(Krom.loadSound(desc.files[0]))));
+		var sound = Krom.loadSound(desc.files[0]);
+		if (sound == null) {
+			failed({
+				url: desc.files.join(","),
+				error: "Could not load sound(s)",
+			});
+		}
+		else {
+			done(new kha.krom.Sound(Bytes.ofData(sound)));
+		}
 	}
 
 	public static function getVideoFormats(): Array<String> {
 		return ["webm"];
 	}
 
-	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void, failed: AssetError->Void): Void {}
+	public static function loadVideoFromDescription(desc: Dynamic, done: kha.Video->Void, failed: AssetError->Void): Void {
+		failed({
+			url: desc.files.join(","),
+			error: "Could not load video(s), Krom currently does not support loading videos",
+		});
+	}
 
 	public static function loadBlobFromDescription(desc: Dynamic, done: Blob->Void, failed: AssetError->Void) {
-		done(new Blob(Bytes.ofData(Krom.loadBlob(desc.files[0]))));
+		var blob = Krom.loadBlob(desc.files[0]);
+		if (blob == null) {
+			failed({
+				url: desc.files.join(","),
+				error: "Could not load blob(s)",
+			});
+		}
+		else {
+			done(new Blob(Bytes.ofData(blob)));
+		}
 	}
 
 	public static function loadFontFromDescription(desc: Dynamic, done: Font->Void, failed: AssetError->Void): Void {
 		loadBlobFromDescription(desc, function(blob: Blob) {
 			done(new Kravur(blob));
-		}, failed);
+		}, (a: AssetError) -> {
+			a.error = "Could not load font(s)";
+			failed(a);
+		});
 	}
 }


### PR DESCRIPTION
This PR implements the `failed` callback on Krom and HL targets in most situations. This means that the "Could not read hxBytes of undefined" errors are finally gone in most cases – they didn't tell anyone what asset caused the problem and they were difficult to debug from remote if some Armory users for example simply shared just that error message. More importantly, it can no longer happen on Krom or HL that `Image` objects are returned to the user that neither contain a texture or a render target, thus crashing the application at a later point in time.

**A few remarks:**

I didn't implement the `failed` callback in HL for loading videos because I wasn't sure how to handle things in `kinc_video_init()` (e.g. [video.cpp.h](https://github.com/Kode/Kinc/blob/21a5a39ca8729d484437100d663ad7626906bd13/Backends/System/Windows/Sources/kinc/backend/video.cpp.h#L117) for Windows) which doesn't have a return value at the moment and on Windows simply ignores the HRESULT values returned from the functions it calls. I don't know if you want to slightly change Kinc's API, but I think this is required in order to get error information out of this method. Preferably there would be some more stuff in place that in case of an error would print the actual _reason_ to the console (e.g. the `HRESULT` value if `!= S_OK`). I think this would have a _very minor_ impact on performance but would be an _tremendously helpful_ change.

The same holds true for loading sounds:
- Errors when loading .wav files are handled with `kinc_affirm()` and not passed to Kha. Instead the user either sees "Unknown Error" or the application just crashes.
- Errors when loading .ogg files [result in a Haxe exception](https://api.haxe.org/sys/io/File.html#getBytes). I'm not sure whether you would be ok with wrapping the entire call to `new kha.korehl.Sound()` in a try/catch, because otherwise I don't think there is a nice way of calling a failed callback in the current API.

As for loading images in HL, I changed `Image.fromFile()` so that it returns null in the error case. If you don't want to do this, I can instead move that code into the LoaderImpl, but that would be a rather hacky workaround and I think the current way is better since users will notice any issues before the application fails in mysterious ways at a later point in time. It probably makes sense to change the return type of `Image.fromFile()` to `Null<Image>` to make the new behaviour clear and to satisfy Haxe's null safety checks, but it would introduce more inconsistency for the Kha API since it's not really used anywhere else in Kha, so I'm not sure whether you'd want that.

Loading non-existing sounds still crashes on Kode/Krom. Fixing this is pretty simple (see https://github.com/armory3d/armorcore/pull/56), but I don't want to open PRs for untested code. Please see below on why I can't test for Kode/Krom.

The current state of things when attempting to load files that don't exist (✔ meaning the `failed` callback is called):
|         | Krom                               | HL    |
|---------|------------------------------------|-------|
| Images  | ✔                                 | ✔    |
| Sounds  | ✔ (Armorcore), ❌ crash (Kode/Krom) | ❌ crash |
| Blobs   | ✔                                 | ✔    |
| Fonts   | ✔                                 | ✔    |
| Videos  | ✔                                 | ❌ crash |

**Please note** that I could test my Krom-related changes **only with Armorcore and not with Kode/Krom**, since the latter fails to build with a linker error due to `kickstart()` being disabled by an `#if 0` block:

```
1>   Creating library [...]\Krom\build\x64\Debug\Krom.lib and object [...]\Krom\build\x64\Debug\Krom.exp
1>windowsunit.obj : error LNK2019: unresolved external symbol kickstart referenced in function WinMain
1>[...]\Krom\build\x64\Debug\Krom.exe : fatal error LNK1120: 1 unresolved externals
```