### PR TITLE
fix vertical alignment for drawAlignedString

### DIFF
--- a/Sources/kha/graphics2/GraphicsExtension.hx
+++ b/Sources/kha/graphics2/GraphicsExtension.hx
@@ -344,13 +344,13 @@ class GraphicsExtension {
 			}
 		}
 		var yoffset = 0.0;
-		if (verAlign == TextMiddle || verAlign == TextBottom) {
+		if (verAlign == TextTop || verAlign == TextBottom) {
 			var height = g2.font.height(g2.fontSize);
-			if (verAlign == TextMiddle) {
+			if (verAlign == TextTop) {
 				yoffset = -height * 0.5;
 			}
 			else {
-				yoffset = -height;
+				yoffset = height * 0.5;
 			}
 		}
 		g2.drawCharacters(text, start, length, x + xoffset, y + yoffset);


### PR DESCRIPTION
vertical alignment is drawing: bottom, middle, and top with default as top. but it should be: top, middle, bottom, with default middle, just so it works as a text editor, and like horizontal alignment.