### PR TITLE
Fix Assets.progress with dce

### DIFF
--- a/Sources/kha/internal/AssetsBuilder.hx
+++ b/Sources/kha/internal/AssetsBuilder.hx
@@ -129,7 +129,7 @@ class AssetsBuilder {
 				fields.push({
 					name: name + "Size",
 					doc: null,
-					meta: [],
+					meta: [{pos: pos, name: ":keep"}],
 					access: [APublic],
 					kind: FVar(macro : Dynamic, macro $v{filesize}),
 					pos: Context.currentPos()


### PR DESCRIPTION
Because file sizes is not found in Assets.images.imgSize, they are `0` and progress is `Infinity`