### PR TITLE
Remove prefixes

### DIFF
--- a/Backends/HTML5/kha/CanvasImage.hx
+++ b/Backends/HTML5/kha/CanvasImage.hx
@@ -27,7 +27,7 @@ class CanvasImage extends Image {
 	var g2canvas: CanvasGraphics = null;
 
 	public static function init() {
-		var canvas: Dynamic = Browser.document.createElement("canvas");
+		final canvas = Browser.document.createCanvasElement();
 		if (canvas != null) {
 			context = canvas.getContext("2d");
 			canvas.width = 2048;
@@ -56,7 +56,7 @@ class CanvasImage extends Image {
 
 	override function get_g2(): kha.graphics2.Graphics {
 		if (g2canvas == null) {
-			var canvas: Dynamic = Browser.document.createElement("canvas");
+			final canvas = Browser.document.createCanvasElement();
 			image = canvas;
 			var context = canvas.getContext("2d");
 			canvas.width = width;

--- a/Backends/HTML5/kha/Display.hx
+++ b/Backends/HTML5/kha/Display.hx
@@ -66,7 +66,7 @@ class Display {
 	public var pixelsPerInch(get, never): Int;
 
 	function get_pixelsPerInch(): Int {
-		var dpiElement = Browser.document.createElement("div");
+		final dpiElement = Browser.document.createDivElement();
 		dpiElement.style.position = "absolute";
 		dpiElement.style.width = "1in";
 		dpiElement.style.height = "1in";

--- a/Backends/HTML5/kha/LoaderImpl.hx
+++ b/Backends/HTML5/kha/LoaderImpl.hx
@@ -32,7 +32,7 @@ class LoaderImpl {
 			}, failed);
 		}
 		else {
-			var img: ImageElement = cast Browser.document.createElement("img");
+			final img = Browser.document.createImageElement();
 			img.onerror = function(event: Dynamic) failed({url: desc.files[0], error: event});
 			img.onload = function(event: Dynamic) done(Image.fromImage(img, readable));
 			img.crossOrigin = "";

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -529,14 +529,7 @@ class SystemImpl {
 	static function initAnimate(callback: Window->Void) {
 		var canvas: CanvasElement = getCanvasElement();
 
-		var window: Dynamic = Browser.window;
-		var requestAnimationFrame = window.requestAnimationFrame;
-		if (requestAnimationFrame == null)
-			requestAnimationFrame = window.mozRequestAnimationFrame;
-		if (requestAnimationFrame == null)
-			requestAnimationFrame = window.webkitRequestAnimationFrame;
-		if (requestAnimationFrame == null)
-			requestAnimationFrame = window.msRequestAnimationFrame;
+		final window = Browser.window;
 
 		var isRefreshRateDetectionActive = false;
 		var lastTimestamp = 0.0;
@@ -547,10 +540,7 @@ class SystemImpl {
 		];
 
 		function animate(timestamp) {
-			if (requestAnimationFrame == null)
-				Browser.window.setTimeout(animate, 1000.0 / 60.0);
-			else
-				requestAnimationFrame(animate);
+			window.requestAnimationFrame(animate);
 
 			var sysGamepads = getGamepads();
 			if (sysGamepads != null) {
@@ -631,7 +621,7 @@ class SystemImpl {
 		}, 500);
 
 		Scheduler.start();
-		requestAnimationFrame(animate);
+		window.requestAnimationFrame(animate);
 		callback(SystemImpl.window);
 	}
 
@@ -639,56 +629,30 @@ class SystemImpl {
 		untyped if (SystemImpl.khanvas.requestPointerLock) {
 			SystemImpl.khanvas.requestPointerLock();
 		}
-		else if (SystemImpl.khanvas.mozRequestPointerLock) {
-			SystemImpl.khanvas.mozRequestPointerLock();
-		}
-		else if (SystemImpl.khanvas.webkitRequestPointerLock) {
-			SystemImpl.khanvas.webkitRequestPointerLock();
-		}
 	}
 
 	public static function unlockMouse(): Void {
 		untyped if (document.exitPointerLock) {
 			document.exitPointerLock();
 		}
-		else if (document.mozExitPointerLock) {
-			document.mozExitPointerLock();
-		}
-		else if (document.webkitExitPointerLock) {
-			document.webkitExitPointerLock();
-		}
 	}
 
 	public static function canLockMouse(): Bool {
-		return Syntax.code("'pointerLockElement' in document ||
-		'mozPointerLockElement' in document ||
-		'webkitPointerLockElement' in document");
+		return Syntax.code("'pointerLockElement' in document");
 	}
 
 	public static function isMouseLocked(): Bool {
-		return Syntax.code("document.pointerLockElement === kha_SystemImpl.khanvas ||
-			document.mozPointerLockElement === kha_SystemImpl.khanvas ||
-			document.webkitPointerLockElement === kha_SystemImpl.khanvas");
+		return Syntax.code("document.pointerLockElement === kha_SystemImpl.khanvas");
 	}
 
 	public static function notifyOfMouseLockChange(func: Void->Void, error: Void->Void): Void {
 		js.Browser.document.addEventListener("pointerlockchange", func, false);
-		js.Browser.document.addEventListener("mozpointerlockchange", func, false);
-		js.Browser.document.addEventListener("webkitpointerlockchange", func, false);
-
 		js.Browser.document.addEventListener("pointerlockerror", error, false);
-		js.Browser.document.addEventListener("mozpointerlockerror", error, false);
-		js.Browser.document.addEventListener("webkitpointerlockerror", error, false);
 	}
 
 	public static function removeFromMouseLockChange(func: Void->Void, error: Void->Void): Void {
 		js.Browser.document.removeEventListener("pointerlockchange", func, false);
-		js.Browser.document.removeEventListener("mozpointerlockchange", func, false);
-		js.Browser.document.removeEventListener("webkitpointerlockchange", func, false);
-
 		js.Browser.document.removeEventListener("pointerlockerror", error, false);
-		js.Browser.document.removeEventListener("mozpointerlockerror", error, false);
-		js.Browser.document.removeEventListener("webkitpointerlockerror", error, false);
 	}
 
 	static function setMouseXY(event: MouseEvent): Void {
@@ -893,13 +857,6 @@ class SystemImpl {
 
 		var movementX = event.movementX;
 		var movementY = event.movementY;
-
-		if (event.movementX == null) {
-			movementX = (untyped event.mozMovementX != null) ? untyped event.mozMovementX : ((untyped event.webkitMovementX != null) ? untyped event.webkitMovementX : (mouseX
-				- lastMouseX));
-			movementY = (untyped event.mozMovementY != null) ? untyped event.mozMovementY : ((untyped event.webkitMovementY != null) ? untyped event.webkitMovementY : (mouseY
-				- lastMouseY));
-		}
 
 		// this ensures same behaviour across browser until they fix it
 		if (firefox) {

--- a/Backends/HTML5/kha/SystemImpl.hx
+++ b/Backends/HTML5/kha/SystemImpl.hx
@@ -311,14 +311,14 @@ class SystemImpl {
 	}
 
 	public static function copyToClipboard(text: String) {
-		var textArea = Browser.document.createElement("textarea");
-		untyped textArea.value = text;
+		var textArea = Browser.document.createTextAreaElement();
+		textArea.value = text;
 		textArea.style.top = "0";
 		textArea.style.left = "0";
 		textArea.style.position = "fixed";
 		Browser.document.body.appendChild(textArea);
 		textArea.focus();
-		untyped textArea.select();
+		textArea.select();
 		try {
 			Browser.document.execCommand("copy");
 		}
@@ -626,14 +626,14 @@ class SystemImpl {
 	}
 
 	public static function lockMouse(): Void {
-		untyped if (SystemImpl.khanvas.requestPointerLock) {
+		if (SystemImpl.khanvas.requestPointerLock != null) {
 			SystemImpl.khanvas.requestPointerLock();
 		}
 	}
 
 	public static function unlockMouse(): Void {
-		untyped if (document.exitPointerLock) {
-			document.exitPointerLock();
+		if (Browser.document.exitPointerLock != null) {
+			Browser.document.exitPointerLock();
 		}
 	}
 
@@ -1267,8 +1267,8 @@ class SystemImpl {
 			return null; // Chrome crashes if navigator.getGamepads() is called when using VR
 		}
 
-		if (untyped navigator.getGamepads) {
-			return js.Browser.navigator.getGamepads();
+		if (Browser.navigator.getGamepads != null) {
+			return Browser.navigator.getGamepads();
 		}
 		else {
 			return null;

--- a/Backends/HTML5/kha/capture/AudioCapture.hx
+++ b/Backends/HTML5/kha/capture/AudioCapture.hx
@@ -1,5 +1,6 @@
 package kha.capture;
 
+import js.Browser.navigator;
 import js.html.audio.AudioProcessingEvent;
 import kha.audio2.Buffer;
 
@@ -16,8 +17,8 @@ class AudioCapture {
 			return;
 		}
 
-		var getUserMedia = untyped __js__("navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia");
-		getUserMedia.call(js.Browser.navigator, {audio: true}, function(stream: Dynamic) {
+		final getUserMedia = (navigator : Dynamic).getUserMedia;
+		getUserMedia.call(navigator, {audio: true}, function(stream: Dynamic) {
 			input = kha.audio2.Audio._context.createMediaStreamSource(stream);
 
 			var bufferSize = 1024 * 2;

--- a/Backends/HTML5/kha/capture/VideoCapture.hx
+++ b/Backends/HTML5/kha/capture/VideoCapture.hx
@@ -1,11 +1,12 @@
 package kha.capture;
 
+import js.Browser.navigator;
 import js.Browser;
 
 class VideoCapture {
 	public static function init(initialized: kha.Video->Void, error: Void->Void): Void {
-		var getUserMedia = untyped __js__("navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia");
-		getUserMedia.call(js.Browser.navigator, {audio: true, video: true}, function(stream: Dynamic) {
+		final getUserMedia = (navigator : Dynamic).getUserMedia;
+		getUserMedia.call(navigator, {audio: true, video: true}, function(stream: Dynamic) {
 			var element: js.html.VideoElement = cast Browser.document.createElement("video");
 			element.srcObject = stream;
 			element.onloadedmetadata = function(e) {

--- a/Backends/HTML5/kha/capture/VideoCapture.hx
+++ b/Backends/HTML5/kha/capture/VideoCapture.hx
@@ -7,7 +7,7 @@ class VideoCapture {
 	public static function init(initialized: kha.Video->Void, error: Void->Void): Void {
 		final getUserMedia = (navigator : Dynamic).getUserMedia;
 		getUserMedia.call(navigator, {audio: true, video: true}, function(stream: Dynamic) {
-			var element: js.html.VideoElement = cast Browser.document.createElement("video");
+			final element = Browser.document.createVideoElement();
 			element.srcObject = stream;
 			element.onloadedmetadata = function(e) {
 				initialized(kha.js.Video.fromElement(element));

--- a/Backends/HTML5/kha/js/CanvasGraphics.hx
+++ b/Backends/HTML5/kha/js/CanvasGraphics.hx
@@ -105,18 +105,7 @@ class CanvasGraphics extends Graphics {
 	}
 
 	override function set_imageScaleQuality(value: ImageScaleQuality): ImageScaleQuality {
-		if (value == ImageScaleQuality.Low) {
-			untyped canvas.mozImageSmoothingEnabled = false;
-			untyped canvas.webkitImageSmoothingEnabled = false;
-			untyped canvas.msImageSmoothingEnabled = false;
-			canvas.imageSmoothingEnabled = false;
-		}
-		else {
-			untyped canvas.mozImageSmoothingEnabled = true;
-			untyped canvas.webkitImageSmoothingEnabled = true;
-			untyped canvas.msImageSmoothingEnabled = true;
-			canvas.imageSmoothingEnabled = true;
-		}
+		canvas.imageSmoothingEnabled = value == ImageScaleQuality.High;
 		return scaleQuality = value;
 	}
 

--- a/Backends/HTML5/kha/js/Video.hx
+++ b/Backends/HTML5/kha/js/Video.hx
@@ -32,7 +32,7 @@ class Video extends kha.Video {
 
 		video.done = done;
 
-		video.element = cast Browser.document.createElement("video");
+		video.element = Browser.document.createVideoElement();
 
 		video.filenames = [];
 		for (filename in filenames) {


### PR DESCRIPTION
I removed code prefixes that have been removed since the 2013–2016 range. Fullscreen prefixes remain because they have been only partially removed since 2018. IE11 hacks are still in place as well.

I also replaced untyped stuff with null checks and createSpotElement shortcuts.