### PR TITLE
Add missing render target format mappings in Kore-HL backend

### DIFF
--- a/Backends/Kore-HL/kha/Image.hx
+++ b/Backends/Kore-HL/kha/Image.hx
@@ -93,10 +93,16 @@ class Image implements Canvas implements Resource {
 				return 0;
 			case RGBA64: // Target64BitFloat
 				return 1;
+			case A32: // Target32BitRedFloat
+				return 2;
 			case RGBA128: // Target128BitFloat
 				return 3;
 			case DEPTH16: // Target16BitDepth
 				return 4;
+			case L8: // Target8BitRed
+				return 5;
+			case A16: // Target16BitRedFloat
+				return 6;
 			default:
 				return 0;
 		}


### PR DESCRIPTION
Prevents visual artifacts on transparent materials, aligned with Kore-hxcpp backend implementation.