### PR TITLE
Small updates

### DIFF
--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -624,8 +624,8 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniform4f((cast location : ConstantLocation).value, value.x, value.y, value.z, value.w);
 	}
 
-	static var matrixCache = new js.lib.Float32Array(16);
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
+		static var matrixCache = new js.lib.Float32Array(16);
 		matrixCache[0] = matrix._00;
 		matrixCache[1] = matrix._01;
 		matrixCache[2] = matrix._02;
@@ -645,8 +645,8 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniformMatrix4fv((cast location : ConstantLocation).value, false, matrixCache);
 	}
 
-	static var matrix3Cache = new js.lib.Float32Array(9);
 	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
+		static var matrix3Cache = new js.lib.Float32Array(9);
 		matrix3Cache[0] = matrix._00;
 		matrix3Cache[1] = matrix._01;
 		matrix3Cache[2] = matrix._02;

--- a/Backends/HTML5/kha/js/graphics4/Graphics.hx
+++ b/Backends/HTML5/kha/js/graphics4/Graphics.hx
@@ -624,8 +624,8 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniform4f((cast location : ConstantLocation).value, value.x, value.y, value.z, value.w);
 	}
 
+	static var matrixCache = new js.lib.Float32Array(16);
 	public inline function setMatrix(location: kha.graphics4.ConstantLocation, matrix: FastMatrix4): Void {
-		static var matrixCache = new js.lib.Float32Array(16);
 		matrixCache[0] = matrix._00;
 		matrixCache[1] = matrix._01;
 		matrixCache[2] = matrix._02;
@@ -645,8 +645,8 @@ class Graphics implements kha.graphics4.Graphics {
 		SystemImpl.gl.uniformMatrix4fv((cast location : ConstantLocation).value, false, matrixCache);
 	}
 
+	static var matrix3Cache = new js.lib.Float32Array(9);
 	public inline function setMatrix3(location: kha.graphics4.ConstantLocation, matrix: FastMatrix3): Void {
-		static var matrix3Cache = new js.lib.Float32Array(9);
 		matrix3Cache[0] = matrix._00;
 		matrix3Cache[1] = matrix._01;
 		matrix3Cache[2] = matrix._02;

--- a/Backends/Kore-HL/kha/arrays/ByteArray.hx
+++ b/Backends/Kore-HL/kha/arrays/ByteArray.hx
@@ -71,7 +71,7 @@ abstract ByteArray(ByteArrayPrivate) {
 	}
 
 	public inline function getUint32(byteOffset: Int): Int {
-		return kinc_bytearray_getuint32(this.self, this.byteArrayOffset + byteOffset);
+		return kinc_bytearray_getuint32(this.self, this.byteArrayOffset + byteOffset).toInt();
 	}
 
 	public inline function getFloat32(byteOffset: Int): FastFloat {

--- a/Backends/Krom/Krom.hx
+++ b/Backends/Krom/Krom.hx
@@ -93,6 +93,7 @@ extern class Krom {
 	static function setKeyboardDownCallback(callback: Int->Void): Void;
 	static function setKeyboardUpCallback(callback: Int->Void): Void;
 	static function setKeyboardPressCallback(callback: Int->Void): Void;
+	static function setMouseCursor(cursor: Int): Void;
 	static function setMouseDownCallback(callback: Int->Int->Int->Void): Void;
 	static function setMouseUpCallback(callback: Int->Int->Int->Void): Void;
 	static function setMouseMoveCallback(callback: Int->Int->Int->Int->Void): Void;


### PR DESCRIPTION
- ~put `matrixCache` static variables outside `setMatrix` functions for 3D performance improvements in WebGL (taken from Armory's Kha)~
- remove deprecation warnings when converting to a UInt32 in Kore-HL
- expose `setMouseCursor` in Krom