### PR TITLE
Type Dynamic callbacks in Assets

### DIFF
--- a/Sources/kha/Assets.hx
+++ b/Sources/kha/Assets.hx
@@ -5,27 +5,31 @@ import haxe.Unserializer;
 
 using StringTools;
 
-typedef AssetData = {
-	name: String,
-	files: Array<String>,
-	file_sizes: Array<Int>,
-	type: String,
-	// image
-	?original_width: Int,
-	?original_height: Int,
-	// shader
-	?inputs: Array<AssetShaderVar>,
-	?outputs: Array<AssetShaderVar>,
-	?uniforms: Array<AssetShaderVar>,
-	?types: Array<{
-		name: String,
-		members: Array<AssetShaderVar>,
-	}>
+private typedef AssetDataObject = {
+	/** File name, given by khamake, used as identifier in `Assets.someList.get()` function **/
+	var name: String;
+
+	/** List of file paths, unified by khamake to single file with `name`. **/
+	var files: Array<String>;
+
+	/** File sizes in bytes **/
+	var file_sizes: Array<Int>;
+
+	/** Can be `image`, `sound`, `blob`, `font` and `video` **/
+	var type: String;
+
+	/** Original file width (only for images) **/
+	var ?original_width: Int;
+
+	/** Original file height (only for images) **/
+	var ?original_height: Int;
 }
 
-private typedef AssetShaderVar = {
-	type: String,
-	name: String
+@:forward(name, files, file_sizes, type, original_width, original_height)
+private abstract AssetData(AssetDataObject) from AssetDataObject {
+	@:op(a.b) function _get(key: String): Dynamic {
+		return Reflect.getProperty(this, key);
+	}
 }
 
 @:build(kha.internal.AssetsBuilder.build("image"))
@@ -99,8 +103,8 @@ class Assets {
 		Additionally by default all sounds are decompressed. The uncompressSoundsFilter can be used to avoid that.
 		Uncompressed sounds can still be played using Audio.stream which is recommended for music.
 	 */
-	public static function loadEverything(callback: ()->Void, filter: (item:AssetData)->Bool = null, uncompressSoundsFilter: (soundItem:AssetData)->Bool = null,
-			?failed: (err:AssetError)->Void): Void {
+	public static function loadEverything(callback: () -> Void, ?filter: (item: AssetData) -> Bool, ?uncompressSoundsFilter: (soundItem: AssetData) -> Bool,
+			?failed: (err: AssetError) -> Void): Void {
 		final lists: Array<Dynamic> = [ImageList, SoundList, BlobList, FontList, VideoList];
 		final listInstances: Array<Dynamic> = [images, sounds, blobs, fonts, videos];
 		var fileCount = 0;

--- a/Sources/kha/Assets.hx
+++ b/Sources/kha/Assets.hx
@@ -5,6 +5,29 @@ import haxe.Unserializer;
 
 using StringTools;
 
+typedef AssetData = {
+	name: String,
+	files: Array<String>,
+	file_sizes: Array<Int>,
+	type: String,
+	// image
+	?original_width: Int,
+	?original_height: Int,
+	// shader
+	?inputs: Array<AssetShaderVar>,
+	?outputs: Array<AssetShaderVar>,
+	?uniforms: Array<AssetShaderVar>,
+	?types: Array<{
+		name: String,
+		members: Array<AssetShaderVar>,
+	}>
+}
+
+private typedef AssetShaderVar = {
+	type: String,
+	name: String
+}
+
 @:build(kha.internal.AssetsBuilder.build("image"))
 private class ImageList {
 	public function new() {}
@@ -76,8 +99,8 @@ class Assets {
 		Additionally by default all sounds are decompressed. The uncompressSoundsFilter can be used to avoid that.
 		Uncompressed sounds can still be played using Audio.stream which is recommended for music.
 	 */
-	public static function loadEverything(callback: Void->Void, filter: Dynamic->Bool = null, uncompressSoundsFilter: Dynamic->Bool = null,
-			?failed: AssetError->Void): Void {
+	public static function loadEverything(callback: ()->Void, filter: (item:AssetData)->Bool = null, uncompressSoundsFilter: (soundItem:AssetData)->Bool = null,
+			?failed: (err:AssetError)->Void): Void {
 		final lists: Array<Dynamic> = [ImageList, SoundList, BlobList, FontList, VideoList];
 		final listInstances: Array<Dynamic> = [images, sounds, blobs, fonts, videos];
 		var fileCount = 0;


### PR DESCRIPTION
I spended enough hours today debugging why this (not my) silly code breaks on cpp:
```haxe
Assets.loadEverything(function () {
	// Avoid passing update/render directly,
	// so replacing them via code injection works
	Scheduler.addTimeTask(function () { update(); }, 0, 1 / 60);
	System.notifyOnFrames(function (frames) { render(frames); });
}, (err:AssetError) -> {
	throw err;
});
```
I want to improve this api, which will also fix future dynamic problems, like `dynamicObj.name.contains` failure on some static targets.
With typed callbacks this should be harder to break and easier to use now.
Also, is this possible to get shaders in assets loader? Seems like not, or there is some ways to enable runtime loading?