### PR TITLE
Fix and cleanup window handling for nodejs

### DIFF
--- a/Backends/Node/kha/SystemImpl.hx
+++ b/Backends/Node/kha/SystemImpl.hx
@@ -14,14 +14,12 @@ import kha.netsync.Session;
 
 class SystemImpl {
 	static var screenRotation: ScreenRotation = ScreenRotation.RotationNone;
-	static var width: Int;
-	static var height: Int;
 
 	static inline var networkSendRate = 0.05;
 
 	public static function init(options: SystemOptions, callback: Window->Void): Void {
-		SystemImpl.width = options.width;
-		SystemImpl.height = options.height;
+		Window.get(0).width = options.width;
+		Window.get(0).height = options.height;
 		init2();
 		callback(null);
 	}
@@ -39,8 +37,8 @@ class SystemImpl {
 	public static function changeResolution(width: Int, height: Int): Void {}
 
 	public static function _updateSize(width: Int, height: Int): Void {
-		SystemImpl.width = width;
-		SystemImpl.height = height;
+		Window.get(0).width = width;
+		Window.get(0).height = height;
 	}
 
 	public static function _updateScreenRotation(value: Int): Void {
@@ -50,14 +48,6 @@ class SystemImpl {
 	public static function getTime(): Float {
 		var time = Node.process.hrtime();
 		return cast(time[0], Float) + cast(time[1], Float) / 1000000000;
-	}
-
-	public static function windowWidth(id: Int): Int {
-		return width;
-	}
-
-	public static function windowHeight(id: Int): Int {
-		return height;
 	}
 
 	public static function screenDpi(): Int {
@@ -109,6 +99,8 @@ class SystemImpl {
 		Scheduler.init();
 
 		Shaders.init();
+		final width = Window.get(0).width;
+		final height = Window.get(0).height;
 		frame = new Framebuffer(0, new EmptyGraphics1(width, height), new EmptyGraphics2(width, height), new EmptyGraphics4(width, height));
 		Scheduler.start();
 

--- a/Sources/kha/System.hx
+++ b/Sources/kha/System.hx
@@ -262,7 +262,7 @@ class System {
 	}
 
 	public static function windowHeight(window: Int = 0): Int {
-		return Window.all[window].height;
+		return Window.get(window).height;
 	}
 
 	public static var screenRotation(get, null): ScreenRotation;


### PR DESCRIPTION
The node target maintains a dummy window for the window API, but `System.windowHeight()` was not able to access it which caused a null access error:
```
[...]\NodeWindowWidth\build\node\kha.js:3378
        return kha_Window.all[$window].height;
                                       ^

TypeError: Cannot read properties of undefined (reading 'height')
    at kha_System.windowHeight ([...]\NodeWindowWidth\build\node\kha.js:3378:33)
    at [...]\NodeWindowWidth\build\node\kha.js:113:30
    at kha_Assets.loadEverything ([...]\NodeWindowWidth\build\node\kha.js:1585:3)
    at [...]\NodeWindowWidth\build\node\kha.js:108:14
    at kha_SystemImpl.init ([...]\NodeWindowWidth\build\node\kha.js:3451:2)
    at kha_System.start ([...]\NodeWindowWidth\build\node\kha.js:3220:17)
    at Main.main ([...]\NodeWindowWidth\build\node\kha.js:107:13)
    at [...]\NodeWindowWidth\build\node\kha.js:23175:6
    at Object.<anonymous> ([...]\NodeWindowWidth\build\node\kha.js:23176:3)
    at Module._compile (node:internal/modules/cjs/loader:1159:14)
```

Also cleaned up the nodejs SystemImpl a bit as discussed on Discord.