### PR TITLE
Faster audio decompression on html5

### DIFF
--- a/Backends/HTML5/kha/js/Microtask.hx
+++ b/Backends/HTML5/kha/js/Microtask.hx
@@ -1,0 +1,28 @@
+package kha.js;
+
+import js.html.MessageChannel;
+
+class Microtask {
+	static var messageChannel: MessageChannel;
+	static final callbacks: Array<() -> Void> = [];
+
+	static function init(): Void {
+		if (messageChannel != null) {
+			return;
+		}
+		messageChannel = new MessageChannel();
+		messageChannel.port1.onmessage = _ -> {
+			final copy = callbacks.copy();
+			callbacks.resize(0);
+			for (callback in copy) {
+				callback();
+			}
+		};
+	}
+
+	public static function queueMicrotask(callback: () -> Void): Void {
+		init();
+		callbacks.push(callback);
+		messageChannel.port2.postMessage(js.Lib.undefined);
+	}
+}

--- a/Backends/HTML5/kha/js/WebAudioSound.hx
+++ b/Backends/HTML5/kha/js/WebAudioSound.hx
@@ -16,7 +16,7 @@ import kha.audio2.Audio;
 		super();
 		this.offset = 0;
 		this.buffer = buffer;
-		this.startTime = Audio._context.currentTime; 
+		this.startTime = Audio._context.currentTime;
 		this.source = Audio._context.createBufferSource();
 		this.source.buffer = this.buffer;
 		this.source.connect(Audio._context.destination);
@@ -91,7 +91,7 @@ class WebAudioSound extends kha.Sound {
 			var i = 0;
 			final lidx = len * 2;
 			function uncompressInner() {
-				var chk_len = idx + 11025;
+				var chk_len = idx + 44100;
 				var next_chk = chk_len > lidx ? lidx : chk_len;
 				while (idx < next_chk) {
 					uncompressedData[idx] = ch0[i];
@@ -100,7 +100,7 @@ class WebAudioSound extends kha.Sound {
 					++i;
 				}
 				if (idx < lidx)
-					js.Browser.window.setTimeout(uncompressInner, 0);
+					Microtask.queueMicrotask(uncompressInner);
 				else {
 					compressedData = null;
 					done();


### PR DESCRIPTION
Makes background audio decoding 30x faster (almost) without frame drops.
4 minutes music is decompressed in 0.6s instead of 18 seconds. On my androids it drops to 50-55 fps at the end of decompression for long tracks, but since most decompressions happen only for sounds and at `loadEverything` call, i think this trade-off is worth it.

Reference info about setTimeout slowness:
https://nolanlawson.com/2025/08/31/why-do-browsers-throttle-javascript-timers/