### PR TITLE
Update ByteArray.hx

### DIFF
--- a/Backends/Kinc-HL/kha/arrays/ByteArray.hx
+++ b/Backends/Kinc-HL/kha/arrays/ByteArray.hx
@@ -70,7 +70,7 @@ abstract ByteArray(ByteArrayPrivate) {
 		return kinc_bytearray_getint32(this.self, this.byteArrayOffset + byteOffset);
 	}
 
-	public inline function getUint32(byteOffset: Int): hl.I64 {
+	public inline function getUint32(byteOffset: Int): Int {
 		return kinc_bytearray_getuint32(this.self, this.byteArrayOffset + byteOffset);
 	}
 


### PR DESCRIPTION
Fix hashlink warning for cast to Int pointed out by Zeta

On HL ByteArray.getUInt32 returns a hl.I64 for some reason: <https://github.com/Kode/Kha/blob/9585c2ba99683734dc2421ac31252c2a7e7e7153/Backends/Kinc-HL/kha/arrays/ByteArray.hx#L73>
But then it's turned into an Int here: <https://github.com/Kode/Kha/blob/9585c2ba99683734dc2421ac31252c2a7e7e7153/Sources/kha/arrays/Uint32Array.hx#L16>, which leads to that new warning.