### PR TITLE
Increasing Max Gamepad Limit to 8.

### DIFF
--- a/Backends/Kinc-HL/kha/SystemImpl.hx
+++ b/Backends/Kinc-HL/kha/SystemImpl.hx
@@ -43,7 +43,7 @@ class SystemImpl {
 		mouse = new kha.input.MouseImpl();
 		pen = new kha.input.Pen();
 		gamepads = new Array<Gamepad>();
-		for (i in 0...4) {
+		for (i in 0...8) {
 			gamepads[i] = new kha.input.Gamepad(i);
 			gamepads[i].connected = kinc_gamepad_connected(i);
 		}

--- a/Backends/Kinc-hxcpp/kha/SystemImpl.hx
+++ b/Backends/Kinc-hxcpp/kha/SystemImpl.hx
@@ -162,7 +162,7 @@ class SystemImpl {
 		mouse = new kha.input.MouseImpl();
 		pen = new kha.input.Pen();
 		gamepads = new Array<Gamepad>();
-		for (i in 0...4) {
+		for (i in 0...8) {
 			gamepads[i] = new Gamepad(i);
 			gamepads[i].connected = checkGamepadConnected(i);
 		}

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -16,7 +16,7 @@ class SystemImpl {
 	static var keyboard: Keyboard;
 	static var mouse: Mouse;
 	static var pen: Pen;
-	static var maxGamepads: Int = 4;
+	static var maxGamepads: Int = 8;
 	static var gamepads: Array<Gamepad>;
 	static var mouseLockListeners: Array<Void->Void> = [];
 


### PR DESCRIPTION
Increasing Max Gamepad Limit to 8. this will prevent out of bounds exceptions in kinc backend. if there is more than 4 controllers. 