### PR TITLE
Get the refresh rate from Monitor in Krom

### DIFF
--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -80,7 +80,6 @@ extern class Krom {
 	static function unloadImage(image: kha.Image): Void;
 	static function loadSound(file: String): Dynamic;
 	static function writeAudioBuffer(buffer: js.lib.ArrayBuffer, samples: Int): Void;
-	static function getSamplesPerSecond(): Int;
 	static function loadBlob(file: String): js.lib.ArrayBuffer;
 
 	static function init(title: String, width: Int, height: Int, samplesPerPixel: Int, vSync: Bool, windowMode: Int, windowFeatures: Int, kromApi: Int): Void;

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -80,6 +80,7 @@ extern class Krom {
 	static function unloadImage(image: kha.Image): Void;
 	static function loadSound(file: String): Dynamic;
 	static function writeAudioBuffer(buffer: js.lib.ArrayBuffer, samples: Int): Void;
+	static function getSamplesPerSecond(): Int;
 	static function loadBlob(file: String): js.lib.ArrayBuffer;
 
 	static function init(title: String, width: Int, height: Int, samplesPerPixel: Int, vSync: Bool, windowMode: Int, windowFeatures: Int, kromApi: Int): Void;
@@ -115,6 +116,7 @@ extern class Krom {
 	static function screenDpi(): Int;
 	static function systemId(): String;
 	static function requestShutdown(): Void;
+	static function displayFrequency(): Int;
 	static function displayCount(): Int;
 	static function displayWidth(index: Int): Int;
 	static function displayHeight(index: Int): Int;

--- a/Backends/Krom/kha/Display.hx
+++ b/Backends/Krom/kha/Display.hx
@@ -79,7 +79,7 @@ class Display {
 	public var frequency(get, never): Int;
 
 	function get_frequency(): Int {
-		return 60;
+		return Krom.displayFrequency();
 	}
 
 	public var pixelsPerInch(get, never): Int;

--- a/Backends/Krom/kha/SystemImpl.hx
+++ b/Backends/Krom/kha/SystemImpl.hx
@@ -207,7 +207,7 @@ class SystemImpl {
 	}
 
 	public static function getRefreshRate(): Int {
-		return 60;
+		return Krom.displayFrequency();
 	}
 
 	public static function getSystemId(): String {

--- a/Backends/Krom/kha/krom/Graphics.hx
+++ b/Backends/Krom/kha/krom/Graphics.hx
@@ -61,7 +61,7 @@ class Graphics implements kha.graphics4.Graphics {
 	}
 
 	public function refreshRate(): Int {
-		return 60;
+		return Krom.displayFrequency();
 	}
 
 	public function clear(?color: Color, ?depth: Float, ?stencil: Int): Void {

--- a/Sources/kha/Scheduler.hx
+++ b/Sources/kha/Scheduler.hx
@@ -56,11 +56,6 @@ class Scheduler {
 	static inline function get_onedifhz(): Float {
 		return 1.0 / Display.primary.frequency;
 	}
-	#elseif kha_krom
-	static var onedifhz(get, never): Float;
-	static inline function get_onedifhz(): Float {
-		return 1.0 / Krom.displayFrequency();
-	}
 	#else
 	static var onedifhz: Float;
 	#end
@@ -101,7 +96,7 @@ class Scheduler {
 
 	public static function start(restartTimers: Bool = false): Void {
 		vsync = Window.get(0).vSynced;
-		#if !(kha_html5 || kha_debug_html5 || kha_krom)
+		#if !(kha_html5 || kha_debug_html5)
 		var hz = Display.primary != null ? Display.primary.frequency : 60;
 		if (hz >= 57 && hz <= 63)
 			hz = 60;

--- a/Sources/kha/Scheduler.hx
+++ b/Sources/kha/Scheduler.hx
@@ -51,11 +51,15 @@ class Scheduler {
 	static var vsync: Bool;
 
 	// Html5 target can update display frequency after some delay
-	#if kha_html5
+	#if (kha_html5 || kha_debug_html5)
 	static var onedifhz(get, never): Float;
-
 	static inline function get_onedifhz(): Float {
 		return 1.0 / Display.primary.frequency;
+	}
+	#elseif kha_krom
+	static var onedifhz(get, never): Float;
+	static inline function get_onedifhz(): Float {
+		return 1.0 / Krom.displayFrequency();
 	}
 	#else
 	static var onedifhz: Float;
@@ -97,8 +101,8 @@ class Scheduler {
 
 	public static function start(restartTimers: Bool = false): Void {
 		vsync = Window.get(0).vSynced;
-		#if !kha_html5
-		var hz = Display.primary.frequency;
+		#if !(kha_html5 || kha_debug_html5 || kha_krom)
+		var hz = Display.primary != null ? Display.primary.frequency : 60;
 		if (hz >= 57 && hz <= 63)
 			hz = 60;
 		onedifhz = 1.0 / hz;

--- a/Sources/kha/System.hx
+++ b/Sources/kha/System.hx
@@ -360,11 +360,7 @@ class System {
 	public static var refreshRate(get, null): Int;
 
 	static function get_refreshRate(): Int {
-		#if kha_krom
-		return Krom.displayFrequency();
-		#else
 		return Display.primary.frequency;
-		#end
 	}
 
 	@:deprecated("Use the kha.Display API instead")

--- a/Sources/kha/System.hx
+++ b/Sources/kha/System.hx
@@ -360,7 +360,11 @@ class System {
 	public static var refreshRate(get, null): Int;
 
 	static function get_refreshRate(): Int {
+		#if kha_krom
+		return Krom.displayFrequency();
+		#else
 		return Display.primary.frequency;
+		#end
 	}
 
 	@:deprecated("Use the kha.Display API instead")


### PR DESCRIPTION
Get's the refresh rate from the Monitor in Krom instead of the hardcoded 60. Goes together with [this PR](https://github.com/Kode/Krom/pull/153).