### PR TITLE
Fixed stereo ogg loading for native targets

### DIFF
--- a/Sources/kha/Sound.hx
+++ b/Sources/kha/Sound.hx
@@ -41,6 +41,7 @@ class Sound implements Resource {
 		}
 		else {
 			length = samples / samplesPerSecond;
+			samples *= channels;
 			uncompressedData = new kha.arrays.Float32Array(samples);
 			for (i in 0...samples) {
 				untyped __cpp__("*((float*)&this->uncompressedData->self.data[{0} * 4]) = data[{0}] / 32767.0f", i);


### PR DESCRIPTION
I was wondering why my stereo ogg sounds are cut in half when playing, and found that stb_vorbis_decode_memory is returning the samples for one channel, not the sum of them