### PR TITLE
[HL] Implement gamepad connected/vendor/id and fix float value conversion

### DIFF
--- a/Backends/Kinc-HL/kinc-bridge/system.c.h
+++ b/Backends/Kinc-HL/kinc-bridge/system.c.h
@@ -93,11 +93,16 @@ void hl_kinc_system_load_url(vbyte *url) {
 	kinc_load_url((char *)url);
 }
 
-// const char* getGamepadId(int index);
-
 vbyte *hl_kinc_get_gamepad_id(int index) {
-	return NULL;
-	// return (vbyte*)getGamepadId(index);
+	return (vbyte*)kinc_gamepad_product_name(index);
+}
+
+vbyte *hl_kinc_get_gamepad_vendor(int index) {
+	return (vbyte*)kinc_gamepad_vendor(index);
+}
+
+bool hl_kinc_gamepad_connected(int index) {
+	return kinc_gamepad_connected(index);
 }
 
 typedef void (*FN_KEY_DOWN)(int, void *);


### PR DESCRIPTION
This PR implements `gamepad.connected`, `gamepad.vendor` and `gamepad.id` on HL, and fixes wrong axis and button values due to the previously missing conversion between floats used by Kinc and doubles used by Haxe.

I would also really like to implement the mentioned gamepad properties for Armorcore, but since Armory uses Kode's version of Kha (plus some minor adjustments Lubos manually applies after each update which I can't influence with a PR) this means that I would also need to implement the changes for Kode/Krom to make Kha work in all cases, but Kode/Krom doesn't build at the moment... @ Rob it would be awesome if you can implement the gamepad properties for Kode/Krom so that adding these to Kha's Krom backend would work correctly independent of whether Krom or Armorcore is used.

---

Slightly off-topic question: for gamepad sticks, how should the y-axis behave? Should a y value of 1 correspond to "stick up" or "stick down"? Currently the y axis seems to be inverted on html5 compared to all the other targets: <https://github.com/armory3d/armory/issues/2886#issuecomment-1728450149>.