### PR TITLE
Don't throw on small determinant

### DIFF
--- a/Sources/kha/math/FastMatrix3.hx
+++ b/Sources/kha/math/FastMatrix3.hx
@@ -158,7 +158,8 @@ class FastMatrix3 {
 
 		var det: FastFloat = _00 * c00 - _01 * c01 + _02 * c02;
 		if (Math.abs(det) < 0.000001) {
-			throw "determinant is too small";
+			final sign = det < 0 ? -1 : 1;
+			det = 0.000001 * sign;
 		}
 
 		var c10 = cofactor(_01, _21, _02, _22);

--- a/Sources/kha/math/FastMatrix4.hx
+++ b/Sources/kha/math/FastMatrix4.hx
@@ -286,7 +286,8 @@ class FastMatrix4 {
 
 		var det: FastFloat = _00 * c00 - _01 * c01 + _02 * c02 - _03 * c03;
 		if (Math.abs(det) < 0.000001) {
-			throw "determinant is too small";
+			final sign = det < 0 ? -1 : 1;
+			det = 0.000001 * sign;
 		}
 
 		var c10 = cofactor(_01, _21, _31, _02, _22, _32, _03, _23, _33);

--- a/Sources/kha/math/Matrix3.hx
+++ b/Sources/kha/math/Matrix3.hx
@@ -156,7 +156,8 @@ class Matrix3 {
 
 		var det: Float = _00 * c00 - _01 * c01 + _02 * c02;
 		if (Math.abs(det) < 0.000001) {
-			throw "determinant is too small";
+			final sign = det < 0 ? -1 : 1;
+			det = 0.000001 * sign;
 		}
 
 		var c10 = cofactor(_01, _21, _02, _22);

--- a/Sources/kha/math/Matrix4.hx
+++ b/Sources/kha/math/Matrix4.hx
@@ -284,7 +284,8 @@ class Matrix4 {
 
 		var det: Float = _00 * c00 - _01 * c01 + _02 * c02 - _03 * c03;
 		if (Math.abs(det) < 0.000001) {
-			throw "determinant is too small";
+			final sign = det < 0 ? -1 : 1;
+			det = 0.000001 * sign;
 		}
 
 		var c10 = cofactor(_01, _21, _31, _02, _22, _32, _03, _23, _33);


### PR DESCRIPTION
I think this is too easy to get this error while inverting matrices with a small scale and such check can be done externally when needed. Is there are cases when this throw can be useful?